### PR TITLE
Use floats rather than ints when computing percentA() and percentB()

### DIFF
--- a/jplag/src/main/java/jplag/AllMatches.java
+++ b/jplag/src/main/java/jplag/AllMatches.java
@@ -103,13 +103,13 @@ public class AllMatches extends Matches implements Comparator<AllMatches> {
     return (200*(float)tokensMatched())/(sa+sb);
   }
   public final float percentA() {
-  	int divisor;
+    float divisor;
   	if(bcmatchesA != null) divisor = subA.size()-subA.files.length-bcmatchesA.tokensMatched();
     else divisor = subA.size()-subA.files.length;
     return (divisor == 0 ? 0 : (tokensMatched()*100 / divisor));
   }
   public final float percentB() {
-    int divisor;
+    float divisor;
 	if(bcmatchesB != null) divisor = subB.size()-subB.files.length-bcmatchesB.tokensMatched();
 	else divisor = subB.size()-subB.files.length;
     return (divisor == 0 ? 0 : (tokensMatched()*100 / divisor));


### PR DESCRIPTION
Hello

I recently noticed the following detail in the generated files `results/match*.html`: the two percentages that appear in the top right-hand side are always truncated to the nearest integer, so that the percentage in the top left-hand side (average similarity) does not seem to correspond to the average.

Here is a screenshot that shows the issue.
![jplag_fix-rounding_before](https://cloud.githubusercontent.com/assets/10367254/14888300/eb417a50-0d59-11e6-823f-8cc910e9799e.png)

This seems to be related to the functions `percentA()` and `percentB()` in `jplag/AllMatches.java`
that should probably compute using floats rather than ints.

Here is another screenshot that shows the same example, if one applies the enclosed patch.
![jplag_fix-rounding_now](https://cloud.githubusercontent.com/assets/10367254/14888307/f4e7785c-0d59-11e6-865b-385b020bd0bd.png)

Kind regards.