### PR TITLE
Docs and typofix

### DIFF
--- a/jplag.frontend-utils/src/main/java/jplag/Language.java
+++ b/jplag.frontend-utils/src/main/java/jplag/Language.java
@@ -7,27 +7,39 @@ import java.io.*;
  * One interface for all languages...
  */
 public interface Language {
+	/** Get known suffixes for files containing code in the language. */
 	public String[] suffixes();
 
+	/** Descriptive name of the language (one line). */
 	public String name();
 
+	/** Short (one word) name of the language. */
 	public String getShortName();
 
+	/** Minimum number of tokens needed for a match. */
 	public int min_token_match();
 
+	/** Parse a set files in a directory, and return the parse result. */
 	public Structure parse(File dir, String[] files);
 
+	/** Whether errors were found during the last {@link #parse}. */
 	public boolean errors();
 
+	/** Number of found errors found during the last {@link #parse}. */
 	public int errorsCount();
 
+	/** Does the parser provide column information? */
 	public boolean supportsColumns();
 
+	/** Whether JPlag should use a fixed-width font in its reports. */
 	public boolean isPreformated();
 
+	/** Whether tokens from the scanner are indexed. */
 	public boolean usesIndex();
 
+	/** Number of defined tokens in the scanner of the language. */
 	public int noOfTokens();
 
+	/** Convert a token type to a text representation. */
 	public String type2string(int type);
 }

--- a/jplag.frontend-utils/src/main/java/jplag/Language.java
+++ b/jplag.frontend-utils/src/main/java/jplag/Language.java
@@ -32,7 +32,7 @@ public interface Language {
 	public boolean supportsColumns();
 
 	/** Whether JPlag should use a fixed-width font in its reports. */
-	public boolean isPreformated();
+	public boolean isPreformatted();
 
 	/** Whether tokens from the scanner are indexed. */
 	public boolean usesIndex();

--- a/jplag.frontend.chars/src/main/java/jplag/chars/Language.java
+++ b/jplag.frontend.chars/src/main/java/jplag/chars/Language.java
@@ -56,7 +56,7 @@ public class Language implements jplag.Language {
 		return false;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return false;
 	}
 

--- a/jplag.frontend.cpp/src/main/java/jplag/cpp/Language.java
+++ b/jplag.frontend.cpp/src/main/java/jplag/cpp/Language.java
@@ -43,7 +43,7 @@ public class Language implements jplag.Language {
 		return false;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.csharp-1.2/src/main/java/jplag/csharp/Language.java
+++ b/jplag.frontend.csharp-1.2/src/main/java/jplag/csharp/Language.java
@@ -47,7 +47,7 @@ public class Language implements jplag.Language {
 		return true;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.java-1.1exp/src/main/java/jplag/javax/Language.java
+++ b/jplag.frontend.java-1.1exp/src/main/java/jplag/javax/Language.java
@@ -39,7 +39,7 @@ public class Language implements jplag.Language {
 		return false;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.java-1.2/src/main/java/jplag/java/Language.java
+++ b/jplag.frontend.java-1.2/src/main/java/jplag/java/Language.java
@@ -45,7 +45,7 @@ public class Language implements jplag.Language {
 		return true;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.java-1.5/src/main/java/jplag/java15/Language.java
+++ b/jplag.frontend.java-1.5/src/main/java/jplag/java15/Language.java
@@ -45,7 +45,7 @@ public class Language implements jplag.Language {
 		return true;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.java-1.5/src/main/java/jplag/java15/LanguageWithDelimitedMethods.java
+++ b/jplag.frontend.java-1.5/src/main/java/jplag/java15/LanguageWithDelimitedMethods.java
@@ -50,7 +50,7 @@ public class LanguageWithDelimitedMethods implements jplag.Language {
 		return true;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.java-1.7/src/main/java/jplag/java17/Language.java
+++ b/jplag.frontend.java-1.7/src/main/java/jplag/java17/Language.java
@@ -45,7 +45,7 @@ public class Language implements jplag.Language {
 		return true;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.java-1.9/src/main/java/jplag/java19/Language.java
+++ b/jplag.frontend.java-1.9/src/main/java/jplag/java19/Language.java
@@ -38,7 +38,7 @@ public class Language implements jplag.Language {
 		return true;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.python-3/src/main/java/jplag/python3/Language.java
+++ b/jplag.frontend.python-3/src/main/java/jplag/python3/Language.java
@@ -46,7 +46,7 @@ public class Language implements jplag.Language {
         return true;
     }
 
-    public boolean isPreformated() {
+    public boolean isPreformatted() {
         return true;
     }
 

--- a/jplag.frontend.scheme/src/main/java/jplag/scheme/Language.java
+++ b/jplag.frontend.scheme/src/main/java/jplag/scheme/Language.java
@@ -41,7 +41,7 @@ public class Language implements jplag.Language {
 		return false;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return true;
 	}
 

--- a/jplag.frontend.text/src/main/java/jplag/text/Language.java
+++ b/jplag.frontend.text/src/main/java/jplag/text/Language.java
@@ -53,7 +53,7 @@ public class Language implements jplag.Language {
 		return true;
 	}
 
-	public boolean isPreformated() {
+	public boolean isPreformatted() {
 		return false;
 	}
 

--- a/jplag/src/main/java/jplag/Report.java
+++ b/jplag/src/main/java/jplag/Report.java
@@ -485,16 +485,16 @@ public class Report implements TokenConstants {
 
 			for (int j = 0; j < files.length; j++) {
 				f.println("<HR>\n<H3><CENTER>" + files[j] + "</CENTER></H3><HR>");
-				if (this.language.isPreformated())
+				if (this.language.isPreformatted())
 					f.println("<PRE>");
 				for (int k = 0; k < text[j].length; k++) {
 					f.print(text[j][k]);
-					if (!this.language.isPreformated())
+					if (!this.language.isPreformatted())
 						f.println("<BR>");
 					else
 						f.println();
 				}
-				if (language.isPreformated())
+				if (language.isPreformatted())
 					f.println("</PRE>");
 			}
 
@@ -761,16 +761,16 @@ public class Report implements TokenConstants {
 
 		for (int x = 0; x < text.length; x++) {
 			f.println("<HR>\n<H3><CENTER>" + files[x] + "</CENTER></H3><HR>");
-			if (this.language.isPreformated())
+			if (this.language.isPreformatted())
 				f.println("<PRE>");
 			for (int y = 0; y < text[x].length; y++) {
 				f.print(text[x][y]);
-				if (!this.language.isPreformated())
+				if (!this.language.isPreformatted())
 					f.println("<BR>");
 				else
 					f.println();
 			}
-			if (this.language.isPreformated())
+			if (this.language.isPreformatted())
 				f.println("</PRE>");
 		}
 		f.println("</BODY>\n</HTML>");
@@ -976,16 +976,16 @@ public class Report implements TokenConstants {
 
 		for (int x = 0; x < text.length; x++) {
 			f.println("<HR>\n<H3><CENTER>" + files[x] + "</CENTER></H3><HR>");
-			if (this.language.isPreformated())
+			if (this.language.isPreformatted())
 				f.println("<PRE>");
 			for (int y = 0; y < text[x].length; y++) {
 				f.print(text[x][y]);
-				if (!this.language.isPreformated())
+				if (!this.language.isPreformatted())
 					f.println("<BR>");
 				else
 					f.println();
 			}
-			if (this.language.isPreformated())
+			if (this.language.isPreformatted())
 				f.println("</PRE>");
 		}
 		f.println("\n</BODY>\n</HTML>");


### PR DESCRIPTION
While trying to add a new language to JPlag, I added documentation for `jplag.Language` to decrease the ambiguity of its functions.
Most of it is by educated guess from looking at how other people use it, and how Jplag uses the function. Two remarks:

- I have no idea what the purpose of `usesIndex()` is.
- Function `errors()` seems rewritable to `errorsCount() != 0`. It looks like `errors` was intended to count each file, but jplag uses it wrongly in that case (`jplag.Submission`, line 139 is the only use of it).
