### PR TITLE
Build fixes re. Maven relativePath and ProGuard configuration

### DIFF
--- a/jplag.adminTool/pom.xml
+++ b/jplag.adminTool/pom.xml
@@ -8,6 +8,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 
 	<repositories>

--- a/jplag.atujplag/pom.xml
+++ b/jplag.atujplag/pom.xml
@@ -8,6 +8,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 
 	<repositories>

--- a/jplag.frontend-utils/pom.xml
+++ b/jplag.frontend-utils/pom.xml
@@ -6,6 +6,7 @@
   	<groupId>edu.kit.ipd.jplag</groupId>
   	<artifactId>parent</artifactId>
   	<version>0.3-SNAPSHOT</version>
+  	<relativePath>../jplag.parent/pom.xml</relativePath>
   </parent>
 
   	<repositories>

--- a/jplag.frontend.chars/pom.xml
+++ b/jplag.frontend.chars/pom.xml
@@ -38,6 +38,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>chars</artifactId>
 </project>

--- a/jplag.frontend.cpp/pom.xml
+++ b/jplag.frontend.cpp/pom.xml
@@ -110,5 +110,6 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/jplag.frontend.csharp-1.2/pom.xml
+++ b/jplag.frontend.csharp-1.2/pom.xml
@@ -82,5 +82,6 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/jplag.frontend.java-1.1exp/pom.xml
+++ b/jplag.frontend.java-1.1exp/pom.xml
@@ -112,5 +112,6 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/jplag.frontend.java-1.2/pom.xml
+++ b/jplag.frontend.java-1.2/pom.xml
@@ -84,5 +84,6 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/jplag.frontend.java-1.5/pom.xml
+++ b/jplag.frontend.java-1.5/pom.xml
@@ -78,6 +78,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>java-1.5</artifactId>
 </project>

--- a/jplag.frontend.java-1.7/pom.xml
+++ b/jplag.frontend.java-1.7/pom.xml
@@ -95,5 +95,6 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/jplag.frontend.scheme/pom.xml
+++ b/jplag.frontend.scheme/pom.xml
@@ -123,5 +123,6 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/jplag.frontend.text/pom.xml
+++ b/jplag.frontend.text/pom.xml
@@ -83,5 +83,6 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 </project>

--- a/jplag.homepage/pom.xml
+++ b/jplag.homepage/pom.xml
@@ -9,6 +9,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<version>0.3-SNAPSHOT</version>
 		<artifactId>parent</artifactId>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 
 	<repositories>

--- a/jplag.utils/pom.xml
+++ b/jplag.utils/pom.xml
@@ -8,6 +8,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 
 	<repositories>

--- a/jplag.webService/pom.xml
+++ b/jplag.webService/pom.xml
@@ -8,6 +8,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 
 	<repositories>

--- a/jplag.wsClient/pom.xml
+++ b/jplag.wsClient/pom.xml
@@ -8,6 +8,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 
 	<repositories>

--- a/jplag/pom.xml
+++ b/jplag/pom.xml
@@ -8,6 +8,7 @@
 		<groupId>edu.kit.ipd.jplag</groupId>
 		<artifactId>parent</artifactId>
 		<version>0.3-SNAPSHOT</version>
+		<relativePath>../jplag.parent/pom.xml</relativePath>
 	</parent>
 
 	<repositories>

--- a/jplag/pom.xml
+++ b/jplag/pom.xml
@@ -113,6 +113,7 @@
 			<plugin>
 				<groupId>com.github.wvengen</groupId>
 				<artifactId>proguard-maven-plugin</artifactId>
+				<version>2.10.11</version>
 				<!-- executions>
 					<execution>
 						<phase>package</phase>
@@ -122,7 +123,7 @@
 					</execution>
 				</executions-->
 				<configuration>
-					<progruardVersion>4.8</progruardVersion>
+					<proguardVersion>4.8</proguardVersion>
 					<options>
 						<option>-allowaccessmodification</option>
 						<option>-keep public class * extends java.applet.Applet { *; }</option>


### PR DESCRIPTION
This fixes a bunch of warnings that Maven spits out when it analyzes the project.