### PR TITLE
Fix compilation failure related to jplag.frontend.java-1.5/pom.xml

### DIFF
--- a/jplag.frontend.java-1.5/pom.xml
+++ b/jplag.frontend.java-1.5/pom.xml
@@ -41,7 +41,7 @@
 					<grammarEncoding>${project.build.sourceEncoding}</grammarEncoding>
 					<debugparser>false</debugparser>
 					<isStatic>false</isStatic>
-					<outputDirectory>src/main/java/jplag/java15/grammar</outputDirectory>
+					<outputDirectory>${project.basedir}/src/main/java/jplag/java15/grammar</outputDirectory>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Hello,

When compiling JFlag with Maven 3.2.5 and running the following command in the jflag root folder:

    $ mvn clean generate-sources package

I was getting a compilation failure:
```
(...)
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] JPlag Plagiarism Detector .......................... SUCCESS [  0.134 s]
[INFO] frontend-utils ..................................... SUCCESS [  1.268 s]
[INFO] chars .............................................. SUCCESS [  0.387 s]
[INFO] cpp ................................................ SUCCESS [  1.505 s]
[INFO] csharp-1.2 ......................................... SUCCESS [  2.084 s]
[INFO] java-1.1exp ........................................ SUCCESS [  1.623 s]
[INFO] java-1.2 ........................................... SUCCESS [  1.344 s]
[INFO] java-1.5 ........................................... FAILURE [  0.827 s]
[INFO] java-1.7 ........................................... SKIPPED
[INFO] scheme ............................................. SKIPPED
[INFO] text ............................................... SKIPPED
[INFO] utils .............................................. SKIPPED
[INFO] jplag .............................................. SKIPPED
[INFO] JPlag Aggregator ................................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 9.585 s
[INFO] Finished at: 2015-04-02T17:29:57+02:00
[INFO] Final Memory: 49M/430M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project java-1.5: Compilation failure: Compilation failure:
[ERROR] (...)/jplag/jplag.frontend.java-1.5/src/main/java/jplag/java15/Parser.java:[8,27] error: cannot find symbol
[ERROR] package jplag.java15.grammar
(...)
```
and it appeared that the files under package "jplag.java15.grammar" had been generated in a wrong folder (namely in a "src" subfolder of the jplag root folder).

With this new value of "outputDirectory" it seems to be OK.

Best regards.