### PR TITLE
Fix similarity ordering

### DIFF
--- a/jplag/src/main/java/jplag/JPlagResult.java
+++ b/jplag/src/main/java/jplag/JPlagResult.java
@@ -52,8 +52,8 @@ public class JPlagResult {
         this.durationInMillis = durationInMillis;
         this.numberOfSubmissions = numberOfSubmissions;
         this.options = options;
-
-        this.similarityDistribution = calculateSimilarityDistribution(comparisons);
+        similarityDistribution = calculateSimilarityDistribution(comparisons);
+        comparisons.sort((first, second) -> Float.compare(second.percent(), first.percent())); // Sort by percentage (descending).
     }
 
     /**
@@ -68,6 +68,9 @@ public class JPlagResult {
         return similarityDistribution;
     }
 
+    /**
+     * @return a list of comparisons sorted by percentage (descending).
+     */
     public List<JPlagComparison> getComparisons() {
         return comparisons;
     }

--- a/jplag/src/main/java/jplag/reporting/Report.java
+++ b/jplag/src/main/java/jplag/reporting/Report.java
@@ -29,6 +29,7 @@ import jplag.Token;
  */
 public class Report {
 
+    private static final String CSV_FILE = "matches_avg.csv";
     private final Map<JPlagComparison, Integer> comparisonToIndex = new HashMap<>();
     private int currentComparisonIndex = 0;
     private final Messages msg;
@@ -401,11 +402,9 @@ public class Report {
         writeIndexBegin(htmlFile, msg.getString("Report.Search_Results"));
         writeDistribution(htmlFile);
 
-        String csvFile = "matches_avg.csv";
+        writeLinksToComparisons(htmlFile, "<H4>" + msg.getString("Report.MatchesAvg"), CSV_FILE);
 
-        writeLinksToComparisons(htmlFile, "<H4>" + msg.getString("Report.MatchesAvg"), csvFile);
-
-        writeMatchesCSV(csvFile);
+        writeMatchesCSV(CSV_FILE);
 
         writeIndexEnd(htmlFile);
 
@@ -542,7 +541,7 @@ public class Report {
     }
 
     private void writeLinksToComparisons(HTMLFile htmlFile, String headerStr, String csvFile) {
-        List<JPlagComparison> comparisons = result.getComparisons();
+        List<JPlagComparison> comparisons = result.getComparisons(); // should be already sorted!
 
         htmlFile.println(headerStr + " (<a href=\"help-sim-" + "en" // Country tag
                 + ".html\"><small><font color=\"#000088\">" + msg.getString("Report.WhatIsThis") + "</font></small></a>):</H4>");

--- a/jplag/src/main/java/jplag/reporting/Report.java
+++ b/jplag/src/main/java/jplag/reporting/Report.java
@@ -29,12 +29,15 @@ import jplag.Token;
  */
 public class Report {
 
-    private JPlagResult result;
-    private final File reportDir;
+    private final Map<JPlagComparison, Integer> comparisonToIndex = new HashMap<>();
+    private int currentComparisonIndex = 0;
     private final Messages msg;
 
-    private int currentComparisonIndex = 0;
-    private final Map<JPlagComparison, Integer> comparisonToIndex = new HashMap<>();
+    // SUBMISSION - here it comes...
+    private final String[] pics = {"forward.gif", "back.gif"};
+    private final File reportDir;
+
+    private JPlagResult result;
 
     public Report(File reportDir) throws ExitException {
         this.reportDir = reportDir;
@@ -43,21 +46,15 @@ public class Report {
         validateReportDir();
     }
 
-    /**
-     * Make sure the report directory exists, is a directory and has write access.
-     */
-    private void validateReportDir() throws ExitException {
-        if (!reportDir.exists() && !reportDir.mkdirs()) {
-            throw new ExitException("Cannot create report directory!");
-        }
+    public void writeResult(JPlagResult result) throws ExitException {
+        this.result = result;
+        
+        System.out.print("Writing report...");
+        writeIndex();
 
-        if (!reportDir.isDirectory()) {
-            throw new ExitException(reportDir + " is not a directory!");
-        }
+        copyStaticFiles();
 
-        if (!reportDir.canWrite()) {
-            throw new ExitException("Cannot write directory: " + reportDir);
-        }
+        writeMatches(result.getComparisons());
     }
 
     /*
@@ -67,11 +64,11 @@ public class Report {
         int redValue = (int) (Rl + (Rh - Rl) * percent / 100);
         int greenValue = (int) (Gl + (Gh - Gl) * percent / 100);
         int blueValue = (int) (Bl + (Bh - Bl) * percent / 100);
-
+    
         String red = (redValue < 16 ? "0" : "") + Integer.toHexString(redValue);
         String green = (greenValue < 16 ? "0" : "") + Integer.toHexString(greenValue);
         String blue = (blueValue < 16 ? "0" : "") + Integer.toHexString(blueValue);
-
+    
         return "#" + red + green + blue;
     }
 
@@ -80,15 +77,15 @@ public class Report {
      */
     private void copyStaticFiles() {
         final String[] fileList = {"back.gif", "forward.gif", "help-en.html", "help-sim-en.html", "logo.gif", "fields.js"};
-
+    
         for (int i = fileList.length - 1; i >= 0; i--) {
             try {
                 URL url = Report.class.getResource("data/" + fileList[i]);
                 DataInputStream dis = new DataInputStream(url.openStream());
-
+    
                 File dest = new File(reportDir, fileList[i]);
                 DataOutputStream dos = new DataOutputStream(new FileOutputStream(dest));
-
+    
                 byte[] buffer = new byte[1024];
                 int count;
                 do {
@@ -105,28 +102,6 @@ public class Report {
         }
     }
 
-    private int getComparisonIndex(JPlagComparison comparison) {
-        Integer index = comparisonToIndex.get(comparison);
-
-        if (index != null) {
-            return index;
-        }
-
-        comparisonToIndex.put(comparison, currentComparisonIndex++);
-
-        return currentComparisonIndex - 1;
-    }
-
-    public void writeResult(JPlagResult result) throws ExitException {
-        this.result = result;
-
-        writeIndex();
-
-        copyStaticFiles();
-
-        writeMatches(result.getComparisons());
-    }
-
     /**
      * Create a new HTML file.
      */
@@ -140,248 +115,16 @@ public class Report {
         }
     }
 
-    private void writeHTMLHeader(HTMLFile file, String title) {
-        file.println("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">");
-        file.println("<HTML><HEAD><TITLE>" + title + "</TITLE>");
-        file.println("<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">");
-        file.println("</HEAD>");
-    }
-
-    /**
-     * Write the index.html file.
-     */
-    private void writeIndex() throws ExitException {
-        HTMLFile htmlFile = createHTMLFile("index.html");
-
-        writeIndexBegin(htmlFile, msg.getString("Report.Search_Results"));
-        writeDistribution(htmlFile);
-
-        String csvFile = "matches_avg.csv";
-
-        writeLinksToComparisons(htmlFile, "<H4>" + msg.getString("Report.MatchesAvg"), csvFile);
-
-        writeMatchesCSV(csvFile);
-
-        writeIndexEnd(htmlFile);
-
-        htmlFile.close();
-    }
-
-    /**
-     * Write the beginning of the index.html file.
-     */
-    private void writeIndexBegin(HTMLFile htmlFile, String title) {
-        writeHTMLHeader(htmlFile, title);
-
-        htmlFile.println("<BODY BGCOLOR=#ffffff LINK=#000088 VLINK=#000000 TEXT=#000000>");
-        htmlFile.println("<TABLE ALIGN=center CELLPADDING=2 CELLSPACING=1>");
-        htmlFile.println("<TR VALIGN=middle ALIGN=center BGCOLOR=#ffffff><TD>" + "<IMG SRC=\"logo.gif\" ALT=\"JPlag\" BORDER=0></TD>");
-        htmlFile.println("<TD><H1><BIG>" + title + "</BIG></H1></TD></TR>");
-
-        htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Language") + ":</TD><TD>"
-                + result.getOptions().getLanguageOption().name() + "</TD></TR>");
-        htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Submissions") + ":</TD><TD>" + result.getNumberOfSubmissions());
-
-        htmlFile.println("</TD></TR>");
-
-        if (result.getOptions().hasBaseCode()) {
-            htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Basecode_submission") + ":</TD>" + "<TD>"
-                    + result.getOptions().getBaseCodeSubmissionName() + "</TD></TR>");
+    private int getComparisonIndex(JPlagComparison comparison) {
+        Integer index = comparisonToIndex.get(comparison);
+    
+        if (index != null) {
+            return index;
         }
-
-        if (result.getComparisons().size() > 0) {
-            htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Matches_displayed") + ":</TD>" + "<TD>");
-
-            htmlFile.println(result.getComparisons().size() + " (" + msg.getString("Report.Treshold") + ": "
-                    + result.getOptions().getSimilarityThreshold() + "%)<br>");
-
-            htmlFile.println("</TD></TR>");
-        }
-
-        SimpleDateFormat dateFormat = new SimpleDateFormat();
-
-        htmlFile.println(
-                "<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Date") + ":</TD><TD>" + dateFormat.format(new Date()) + "</TD></TR>");
-        htmlFile.println("<TR BGCOLOR=#aaaaff>" + "<TD><EM>" + msg.getString("Report.Minimum_Match_Length") + "</EM> ("
-                + msg.getString("Report.sensitivity") + "):</TD><TD>" + result.getOptions().getMinTokenMatch() + "</TD></TR>");
-        htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Suffixes") + ":</TD><TD>");
-
-        String[] fileSuffixes = result.getOptions().getFileSuffixes();
-
-        for (int i = 0; i < fileSuffixes.length; i++) {
-            htmlFile.print(fileSuffixes[i] + (i < fileSuffixes.length - 1 ? ", " : "</TD></TR>\n"));
-        }
-
-        htmlFile.println("</TABLE>\n<HR>");
-    }
-
-    /**
-     * Write the end of the index.html file.
-     */
-    private void writeIndexEnd(HTMLFile htmlFile) {
-        htmlFile.println("<HR>\n<P ALIGN=right><FONT SIZE=\"1\" FACE=\"helvetica\">JPlag</FONT></P>");
-        htmlFile.println("</BODY>\n</HTML>");
-    }
-
-    private void writeDistribution(HTMLFile htmlFile) {
-        int barLength = 75;
-        int[] similarityDistribution = result.getSimilarityDistribution();
-
-        int max = 1;
-
-        for (int i = 0; i < 10; i++) {
-            if (similarityDistribution[i] > max) {
-                max = similarityDistribution[i];
-            }
-        }
-
-        htmlFile.println("<H4>" + this.msg.getString("Report.Distribution") + ":</H4>\n<CENTER>");
-        htmlFile.println("<TABLE CELLPADDING=1 CELLSPACING=1>");
-
-        for (int i = 9; i >= 0; i--) {
-            htmlFile.print("<TR BGCOLOR=" + color(i * 10 + 10, 128, 192, 128, 192, 255, 255) + "><TD ALIGN=center>" + (i * 10) + "% - "
-                    + (i * 10 + 10) + "%" + "</TD><TD ALIGN=right>" + similarityDistribution[i] + "</TD><TD>");
-
-            for (int j = (similarityDistribution[i] * barLength / max); j > 0; j--) {
-                htmlFile.print("#");
-            }
-
-            if (similarityDistribution[i] * barLength / max == 0) {
-                if (similarityDistribution[i] == 0) {
-                    htmlFile.print(".");
-                } else {
-                    htmlFile.print("#");
-                }
-            }
-
-            htmlFile.println("</TD></TR>");
-        }
-
-        htmlFile.println("</TABLE></CENTER>\n<P>\n<HR>");
-    }
-
-    private void writeLinksToComparisons(HTMLFile htmlFile, String headerStr, String csvFile) {
-        List<JPlagComparison> comparisons = result.getComparisons();
-
-        htmlFile.println(headerStr + " (<a href=\"help-sim-" + "en" // Country tag
-                + ".html\"><small><font color=\"#000088\">" + msg.getString("Report.WhatIsThis") + "</font></small></a>):</H4>");
-        htmlFile.println("<p><a href=\"" + csvFile + "\">download csv</a></p>");
-        htmlFile.println("<TABLE CELLPADDING=3 CELLSPACING=2>");
-
-        for (JPlagComparison comparison : comparisons) {
-            String submissionNameA = comparison.firstSubmission.name;
-            String submissionNameB = comparison.secondSubmission.name;
-
-            htmlFile.print("<TR><TD BGCOLOR=" + color(comparison.percentA(), 128, 192, 128, 192, 255, 255) + ">" + submissionNameA
-                    + "</TD><TD><nobr>-&gt;</nobr>");
-
-            htmlFile.print("</TD><TD BGCOLOR=" + color(comparison.percentB(), 128, 192, 128, 192, 255, 255) + " ALIGN=center><A HREF=\"match"
-                    + getComparisonIndex(comparison) + ".html\">" + submissionNameB + "</A><BR><FONT COLOR=\""
-                    + color(comparison.percent(), 0, 255, 0, 0, 0, 0) + "\">(" + (((int) (comparison.percent() * 10)) / (float) 10) + "%)</FONT>");
-
-            htmlFile.println("</TD></TR>");
-        }
-
-        htmlFile.println("</TABLE><P>\n");
-        htmlFile.println("<!---->");
-    }
-
-    private void writeMatchesCSV(String fileName) {
-        FileWriter writer = null;
-        File csvFile = new File(reportDir, fileName);
-        List<JPlagComparison> comparisons = result.getComparisons();
-
-        try {
-            csvFile.createNewFile();
-            writer = new FileWriter(csvFile);
-
-            for (JPlagComparison comparison : comparisons) {
-                String submissionNameA = comparison.firstSubmission.name;
-                String submissionNameB = comparison.secondSubmission.name;
-
-                writer.write(getComparisonIndex(comparison) + ";");
-                writer.write(submissionNameA + ";");
-                writer.write(submissionNameB + ";");
-                writer.write((((int) (comparison.percent() * 10)) / (float) 10) + ";");
-                writer.write("\n");
-            }
-
-            writer.flush();
-        } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            try {
-                writer.close();
-            } catch (Exception ignored) {
-            }
-        }
-    }
-
-    private void writeMatches(List<JPlagComparison> comparisons) {
-        comparisons.forEach(comparison -> {
-            try {
-                int i = getComparisonIndex(comparison);
-                writeMatch(comparison, i);
-            } catch (ExitException e) {
-                e.printStackTrace();
-            }
-        });
-    }
-
-    private void writeMatch(JPlagComparison comparison, int i) throws ExitException {
-        HTMLFile htmlFile = createHTMLFile("match" + i + ".html");
-
-        writeHTMLHeader(htmlFile, TagParser.parse(msg.getString("Report.Matches_for_X1_AND_X2"),
-                new String[] {comparison.firstSubmission.name, comparison.secondSubmission.name}));
-
-        htmlFile.println("<body>");
-        htmlFile.println("  <div style=\"align-items: center; display: flex; justify-content: space-around;\">");
-
-        htmlFile.println("    <div>");
-        htmlFile.println("      <h3 align=\"center\">");
-        htmlFile.println(TagParser.parse(msg.getString("Report.Matches_for_X1_AND_X2"),
-                new String[] {comparison.firstSubmission.name, comparison.secondSubmission.name}));
-        htmlFile.println("      </h3>");
-        htmlFile.println("      <h1 align=\"center\">");
-        htmlFile.println("        " + comparison.roundedPercent() + "%");
-        htmlFile.println("      </h1>");
-        htmlFile.println("      <center>");
-        htmlFile.println("        <a href=\"index.html\" target=\"_top\">");
-        htmlFile.println("          " + msg.getString("Report.INDEX"));
-        htmlFile.println("        </a>");
-        htmlFile.println("        <span>-</span>");
-        htmlFile.println("        <a href=\"help-en.html\" target=\"_top\">");
-        htmlFile.println("          " + msg.getString("Report.HELP"));
-        htmlFile.println("        </a>");
-        htmlFile.println("      </center>");
-        htmlFile.println("    </div>");
-
-        htmlFile.println("    <div>");
-        reportComparison(htmlFile, comparison, i);
-        htmlFile.println("    </div>");
-
-        htmlFile.println("  </div>");
-
-        htmlFile.println("  <hr>");
-
-        htmlFile.println("  <div style=\"display: flex;\">");
-
-        if (result.getOptions().getLanguage().usesIndex()) {
-            writeIndexedSubmission(htmlFile, i, comparison, 0);
-            writeIndexedSubmission(htmlFile, i, comparison, 1);
-        } else if (result.getOptions().getLanguage().supportsColumns()) {
-            writeImprovedSubmission(htmlFile, i, comparison, 0);
-            writeImprovedSubmission(htmlFile, i, comparison, 1);
-        } else {
-            writeNormalSubmission(htmlFile, i, comparison, 0);
-            writeNormalSubmission(htmlFile, i, comparison, 1);
-        }
-
-        htmlFile.println("  </div>");
-
-        htmlFile.println("</body>");
-        htmlFile.println("</html>");
-        htmlFile.close();
+    
+        comparisonToIndex.put(comparison, currentComparisonIndex++);
+    
+        return currentComparisonIndex - 1;
     }
 
     /**
@@ -440,185 +183,65 @@ public class Report {
         htmlFile.println("</TABLE>");
     }
 
-    // SUBMISSION - here it comes...
-    private final String[] pics = {"forward.gif", "back.gif"};
-
-    /*
-     * i is the number of the match j == 0 if subA is considered, otherwise (j must then be 1) it is subB
+    /**
+     * Make sure the report directory exists, is a directory and has write access.
      */
-    private void writeNormalSubmission(HTMLFile f, int i, JPlagComparison comparison, int j) throws ExitException {
-        Submission sub = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission);
-        String[] files = comparison.files(j);
-
-        String[][] text = sub.readFiles(files);
-
-        Token[] tokens = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission).tokenList.tokens;
-        Match currentMatch;
-        String hilf;
-        int h;
-        for (int x = 0; x < comparison.matches.size(); x++) {
-            currentMatch = comparison.matches.get(x);
-
-            Token start = tokens[(j == 0 ? currentMatch.startA : currentMatch.startB)];
-            Token ende = tokens[((j == 0 ? currentMatch.startA : currentMatch.startB) + currentMatch.length - 1)];
-
-            for (int y = 0; y < files.length; y++) {
-                if (start.file.equals(files[y]) && text[y] != null) {
-                    hilf = "<FONT color=\"" + Color.getHexadecimalValue(x) + "\">" + (j == 1 ? "<div style=\"position:absolute;left:0\">" : "")
-                            + "<A HREF=\"javascript:ZweiFrames('match" + i + "-" + (1 - j) + ".html#" + x + "'," + (3 - j) + ",'match" + i
-                            + "-top.html#" + x + "',1)\"><IMG SRC=\"" + pics[j] + "\" ALT=\"other\" " + "BORDER=\"0\" ALIGN=\""
-                            + (j == 0 ? "right" : "left") + "\"></A>" + (j == 1 ? "</div>" : "") + "<B>";
-                    // position the icon and the beginning of the colorblock
-                    if (text[y][start.getLine() - 1].endsWith("</FONT>")) {
-                        text[y][start.getLine() - 1] += hilf;
-                    } else {
-                        text[y][start.getLine() - 1] = hilf + text[y][start.getLine() - 1];
-                    }
-                    // the link location is placed 3 lines before the start of a block
-                    h = (Math.max(start.getLine() - 4, 0));
-                    text[y][h] = "<A NAME=\"" + x + "\"></A>" + text[y][h];
-                    // mark the end
-                    if (start.getLine() != ende.getLine() && // if match is only one line
-                            text[y][ende.getLine() - 1].startsWith("<FONT ")) {
-                        text[y][ende.getLine() - 1] = "</B></FONT>" + text[y][ende.getLine() - 1];
-                    } else {
-                        text[y][ende.getLine() - 1] += "</B></FONT>";
-                    }
-                }
-            }
+    private void validateReportDir() throws ExitException {
+        if (!reportDir.exists() && !reportDir.mkdirs()) {
+            throw new ExitException("Cannot create report directory!");
         }
-
-        if (result.getOptions().hasBaseCode() && comparison.bcMatchesA != null && comparison.bcMatchesB != null) {
-            JPlagBaseCodeComparison baseCodeComparison = (j == 0 ? comparison.bcMatchesA : comparison.bcMatchesB);
-
-            for (int x = 0; x < baseCodeComparison.matches.size(); x++) {
-                currentMatch = baseCodeComparison.matches.get(x);
-                Token start = tokens[currentMatch.startA];
-                Token ende = tokens[currentMatch.startA + currentMatch.length - 1];
-
-                for (int y = 0; y < files.length; y++) {
-                    if (start.file.equals(files[y]) && text[y] != null) {
-                        hilf = ("<font color=\"#C0C0C0\"><EM>");
-                        // position the icon and the beginning of the colorblock
-                        if (text[y][start.getLine() - 1].endsWith("<font color=\"#000000\">")) {
-                            text[y][start.getLine() - 1] += hilf;
-                        } else {
-                            text[y][start.getLine() - 1] = hilf + text[y][start.getLine() - 1];
-                        }
-
-                        // mark the end
-                        if (start.getLine() != ende.getLine() && // match is only one line
-                                text[y][ende.getLine() - 1].startsWith("<font color=\"#C0C0C0\">")) {
-                            text[y][ende.getLine() - 1] = "</EM><font color=\"#000000\">" + text[y][ende.getLine() - 1];
-                        } else {
-                            text[y][ende.getLine() - 1] += "</EM><font color=\"#000000\">";
-                        }
-                    }
-                }
-            }
+    
+        if (!reportDir.isDirectory()) {
+            throw new ExitException(reportDir + " is not a directory!");
         }
-
-        f.println("<div style=\"flex-grow: 1;\">");
-
-        for (int x = 0; x < text.length; x++) {
-            f.println("<h3>");
-            f.println("<center>");
-            f.println("<span>" + sub.name + "</span>");
-            f.println("<span> - </span>");
-            f.println("<span>" + files[x] + "</span>");
-            f.println("</center>");
-            f.println("</h3>");
-            f.println("<HR>");
-            if (result.getOptions().getLanguage().isPreformatted()) {
-                f.println("<PRE>");
-            }
-            for (int y = 0; y < text[x].length; y++) {
-                f.print(text[x][y]);
-                if (!result.getOptions().getLanguage().isPreformatted()) {
-                    f.println("<BR>");
-                } else {
-                    f.println();
-                }
-            }
-            if (result.getOptions().getLanguage().isPreformatted()) {
-                f.println("</PRE>");
-            }
+    
+        if (!reportDir.canWrite()) {
+            throw new ExitException("Cannot write directory: " + reportDir);
         }
-
-        f.println("</div>");
     }
 
-    /*
-     * i is the number of the match j == 0 if subA is considered, otherwise it is subB This procedure uses only the
-     * getIndex() method of the token. It is meant to be used with the Character front end
-     */
-    private void writeIndexedSubmission(HTMLFile f, int i, JPlagComparison comparison, int j) throws ExitException {
-        Submission sub = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission);
-        String[] files = comparison.files(j);
-        char[][] text = sub.readFilesChar(files);
-        Token[] tokens = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission).tokenList.tokens;
+    private void writeDistribution(HTMLFile htmlFile) {
+        int barLength = 75;
+        int[] similarityDistribution = result.getSimilarityDistribution();
 
-        // get index array with matches sorted in ascending order.
-        int[] perm = comparison.sort_permutation(j);
+        int max = 1;
 
-        int index = 0; // match index
-        Match onematch = null;
-        Token start = null;
-        Token end = null;
-
-        f.println("<div style=\"flex-grow: 1;\">");
-
-        for (int fileIndex = 0; fileIndex < files.length; fileIndex++) {
-            f.println("<h3>");
-            f.println("<center>");
-            f.println("<span>" + sub.name + "</span>");
-            f.println("<span> - </span>");
-            f.println("<span>" + files[fileIndex] + "</span>");
-            f.println("</center>");
-            f.println("</h3>");
-            f.println("<HR>");
-            char[] buffer = text[fileIndex];
-
-            for (int charNr = 0; charNr < buffer.length; charNr++) {
-                if (onematch == null) {
-                    if (index < comparison.matches.size()) {
-                        onematch = comparison.matches.get(perm[index]);
-                        start = tokens[(j == 0 ? onematch.startA : onematch.startB)];
-                        end = tokens[((j == 0 ? onematch.startA : onematch.startB) + onematch.length - 1)];
-                        index++;
-                    } else {
-                        start = end = null;
-                    }
-                }
-                // begin markup
-                if (start != null && start.getIndex() == charNr) {
-                    f.print("<A NAME=\"" + perm[index - 1] + "\"></A>");
-                    f.print("<FONT color=\"" + Color.getHexadecimalValue(perm[index - 1]) + "\"><B>");
-                    // "<A HREF=\"javascript:ZweiFrames('match"+i+"-"+(1-j)+
-                    // ".html#"+index+"',"+(3-j)+",'match"+i+"-top.html#"+index+
-                    // "',1)\">"+"<IMG SRC=\""+pics[j]+
-                    // "\" ALT=\"other\" BORDER=\"0\" "+"ALIGN="+
-                    // (j==0 ? "right" : "left")+"></A>");
-                }
-                // text
-                if (buffer[charNr] == '<') {
-                    f.print("&lt;");
-                } else if (buffer[charNr] == '>') {
-                    f.print("&gt;");
-                } else if (buffer[charNr] == '\n') {
-                    f.print("<br>\n");
-                } else {
-                    f.print(buffer[charNr]);
-                }
-                // end markup
-                if (end != null && end.getIndex() == charNr) {
-                    f.print("</B></FONT>");
-                    onematch = null; // switch to next match
-                }
+        for (int i = 0; i < 10; i++) {
+            if (similarityDistribution[i] > max) {
+                max = similarityDistribution[i];
             }
         }
 
-        f.println("</div>");
+        htmlFile.println("<H4>" + this.msg.getString("Report.Distribution") + ":</H4>\n<CENTER>");
+        htmlFile.println("<TABLE CELLPADDING=1 CELLSPACING=1>");
+
+        for (int i = 9; i >= 0; i--) {
+            htmlFile.print("<TR BGCOLOR=" + color(i * 10 + 10, 128, 192, 128, 192, 255, 255) + "><TD ALIGN=center>" + (i * 10) + "% - "
+                    + (i * 10 + 10) + "%" + "</TD><TD ALIGN=right>" + similarityDistribution[i] + "</TD><TD>");
+
+            for (int j = (similarityDistribution[i] * barLength / max); j > 0; j--) {
+                htmlFile.print("#");
+            }
+
+            if (similarityDistribution[i] * barLength / max == 0) {
+                if (similarityDistribution[i] == 0) {
+                    htmlFile.print(".");
+                } else {
+                    htmlFile.print("#");
+                }
+            }
+
+            htmlFile.println("</TD></TR>");
+        }
+
+        htmlFile.println("</TABLE></CENTER>\n<P>\n<HR>");
+    }
+
+    private void writeHTMLHeader(HTMLFile file, String title) {
+        file.println("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">");
+        file.println("<HTML><HEAD><TITLE>" + title + "</TITLE>");
+        file.println("<META http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">");
+        file.println("</HEAD>");
     }
 
     /*
@@ -767,5 +390,383 @@ public class Report {
         f.println("</div>");
 
         return f.bytesWritten();
+    }
+
+    /**
+     * Write the index.html file.
+     */
+    private void writeIndex() throws ExitException {
+        HTMLFile htmlFile = createHTMLFile("index.html");
+
+        writeIndexBegin(htmlFile, msg.getString("Report.Search_Results"));
+        writeDistribution(htmlFile);
+
+        String csvFile = "matches_avg.csv";
+
+        writeLinksToComparisons(htmlFile, "<H4>" + msg.getString("Report.MatchesAvg"), csvFile);
+
+        writeMatchesCSV(csvFile);
+
+        writeIndexEnd(htmlFile);
+
+        htmlFile.close();
+    }
+
+    /**
+     * Write the beginning of the index.html file.
+     */
+    private void writeIndexBegin(HTMLFile htmlFile, String title) {
+        writeHTMLHeader(htmlFile, title);
+
+        htmlFile.println("<BODY BGCOLOR=#ffffff LINK=#000088 VLINK=#000000 TEXT=#000000>");
+        htmlFile.println("<TABLE ALIGN=center CELLPADDING=2 CELLSPACING=1>");
+        htmlFile.println("<TR VALIGN=middle ALIGN=center BGCOLOR=#ffffff><TD>" + "<IMG SRC=\"logo.gif\" ALT=\"JPlag\" BORDER=0></TD>");
+        htmlFile.println("<TD><H1><BIG>" + title + "</BIG></H1></TD></TR>");
+
+        htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Language") + ":</TD><TD>"
+                + result.getOptions().getLanguageOption().name() + "</TD></TR>");
+        htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Submissions") + ":</TD><TD>" + result.getNumberOfSubmissions());
+
+        htmlFile.println("</TD></TR>");
+
+        if (result.getOptions().hasBaseCode()) {
+            htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Basecode_submission") + ":</TD>" + "<TD>"
+                    + result.getOptions().getBaseCodeSubmissionName() + "</TD></TR>");
+        }
+
+        if (result.getComparisons().size() > 0) {
+            htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Matches_displayed") + ":</TD>" + "<TD>");
+
+            htmlFile.println(result.getComparisons().size() + " (" + msg.getString("Report.Treshold") + ": "
+                    + result.getOptions().getSimilarityThreshold() + "%)<br>");
+
+            htmlFile.println("</TD></TR>");
+        }
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat();
+
+        htmlFile.println(
+                "<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Date") + ":</TD><TD>" + dateFormat.format(new Date()) + "</TD></TR>");
+        htmlFile.println("<TR BGCOLOR=#aaaaff>" + "<TD><EM>" + msg.getString("Report.Minimum_Match_Length") + "</EM> ("
+                + msg.getString("Report.sensitivity") + "):</TD><TD>" + result.getOptions().getMinTokenMatch() + "</TD></TR>");
+        htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Suffixes") + ":</TD><TD>");
+
+        String[] fileSuffixes = result.getOptions().getFileSuffixes();
+
+        for (int i = 0; i < fileSuffixes.length; i++) {
+            htmlFile.print(fileSuffixes[i] + (i < fileSuffixes.length - 1 ? ", " : "</TD></TR>\n"));
+        }
+
+        htmlFile.println("</TABLE>\n<HR>");
+    }
+
+    /*
+     * i is the number of the match j == 0 if subA is considered, otherwise it is subB This procedure uses only the
+     * getIndex() method of the token. It is meant to be used with the Character front end
+     */
+    private void writeIndexedSubmission(HTMLFile f, int i, JPlagComparison comparison, int j) throws ExitException {
+        Submission sub = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission);
+        String[] files = comparison.files(j);
+        char[][] text = sub.readFilesChar(files);
+        Token[] tokens = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission).tokenList.tokens;
+
+        // get index array with matches sorted in ascending order.
+        int[] perm = comparison.sort_permutation(j);
+
+        int index = 0; // match index
+        Match onematch = null;
+        Token start = null;
+        Token end = null;
+
+        f.println("<div style=\"flex-grow: 1;\">");
+
+        for (int fileIndex = 0; fileIndex < files.length; fileIndex++) {
+            f.println("<h3>");
+            f.println("<center>");
+            f.println("<span>" + sub.name + "</span>");
+            f.println("<span> - </span>");
+            f.println("<span>" + files[fileIndex] + "</span>");
+            f.println("</center>");
+            f.println("</h3>");
+            f.println("<HR>");
+            char[] buffer = text[fileIndex];
+
+            for (int charNr = 0; charNr < buffer.length; charNr++) {
+                if (onematch == null) {
+                    if (index < comparison.matches.size()) {
+                        onematch = comparison.matches.get(perm[index]);
+                        start = tokens[(j == 0 ? onematch.startA : onematch.startB)];
+                        end = tokens[((j == 0 ? onematch.startA : onematch.startB) + onematch.length - 1)];
+                        index++;
+                    } else {
+                        start = end = null;
+                    }
+                }
+                // begin markup
+                if (start != null && start.getIndex() == charNr) {
+                    f.print("<A NAME=\"" + perm[index - 1] + "\"></A>");
+                    f.print("<FONT color=\"" + Color.getHexadecimalValue(perm[index - 1]) + "\"><B>");
+                    // "<A HREF=\"javascript:ZweiFrames('match"+i+"-"+(1-j)+
+                    // ".html#"+index+"',"+(3-j)+",'match"+i+"-top.html#"+index+
+                    // "',1)\">"+"<IMG SRC=\""+pics[j]+
+                    // "\" ALT=\"other\" BORDER=\"0\" "+"ALIGN="+
+                    // (j==0 ? "right" : "left")+"></A>");
+                }
+                // text
+                if (buffer[charNr] == '<') {
+                    f.print("&lt;");
+                } else if (buffer[charNr] == '>') {
+                    f.print("&gt;");
+                } else if (buffer[charNr] == '\n') {
+                    f.print("<br>\n");
+                } else {
+                    f.print(buffer[charNr]);
+                }
+                // end markup
+                if (end != null && end.getIndex() == charNr) {
+                    f.print("</B></FONT>");
+                    onematch = null; // switch to next match
+                }
+            }
+        }
+
+        f.println("</div>");
+    }
+
+    /**
+     * Write the end of the index.html file.
+     */
+    private void writeIndexEnd(HTMLFile htmlFile) {
+        htmlFile.println("<HR>\n<P ALIGN=right><FONT SIZE=\"1\" FACE=\"helvetica\">JPlag</FONT></P>");
+        htmlFile.println("</BODY>\n</HTML>");
+    }
+
+    private void writeLinksToComparisons(HTMLFile htmlFile, String headerStr, String csvFile) {
+        List<JPlagComparison> comparisons = result.getComparisons();
+
+        htmlFile.println(headerStr + " (<a href=\"help-sim-" + "en" // Country tag
+                + ".html\"><small><font color=\"#000088\">" + msg.getString("Report.WhatIsThis") + "</font></small></a>):</H4>");
+        htmlFile.println("<p><a href=\"" + csvFile + "\">download csv</a></p>");
+        htmlFile.println("<TABLE CELLPADDING=3 CELLSPACING=2>");
+
+        for (JPlagComparison comparison : comparisons) {
+            String submissionNameA = comparison.firstSubmission.name;
+            String submissionNameB = comparison.secondSubmission.name;
+
+            htmlFile.print("<TR><TD BGCOLOR=" + color(comparison.percentA(), 128, 192, 128, 192, 255, 255) + ">" + submissionNameA
+                    + "</TD><TD><nobr>-&gt;</nobr>");
+
+            htmlFile.print("</TD><TD BGCOLOR=" + color(comparison.percentB(), 128, 192, 128, 192, 255, 255) + " ALIGN=center><A HREF=\"match"
+                    + getComparisonIndex(comparison) + ".html\">" + submissionNameB + "</A><BR><FONT COLOR=\""
+                    + color(comparison.percent(), 0, 255, 0, 0, 0, 0) + "\">(" + (((int) (comparison.percent() * 10)) / (float) 10) + "%)</FONT>");
+
+            htmlFile.println("</TD></TR>");
+        }
+
+        htmlFile.println("</TABLE><P>\n");
+        htmlFile.println("<!---->");
+    }
+
+    private void writeMatch(JPlagComparison comparison, int i) throws ExitException {
+        HTMLFile htmlFile = createHTMLFile("match" + i + ".html");
+
+        writeHTMLHeader(htmlFile, TagParser.parse(msg.getString("Report.Matches_for_X1_AND_X2"),
+                new String[] {comparison.firstSubmission.name, comparison.secondSubmission.name}));
+
+        htmlFile.println("<body>");
+        htmlFile.println("  <div style=\"align-items: center; display: flex; justify-content: space-around;\">");
+
+        htmlFile.println("    <div>");
+        htmlFile.println("      <h3 align=\"center\">");
+        htmlFile.println(TagParser.parse(msg.getString("Report.Matches_for_X1_AND_X2"),
+                new String[] {comparison.firstSubmission.name, comparison.secondSubmission.name}));
+        htmlFile.println("      </h3>");
+        htmlFile.println("      <h1 align=\"center\">");
+        htmlFile.println("        " + comparison.roundedPercent() + "%");
+        htmlFile.println("      </h1>");
+        htmlFile.println("      <center>");
+        htmlFile.println("        <a href=\"index.html\" target=\"_top\">");
+        htmlFile.println("          " + msg.getString("Report.INDEX"));
+        htmlFile.println("        </a>");
+        htmlFile.println("        <span>-</span>");
+        htmlFile.println("        <a href=\"help-en.html\" target=\"_top\">");
+        htmlFile.println("          " + msg.getString("Report.HELP"));
+        htmlFile.println("        </a>");
+        htmlFile.println("      </center>");
+        htmlFile.println("    </div>");
+
+        htmlFile.println("    <div>");
+        reportComparison(htmlFile, comparison, i);
+        htmlFile.println("    </div>");
+
+        htmlFile.println("  </div>");
+
+        htmlFile.println("  <hr>");
+
+        htmlFile.println("  <div style=\"display: flex;\">");
+
+        if (result.getOptions().getLanguage().usesIndex()) {
+            writeIndexedSubmission(htmlFile, i, comparison, 0);
+            writeIndexedSubmission(htmlFile, i, comparison, 1);
+        } else if (result.getOptions().getLanguage().supportsColumns()) {
+            writeImprovedSubmission(htmlFile, i, comparison, 0);
+            writeImprovedSubmission(htmlFile, i, comparison, 1);
+        } else {
+            writeNormalSubmission(htmlFile, i, comparison, 0);
+            writeNormalSubmission(htmlFile, i, comparison, 1);
+        }
+
+        htmlFile.println("  </div>");
+
+        htmlFile.println("</body>");
+        htmlFile.println("</html>");
+        htmlFile.close();
+    }
+
+    private void writeMatches(List<JPlagComparison> comparisons) { // TODO TS: We should report the progress if there are many comparisons.
+        comparisons.forEach(comparison -> {
+            try {
+                int i = getComparisonIndex(comparison);
+                writeMatch(comparison, i);
+            } catch (ExitException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void writeMatchesCSV(String fileName) {
+        FileWriter writer = null;
+        File csvFile = new File(reportDir, fileName);
+        List<JPlagComparison> comparisons = result.getComparisons();
+
+        try {
+            csvFile.createNewFile();
+            writer = new FileWriter(csvFile);
+
+            for (JPlagComparison comparison : comparisons) {
+                String submissionNameA = comparison.firstSubmission.name;
+                String submissionNameB = comparison.secondSubmission.name;
+
+                writer.write(getComparisonIndex(comparison) + ";");
+                writer.write(submissionNameA + ";");
+                writer.write(submissionNameB + ";");
+                writer.write((((int) (comparison.percent() * 10)) / (float) 10) + ";");
+                writer.write("\n");
+            }
+
+            writer.flush();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                writer.close();
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    /*
+     * i is the number of the match j == 0 if subA is considered, otherwise (j must then be 1) it is subB
+     */
+    private void writeNormalSubmission(HTMLFile f, int i, JPlagComparison comparison, int j) throws ExitException {
+        Submission sub = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission);
+        String[] files = comparison.files(j);
+
+        String[][] text = sub.readFiles(files);
+
+        Token[] tokens = (j == 0 ? comparison.firstSubmission : comparison.secondSubmission).tokenList.tokens;
+        Match currentMatch;
+        String hilf;
+        int h;
+        for (int x = 0; x < comparison.matches.size(); x++) {
+            currentMatch = comparison.matches.get(x);
+
+            Token start = tokens[(j == 0 ? currentMatch.startA : currentMatch.startB)];
+            Token ende = tokens[((j == 0 ? currentMatch.startA : currentMatch.startB) + currentMatch.length - 1)];
+
+            for (int y = 0; y < files.length; y++) {
+                if (start.file.equals(files[y]) && text[y] != null) {
+                    hilf = "<FONT color=\"" + Color.getHexadecimalValue(x) + "\">" + (j == 1 ? "<div style=\"position:absolute;left:0\">" : "")
+                            + "<A HREF=\"javascript:ZweiFrames('match" + i + "-" + (1 - j) + ".html#" + x + "'," + (3 - j) + ",'match" + i
+                            + "-top.html#" + x + "',1)\"><IMG SRC=\"" + pics[j] + "\" ALT=\"other\" " + "BORDER=\"0\" ALIGN=\""
+                            + (j == 0 ? "right" : "left") + "\"></A>" + (j == 1 ? "</div>" : "") + "<B>";
+                    // position the icon and the beginning of the colorblock
+                    if (text[y][start.getLine() - 1].endsWith("</FONT>")) {
+                        text[y][start.getLine() - 1] += hilf;
+                    } else {
+                        text[y][start.getLine() - 1] = hilf + text[y][start.getLine() - 1];
+                    }
+                    // the link location is placed 3 lines before the start of a block
+                    h = (Math.max(start.getLine() - 4, 0));
+                    text[y][h] = "<A NAME=\"" + x + "\"></A>" + text[y][h];
+                    // mark the end
+                    if (start.getLine() != ende.getLine() && // if match is only one line
+                            text[y][ende.getLine() - 1].startsWith("<FONT ")) {
+                        text[y][ende.getLine() - 1] = "</B></FONT>" + text[y][ende.getLine() - 1];
+                    } else {
+                        text[y][ende.getLine() - 1] += "</B></FONT>";
+                    }
+                }
+            }
+        }
+
+        if (result.getOptions().hasBaseCode() && comparison.bcMatchesA != null && comparison.bcMatchesB != null) {
+            JPlagBaseCodeComparison baseCodeComparison = (j == 0 ? comparison.bcMatchesA : comparison.bcMatchesB);
+
+            for (int x = 0; x < baseCodeComparison.matches.size(); x++) {
+                currentMatch = baseCodeComparison.matches.get(x);
+                Token start = tokens[currentMatch.startA];
+                Token ende = tokens[currentMatch.startA + currentMatch.length - 1];
+
+                for (int y = 0; y < files.length; y++) {
+                    if (start.file.equals(files[y]) && text[y] != null) {
+                        hilf = ("<font color=\"#C0C0C0\"><EM>");
+                        // position the icon and the beginning of the colorblock
+                        if (text[y][start.getLine() - 1].endsWith("<font color=\"#000000\">")) {
+                            text[y][start.getLine() - 1] += hilf;
+                        } else {
+                            text[y][start.getLine() - 1] = hilf + text[y][start.getLine() - 1];
+                        }
+
+                        // mark the end
+                        if (start.getLine() != ende.getLine() && // match is only one line
+                                text[y][ende.getLine() - 1].startsWith("<font color=\"#C0C0C0\">")) {
+                            text[y][ende.getLine() - 1] = "</EM><font color=\"#000000\">" + text[y][ende.getLine() - 1];
+                        } else {
+                            text[y][ende.getLine() - 1] += "</EM><font color=\"#000000\">";
+                        }
+                    }
+                }
+            }
+        }
+
+        f.println("<div style=\"flex-grow: 1;\">");
+
+        for (int x = 0; x < text.length; x++) {
+            f.println("<h3>");
+            f.println("<center>");
+            f.println("<span>" + sub.name + "</span>");
+            f.println("<span> - </span>");
+            f.println("<span>" + files[x] + "</span>");
+            f.println("</center>");
+            f.println("</h3>");
+            f.println("<HR>");
+            if (result.getOptions().getLanguage().isPreformatted()) {
+                f.println("<PRE>");
+            }
+            for (int y = 0; y < text[x].length; y++) {
+                f.print(text[x][y]);
+                if (!result.getOptions().getLanguage().isPreformatted()) {
+                    f.println("<BR>");
+                } else {
+                    f.println();
+                }
+            }
+            if (result.getOptions().getLanguage().isPreformatted()) {
+                f.println("</PRE>");
+            }
+        }
+
+        f.println("</div>");
     }
 }


### PR DESCRIPTION
Fixes the ordering of comparisons in the generated report (see #110). The comparisons are sorted when creating a result object. I also sorted the members of the report class, since I don't like the fields to be somewhere in between the methods.