### PR TITLE
Change -s to -m in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You'll find the generated JAR with all dependencies in  `jplag/target`.
 usage: jplag [-h]
              [-l {java_1_1,java_1_2,java_1_5,java_1_5_dm,java_1_7,java_1_9,python_3,c_cpp,c_sharp,char,text,scheme}]
              [-bc BC] [-v {parser,quiet,long,details}] [-d] [-S S] [-p P]
-             [-x X] [-t T] [-s S] [-r R] rootDir
+             [-x X] [-t T] [-m M] [-r R] rootDir
 
 JPlag - Detecting Software Plagiarism
 
@@ -67,8 +67,8 @@ named arguments:
   -x X                   All files named in <file> will be ignored
   -t T                   Tune the sensitivity of  the comparison. A smaller
                          <n> increases the sensitivity
-  -s S                   Similarity  Threshold:  all   matches  above  this
-                         threshold will be saved
+  -m M                   Match similarity  Threshold  [0-100]:  All matches
+                         above this threshold will be saved (Standard: 0.0)
   -r R                   Name of directory in which  the  web pages will be
                          stored (default: result)
 ```

--- a/jplag/src/main/java/jplag/CLI.java
+++ b/jplag/src/main/java/jplag/CLI.java
@@ -69,7 +69,7 @@ public class CLI {
         parser.addArgument("-p").help("comma-separated list of all filename suffixes that are included");
         parser.addArgument("-x").help("All files named in this file will be ignored in the comparison (line-separated list)");
         parser.addArgument("-t").help("Tune the sensitivity of the comparison. A smaller <n> increases the sensitivity");
-        parser.addArgument("-m").setDefault(0f).help("Match similarity Threshold [0-100]: all matches above this threshold will be saved");
+        parser.addArgument("-m").setDefault(0f).help("Match similarity Threshold [0-100]: All matches above this threshold will be saved");
         parser.addArgument("-r").setDefault("result").help("Name of directory in which the comparison results will be stored");
     }
 


### PR DESCRIPTION
Commit https://github.com/jplag/jplag/commit/45d11cd681d10992b520c8b8ea15949ba9c5ecfa changed the CLI-Argument -s into -m without changing the corresponding section in the README.md. This PR changes the section to make it consistent with the current code and to avoid confusion among users (like me) who try to use this parameter when executing JPlag. 