### PR TITLE
Ensure percentA() and percentB() don't truncate the floating-point division

### DIFF
--- a/jplag/src/main/java/jplag/AllMatches.java
+++ b/jplag/src/main/java/jplag/AllMatches.java
@@ -106,13 +106,13 @@ public class AllMatches extends Matches implements Comparator<AllMatches> {
   	int divisor;
   	if(bcmatchesA != null) divisor = subA.size()-subA.files.length-bcmatchesA.tokensMatched();
     else divisor = subA.size()-subA.files.length;
-    return (divisor == 0 ? 0 : (tokensMatched()*100 / divisor));
+    return (divisor == 0 ? 0f : (tokensMatched()*100 / (float) divisor));
   }
   public final float percentB() {
     int divisor;
 	if(bcmatchesB != null) divisor = subB.size()-subB.files.length-bcmatchesB.tokensMatched();
 	else divisor = subB.size()-subB.files.length;
-    return (divisor == 0 ? 0 : (tokensMatched()*100 / divisor));
+    return (divisor == 0 ? 0f : (tokensMatched()*100 / (float) divisor));
   }
 
   public final float roundedPercentMaxAB() {


### PR DESCRIPTION
Hello,
This is an slightly-improved patch for #16.
Sorry for opening a new PR (I just closed #16 and force-pushed my rebased branch, then realized that PRs cannot be reopened in that case, cf. isaacs/github#361).
Kind regards