### PR TITLE
Fix file encoding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ Usage: JPlag [ options ] [<root-dir>]
 
 named arguments:
   -h, --help             show this help message and exit
-  -l {java1,java2,java5,java5dm,java7,java9,python3,cpp,csharp,char,text,scheme}
-                         Select the language to parse the submissions (Standard: java9)
+  -l                     {java1,java2,java5,java5dm,java7,java9,python3,cpp,csharp,char,text,scheme} Select the language to parse the submissions (Standard: java9)
   -bc BC                 Name of the directory which contains the base code (common framework used in all submissions)
-  -v {parser,quiet,long,details}
-                         Verbosity (Standard: quiet)
+  -v                     {quiet,long} Verbosity of the logging (Standard: quiet)
   -d                     (Debug) parser. Non-parsable files will be stored (Standard: false)
   -S S                   Look in directories <root-dir>/*/<dir> for programs
   -p P                   comma-separated list of all filename suffixes that are included

--- a/jplag.frontend.chars/src/main/java/jplag/chars/Parser.java
+++ b/jplag.frontend.chars/src/main/java/jplag/chars/Parser.java
@@ -2,6 +2,7 @@ package jplag.chars;
 
 import java.io.File;
 import java.io.FileReader;
+import java.nio.charset.StandardCharsets;
 
 import jplag.TokenList;
 
@@ -18,7 +19,6 @@ public class Parser extends jplag.Parser implements jplag.TokenConstants {
 				errors++;
 			struct.addToken(new CharToken(FILE_END, files[i], this));
 		}
-		//System.err.println(struct.toString());
 		if (errors == 0)
 			program.print(null, "OK");
 		else
@@ -35,7 +35,7 @@ public class Parser extends jplag.Parser implements jplag.TokenConstants {
 		int offset = 0;
 
 		try {
-			FileReader fis = new FileReader(new File(dir, file));
+			FileReader fis = new FileReader(new File(dir, file), StandardCharsets.UTF_8);
 
 			do {
 				length = fis.read(buffer);

--- a/jplag.frontend.java-1.1exp/src/main/java/jplag/javax/Parser.java
+++ b/jplag.frontend.java-1.1exp/src/main/java/jplag/javax/Parser.java
@@ -19,7 +19,6 @@ public class Parser extends jplag.Parser implements JavaTokenConstants {
 				errors++;
 			struct.addToken(new JavaToken(FILE_END, actFile, 0));
 		}
-		// System.err.println(struct.toString());
 		if (errors == 0)
 			program.print(null, "OK\n");
 		else
@@ -30,10 +29,6 @@ public class Parser extends jplag.Parser implements JavaTokenConstants {
 
 	public void add(int type, Token token) {
 		struct.addToken(new JavaToken(type, actFile, token.beginLine));
-		/*
-		 * System.out.println(token.beginLine+"\t"+ (new
-		 * JavaToken(0,null,0)).type2string(type)+"\t"+ token.image);
-		 */
 	}
 
 }

--- a/jplag.frontend.java-1.7/src/test/java/jplag/StrippedProgram.java
+++ b/jplag.frontend.java-1.7/src/test/java/jplag/StrippedProgram.java
@@ -16,7 +16,7 @@ public class StrippedProgram implements ProgramI {
         } else if (normalMsg != null) {
             System.out.println(normalMsg);
         } else {
-            System.out.println("Someboy messed up - no message given");
+            System.out.println("Somebody messed up - no message given");
         }
     }
 }

--- a/jplag/src/main/java/jplag/JPlag.java
+++ b/jplag/src/main/java/jplag/JPlag.java
@@ -10,6 +10,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -444,7 +445,7 @@ public class JPlag implements ProgramI {
         excludedFileNames = new HashSet<>();
 
         try {
-            BufferedReader reader = new BufferedReader(new FileReader(options.getExclusionFileName()));
+            BufferedReader reader = new BufferedReader(new FileReader(options.getExclusionFileName(), StandardCharsets.UTF_8));
             String line;
 
             while ((line = reader.readLine()) != null) {

--- a/jplag/src/main/java/jplag/JPlag.java
+++ b/jplag/src/main/java/jplag/JPlag.java
@@ -1,7 +1,6 @@
 package jplag;
 
 import static jplag.options.Verbosity.LONG;
-import static jplag.options.Verbosity.PARSER;
 import static jplag.options.Verbosity.QUIET;
 
 import java.io.BufferedReader;
@@ -19,6 +18,7 @@ import java.util.stream.Collectors;
 
 import jplag.options.JPlagOptions;
 import jplag.options.LanguageOption;
+import jplag.options.Verbosity;
 import jplag.strategy.ComparisonStrategy;
 import jplag.strategy.NormalComparisonStrategy;
 import jplag.strategy.ParallelComparisonStrategy;
@@ -135,28 +135,14 @@ public class JPlag implements ProgramI {
 
     @Override
     public void print(String message, String longMessage) {
-        if (options.getVerbosity() == PARSER) {
-            if (longMessage != null) {
-                System.out.println(longMessage);
-            } else if (message != null) {
-                System.out.println(message);
-            }
-        }
-        if (options.getVerbosity() == QUIET) {
-            return;
-        }
-        try {
+        Verbosity verbosity = options.getVerbosity();
+        if (verbosity != QUIET) {
             if (message != null) {
                 System.out.print(message);
             }
-
-            if (longMessage != null) {
-                if (options.getVerbosity() == LONG) {
-                    System.out.print(longMessage);
-                }
+            if (longMessage != null && verbosity == LONG) {
+                System.out.print(longMessage);
             }
-        } catch (Throwable e) {
-            System.out.println(e.getMessage());
         }
     }
 

--- a/jplag/src/main/java/jplag/Submission.java
+++ b/jplag/src/main/java/jplag/Submission.java
@@ -121,11 +121,9 @@ public class Submission implements Comparable<Submission> {
 
     /* parse all the files... */
     public boolean parse() {
-        if (program.getOptions().getVerbosity() != Verbosity.PARSER) {
-            if (files == null || files.size() == 0) {
-                program.print("ERROR: nothing to parse for submission \"" + name + "\"\n", null);
-                return false;
-            }
+        if (files == null || files.size() == 0) {
+            program.print("ERROR: nothing to parse for submission \"" + name + "\"\n", null);
+            return false;
         }
 
         String[] relativeFilePaths = getRelativeFilePaths(submissionFile, files);

--- a/jplag/src/main/java/jplag/Submission.java
+++ b/jplag/src/main/java/jplag/Submission.java
@@ -17,8 +17,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 
-import jplag.options.Verbosity;
-
 /**
  * Represents a single submission. A submission can contain multiple files.
  */
@@ -209,7 +207,7 @@ public class Submission implements Comparable<Submission> {
                 int size = (int) file.length();
                 char[] buffer = new char[size];
 
-                FileReader reader = new FileReader(file);
+                FileReader reader = new FileReader(file, StandardCharsets.UTF_8);
 
                 if (size != reader.read(buffer)) {
                     System.out.println("Not right size read from the file, " + "but I will still continue...");

--- a/jplag/src/main/java/jplag/options/Verbosity.java
+++ b/jplag/src/main/java/jplag/options/Verbosity.java
@@ -1,14 +1,11 @@
 package jplag.options;
 
-public enum Verbosity { // TODO TS: These levels are not used consistently.
-    PARSER,
+public enum Verbosity {
     QUIET,
     LONG;
 
     public static Verbosity fromOption(String optionName) {
         switch (optionName) {
-        case "parser":
-            return PARSER;
         case "quiet":
             return QUIET;
         case "long":

--- a/jplag/src/main/java/jplag/reporting/Report.java
+++ b/jplag/src/main/java/jplag/reporting/Report.java
@@ -7,6 +7,7 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.Date;
@@ -651,7 +652,7 @@ public class Report { // Mostly legacy code with some minor improvements.
 
         try {
             csvFile.createNewFile();
-            writer = new FileWriter(csvFile);
+            writer = new FileWriter(csvFile, StandardCharsets.UTF_8);
 
             for (JPlagComparison comparison : comparisons) {
                 String submissionNameA = comparison.getFirstSubmission().name;

--- a/jplag/src/test/java/jplag/VolumeTest.java
+++ b/jplag/src/test/java/jplag/VolumeTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -59,7 +60,7 @@ public class VolumeTest extends TestBase {
     }
 
     private Map<String, Float> readCSVResults(String filePathAndName) throws IOException {
-        List<String> lines = Files.readAllLines(Path.of(filePathAndName));
+        List<String> lines = Files.readAllLines(Path.of(filePathAndName), StandardCharsets.UTF_8);
         var results = new HashMap<String, Float>();
 
         lines.forEach(line -> {


### PR DESCRIPTION
When using volume testing, I encountered an encoding issue when reading the CSV file (IOException).
This PR enforces consistent encoding in JPlag. We might even offer different file encoding based on the `JPlagOptions`.
Additionally, I removed unused verbosity options.