### PR TITLE
Revert "Dependency(deps): Bump antlr4 and antlr4-runtime from 4.2 to 4.9.2"

### DIFF
--- a/jplag.parent/pom.xml
+++ b/jplag.parent/pom.xml
@@ -274,7 +274,7 @@
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4</artifactId>
-				<version>4.9.2</version>
+				<version>4.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.antlr</groupId>

--- a/jplag.parent/pom.xml
+++ b/jplag.parent/pom.xml
@@ -269,7 +269,7 @@
 			<dependency>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-runtime</artifactId>
-				<version>4.9.2</version>
+				<version>4.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.antlr</groupId>


### PR DESCRIPTION
Reverts jplag/jplag#124 and jplag/jplag#125, since the build is flaky.