### PR TITLE
Add Python 3.5/3.6 support

### DIFF
--- a/jplag.frontend.python-3/src/main/antlr4/jplag/python3/grammar/Python3.g4
+++ b/jplag.frontend.python-3/src/main/antlr4/jplag/python3/grammar/Python3.g4
@@ -170,9 +170,9 @@ decorated
  : decorators ( classdef | funcdef )
  ;
 
-/// funcdef: 'def' NAME parameters ['->' test] ':' suite
+/// funcdef: 'async'? 'def' NAME parameters ['->' test] ':' suite
 funcdef
- : DEF NAME parameters ( '->' test )? ':' suite
+ : ASYNC? DEF NAME parameters ( '->' test )? ':' suite
  ;
 
 /// parameters: '(' [typedargslist] ')'
@@ -399,9 +399,9 @@ while_stmt
  : WHILE test ':' suite ( ELSE ':' suite )?
  ;
 
-/// for_stmt: 'for' exprlist 'in' testlist ':' suite ['else' ':' suite]
+/// for_stmt: 'async'? 'for' exprlist 'in' testlist ':' suite ['else' ':' suite]
 for_stmt
- : FOR exprlist IN testlist ':' suite ( ELSE ':' suite )?
+ : ASYNC? FOR exprlist IN testlist ':' suite ( ELSE ':' suite )?
  ;
 
 /// try_stmt: ('try' ':' suite
@@ -417,9 +417,9 @@ try_stmt
                  )
  ;
 
-/// with_stmt: 'with' with_item (',' with_item)*  ':' suite
+/// with_stmt: 'async'? 'with' with_item (',' with_item)*  ':' suite
 with_stmt
- : WITH with_item ( ',' with_item )* ':' suite
+ : ASYNC? WITH with_item ( ',' with_item )* ':' suite
  ;
 
 /// with_item: test ['as' expr]
@@ -553,7 +553,7 @@ factor
 
 /// power: atom trailer* ['**' factor]
 power
- : atom trailer* ( '**' factor )?
+ : AWAIT? atom trailer* ( '**' factor )?
  ;
 
 /// atom: ('(' [yield_expr|testlist_comp] ')' |
@@ -730,6 +730,8 @@ DEL : 'del';
 PASS : 'pass';
 CONTINUE : 'continue';
 BREAK : 'break';
+ASYNC : 'async';
+AWAIT : 'await';
 
 NEWLINE
  : ( {atStartOfInput()}?   SPACES
@@ -776,15 +778,16 @@ NAME
  ;
 
 /// stringliteral   ::=  [stringprefix](shortstring | longstring)
-/// stringprefix    ::=  "r" | "R"
+/// stringprefix    ::=  "r" | "u" | "R" | "U" | "f" | "F"
+///                      | "fr" | "Fr" | "fR" | "FR" | "rf" | "rF" | "Rf" | "RF"
 STRING_LITERAL
- : [uU]? [rR]? ( SHORT_STRING | LONG_STRING )
+ : ( [rR] | [uU] | [fF] | ( [fF] [rR] ) | ( [rR] [fF] ) )? ( SHORT_STRING | LONG_STRING )
  ;
 
 /// bytesliteral   ::=  bytesprefix(shortbytes | longbytes)
-/// bytesprefix    ::=  "b" | "B" | "br" | "Br" | "bR" | "BR"
+/// bytesprefix    ::=  "b" | "B" | "br" | "Br" | "bR" | "BR" | "rb" | "rB" | "Rb" | "RB"
 BYTES_LITERAL
- : [bB] [rR]? ( SHORT_BYTES | LONG_BYTES )
+ : ( [bB] | ( [bB] [rR] ) | ( [rR] [bB] ) ) ( SHORT_BYTES | LONG_BYTES )
  ;
 
 /// decimalinteger ::=  nonzerodigit digit* | "0"+


### PR DESCRIPTION
Add Python 3.5/3.6 support to the python-3 front end.  As far as I
can tell, there are two missing syntax features that have been added
in 3.5 and 3.6:

(1) Formatted string literals, such as this:

        f'Name: {name}'

I generally cleaned up string literals and binary literals in the
grammar, to be in line with the current rules in Python 3.

(2) The 'async' and 'await' keywords, which can appear in a few
places:

* 'async' can appear optionally in front of 'def', 'for', and 'with'
* 'await' can appear in front of most expressions, with a priority
  much higher than most of the other operators.

In both cases, I've added to the existing rules in Python3.g4 and
the rest of JPlag won't see these as distinct (e.g., a formatted
string literal will be seen as a string literal, 'async def' will
be seen as the beginning of a function, and so on).  I think, for
our purposes, that's probably fine, though I'm open to counterargument
on that point.