### PR TITLE
Fix some warnings

### DIFF
--- a/jplag.frontend.chars/src/main/java/jplag/chars/CharToken.java
+++ b/jplag.frontend.chars/src/main/java/jplag/chars/CharToken.java
@@ -5,12 +5,9 @@ public class CharToken extends jplag.Token {
 
 	private int index;
 
-	private Parser parser;
-
 	public CharToken(int type, String file, int index, Parser parser) {
 		super(type, file, -1);
 		this.index = index;
-		this.parser = parser;
 	}
 
 	public CharToken(int type, String file, Parser parser) {

--- a/jplag.frontend.java-1.1exp/src/main/java/jplag/javax/Language.java
+++ b/jplag.frontend.java-1.1exp/src/main/java/jplag/javax/Language.java
@@ -1,9 +1,8 @@
 package jplag.javax;
 
-import java.io.*;
+import java.io.File;
 
 import jplag.ProgramI;
-import jplag.javax.Parser;
 
 public class Language implements jplag.Language {
 	private Parser parser;

--- a/jplag.frontend.java-1.9/src/main/java/jplag/java19/JavacAdapter.java
+++ b/jplag.frontend.java-1.9/src/main/java/jplag/java19/JavacAdapter.java
@@ -68,7 +68,6 @@ public class JavacAdapter {
 		}
 		final Trees trees = Trees.instance(task);
 		final SourcePositions positions = trees.getSourcePositions();
-		CompilationUnitTree last = null;
 		for (final CompilationUnitTree ast : asts) {
 			final String filename;
 			if (dir==null)
@@ -77,7 +76,6 @@ public class JavacAdapter {
 				filename=Paths.get(dir.toURI()).relativize(Paths.get(ast.getSourceFile().toUri())).toString();
 			}
 			final LineMap map = ast.getLineMap();
-			last=ast;
 			ast.accept(new TreeScanner<Object,Object>() {
 				@Override
 				public Object visitBlock(BlockTree node, Object p) {
@@ -347,7 +345,6 @@ public class JavacAdapter {
 					return super.visitErroneous(node, p);
 				}
 			}, null);
-			long n = positions.getEndPosition(last, last);
 			parser.add(JavaTokenConstants.FILE_END,filename,1,-1,-1);
 		}
 		int errors = 0;
@@ -355,12 +352,6 @@ public class JavacAdapter {
 		{
 			if (diagItem.getKind() == javax.tools.Diagnostic.Kind.ERROR) {
 				errors++;
-			}
-			if (diagItem.getKind() == javax.tools.Diagnostic.Kind.WARNING) {
-				
-			}
-			if (diagItem.getKind() == javax.tools.Diagnostic.Kind.MANDATORY_WARNING) {
-				
 			}
 		}
 		return errors;

--- a/jplag.frontend.python-3/src/main/java/jplag/python3/Python3Token.java
+++ b/jplag.frontend.python-3/src/main/java/jplag/python3/Python3Token.java
@@ -2,6 +2,8 @@ package jplag.python3;
 
 public class Python3Token extends jplag.Token implements Python3TokenConstants {
 
+    private static final long serialVersionUID = 1485877548175917943L;
+    
     private int line, column, length;
 
     public Python3Token(int type, String file, int line, int column, int length) {

--- a/jplag.frontend.text/src/main/java/jplag/text/TextToken.java
+++ b/jplag.frontend.text/src/main/java/jplag/text/TextToken.java
@@ -7,7 +7,7 @@ public class TextToken extends jplag.Token {
         text = text.toLowerCase();
         Integer obj = (Integer) parser.tokenStructure.table.get(text);
         if(obj == null) {
-            obj = new Integer(parser.tokenStructure.serial);
+            obj = Integer.valueOf(parser.tokenStructure.serial);
             if(parser.tokenStructure.serial == Integer.MAX_VALUE)
                 parser.outOfSerials();
             else


### PR DESCRIPTION
Fix some compiler warnings based on dead code, unused imports, deprecated API calls, etc.