### PR TITLE
Replace deprecated syntax by the appropriate replacements.

### DIFF
--- a/jplag.frontend.java-1.7/src/main/java/jplag/java17/Parser.java
+++ b/jplag.frontend.java-1.7/src/main/java/jplag/java17/Parser.java
@@ -7,7 +7,8 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
@@ -78,11 +79,11 @@ public class Parser extends jplag.Parser implements JavaTokenConstants {
 	public boolean parseFile(File dir, String file) {
 		BufferedInputStream fis;
 
-		ANTLRInputStream input;
+		CharStream input;
 		try {
 			fis = new BufferedInputStream(new FileInputStream(new File(dir, file)));
 			currentFile = file;
-			input = new ANTLRInputStream(fis);
+			input = CharStreams.fromStream(fis);			        
 
 			// create a lexer that feeds off of input CharStream
 			Java7Lexer lexer = new Java7Lexer(input);

--- a/jplag.frontend.java-1.7/src/test/java/jplag/antlr4Learning/Antlr4LearningTests.java
+++ b/jplag.frontend.java-1.7/src/test/java/jplag/antlr4Learning/Antlr4LearningTests.java
@@ -5,7 +5,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -28,7 +29,7 @@ public class Antlr4LearningTests {
 	@Test
 	public void testVisitor() throws IOException {
 		BufferedInputStream fis = new BufferedInputStream(new FileInputStream(new File(srcTestResources, "ExceptionOne.java")));
-		ANTLRInputStream input = new ANTLRInputStream(fis);
+		CharStream input = CharStreams.fromStream(fis);
 
 		// create a lexer that feeds off of input CharStream
 		Java7Lexer lexer = new Java7Lexer(input);
@@ -46,7 +47,7 @@ public class Antlr4LearningTests {
 	public void howToUseAntlr4() throws IOException {
 		FileInputStream fis = new FileInputStream(new File(srcTestResources, "Java7FeatureTest.java"));
 		// create a CharStream that reads from file input stream
-		ANTLRInputStream input = new ANTLRInputStream(fis);
+		CharStream input = CharStreams.fromStream(fis);
 
 		// create a lexer that feeds off of input CharStream
 		Java7Lexer lexer = new Java7Lexer(input);
@@ -66,7 +67,7 @@ public class Antlr4LearningTests {
 	public void howToUseAntlr4Tokens() throws IOException {
 		FileInputStream fis = new FileInputStream(new File(srcTestResources, "Java7FeatureTest.java"));
 		// create a CharStream that reads from file input stream
-		ANTLRInputStream input = new ANTLRInputStream(fis);
+		CharStream input = CharStreams.fromStream(fis);
 
 		// create a lexer that feeds off of input CharStream
 		Java7Lexer lexer = new Java7Lexer(input);

--- a/jplag.frontend.java-1.7/src/test/java/jplag/java17/ParserTest.java
+++ b/jplag.frontend.java-1.7/src/test/java/jplag/java17/ParserTest.java
@@ -7,7 +7,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -39,7 +40,7 @@ public class ParserTest {
 	public void testTheNewFancyJava7Features() throws IOException {
 		File file = new File(srcTestResources, "Java7FeatureTest.java");
 		FileInputStream fis = new FileInputStream(file);
-		ANTLRInputStream input = new ANTLRInputStream(fis);
+		CharStream input = CharStreams.fromStream(fis);
 		Java7Lexer lexer = new Java7Lexer(input);
 		CommonTokenStream tokens = new CommonTokenStream(lexer);
 		Java7Parser parser = new Java7Parser(tokens);

--- a/jplag.frontend.python-3/pom.xml
+++ b/jplag.frontend.python-3/pom.xml
@@ -36,12 +36,6 @@
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr4-maven-plugin</artifactId>
 				<version>4.2</version>
-				<configuration>
-					<!-- Comma separated list of grammar files or pattern grammar files
-						By default, grammar file(s) is in ${basedir}/src/main/antlr -->
-					<!-- <grammars>*.g</grammars> -->
-					<grammars>Python3.g4</grammars>
-				</configuration>
 				<executions>
 					<execution>
 						<goals>

--- a/jplag.frontend.python-3/src/main/java/jplag/python3/Parser.java
+++ b/jplag.frontend.python-3/src/main/java/jplag/python3/Parser.java
@@ -7,7 +7,8 @@ import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 
-import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
@@ -82,11 +83,11 @@ public class Parser extends jplag.Parser implements Python3TokenConstants {
     public boolean parseFile(File dir, String file) {
         BufferedInputStream fis;
 
-        ANTLRInputStream input;
+        CharStream input;
         try {
             fis = new BufferedInputStream(new FileInputStream(new File(dir, file)));
             currentFile = file;
-            input = new ANTLRInputStream(fis);
+            input = CharStreams.fromStream(fis);
 
             // create a lexer that feeds off of input CharStream
             Python3Lexer lexer = new Python3Lexer(input);


### PR DESCRIPTION
Mainly replaces `ANTLRInputStream` with `CharStream`.