### PR TITLE
Update POM parent

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: 14
         distribution: 'zulu'
         
     - name: Run Maven Install

--- a/jplag.parent/pom.xml
+++ b/jplag.parent/pom.xml
@@ -65,8 +65,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.build.source>11</project.build.source>
-    <project.build.target>11</project.build.target>
+    <project.build.source>14</project.build.source>
+    <project.build.target>14</project.build.target>
     <project.build.optimize>true</project.build.optimize>
   </properties>
 


### PR DESCRIPTION
Increase Maven compiler version to Java 14.
This adresses #120 since the Java 9+ frontend depends indirectly on the Java version through its use of JavaC.