### PR TITLE
Revert "Dependency(deps): Bump javacc from 3.2 to 7.0.10"

### DIFF
--- a/jplag.frontend.cpp/pom.xml
+++ b/jplag.frontend.cpp/pom.xml
@@ -57,7 +57,7 @@
 					<dependency>
 						<groupId>net.java.dev.javacc</groupId>
 						<artifactId>javacc</artifactId>
-						<version>7.0.10</version>
+						<version>3.2</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/jplag.frontend.scheme/pom.xml
+++ b/jplag.frontend.scheme/pom.xml
@@ -57,7 +57,7 @@
 					<dependency>
 						<groupId>net.java.dev.javacc</groupId>
 						<artifactId>javacc</artifactId>
-						<version>7.0.10</version>
+						<version>3.2</version>
 					</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
Reverts jplag/jplag#136
(why does the PR CI pass after I update from master, but after merging the PR the CI fails?)