### PR TITLE
CLI overhaul

### DIFF
--- a/jplag/src/main/java/jplag/CommandLineArgument.java
+++ b/jplag/src/main/java/jplag/CommandLineArgument.java
@@ -10,57 +10,52 @@ import java.util.Optional;
 import jplag.options.LanguageOption;
 import jplag.strategy.ComparisonMode;
 import net.sourceforge.argparse4j.inf.Argument;
-import net.sourceforge.argparse4j.inf.ArgumentAction;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.Namespace;
 
 /**
  * Command line arguments for the JPlag CLI. Each argument is defined through an enuemral.
  * @author Timur Saglam
  */
 public enum CommandLineArgument {
-    ROOT_DIRECTORY("rootDir", "The root-directory that contains all submissions"),
-    LANGUAGE("-l", "Select the language to parse the submissions", LanguageOption.getDefault().getDisplayName(), LanguageOption.getAllDisplayNames()),
-    BASE_CODE("-bc", "Name of the directory which contains the base code (common framework used in all submissions)"),
-    VERBOSITY("-v", "Verbosity", "quiet", List.of("parser", "quiet", "long", "details")), // TODO SH: Replace verbosity when integrating a real logging library
-    DEBUG("-d", "(Debug) parser. Non-parsable files will be stored", storeTrue()),
-    SUBDIRECTORY("-S", "Look in directories <root-dir>/*/<dir> for programs"),
-    SUFFIXES("-p", "comma-separated list of all filename suffixes that are included"),
-    EXCLUDE_FILE("-x", "All files named in this file will be ignored in the comparison (line-separated list)"),
-    MIN_TOKEN_MATCH("-t", "Tune the sensitivity of the comparison. A smaller <n> increases the sensitivity"),
-    SIMILARITY_THRESHOLD("-m", "Match similarity threshold [0-100]: All matches above this threshold will be saved", 0f), // TODO TS deduplicate default values
-    STORED_MATCHES("-n", "Maximum number of matches that will be saved. If set to -1 all matches will be saved", 30), 
-    RESULT_FOLDER("-r", "Name of directory in which the comparison results will be stored", "result"),
-    COMPARISON_MODE("-c", "Comparison mode used to compare the programs", NORMAL.getName(), ComparisonMode.allNames());
+    ROOT_DIRECTORY("rootDir", String.class, "The root-directory that contains all submissions"),
+    LANGUAGE("-l", String.class, "Select the language to parse the submissions", LanguageOption.getDefault().getDisplayName(), LanguageOption.getAllDisplayNames()),
+    BASE_CODE("-bc", String.class, "Name of the directory which contains the base code (common framework used in all submissions)"),
+    VERBOSITY("-v", String.class, "Verbosity", "quiet", List.of("parser", "quiet", "long", "details")), // TODO SH: Replace verbosity when integrating  a real logging library
+    DEBUG("-d", Boolean.class, "(Debug) parser. Non-parsable files will be stored"),
+    SUBDIRECTORY("-S", String.class, "Look in directories <root-dir>/*/<dir> for programs"),
+    SUFFIXES("-p", String.class, "comma-separated list of all filename suffixes that are included"),
+    EXCLUDE_FILE("-x", String.class, "All files named in this file will be ignored in the comparison (line-separated list)"),
+    MIN_TOKEN_MATCH("-t", Integer.class, "Tune the sensitivity of the comparison. A smaller <n> increases the sensitivity"),
+    SIMILARITY_THRESHOLD("-m", Float.class, "Match similarity threshold [0-100]: All matches above this threshold will be saved", 0f), // TODO TS deduplicate default values
+    STORED_MATCHES("-n", Integer.class, "Maximum number of matches that will be saved. If set to -1 all matches will be saved", 30),
+    RESULT_FOLDER("-r", String.class, "Name of directory in which the comparison results will be stored", "result"),
+    COMPARISON_MODE("-c", String.class, "Comparison mode used to compare the programs", NORMAL.getName(), ComparisonMode.allNames());
 
     private final String flag;
     private final String helptext;
     private final Optional<Object> defaultValue;
     private final Optional<Collection<String>> choices;
-    private final Optional<ArgumentAction> action;
+    private final Class<?> type;
 
-    private CommandLineArgument(String flag, String helpText, Optional<Object> defaultValue, Optional<Collection<String>> choices,
-            Optional<ArgumentAction> action) {
+    private CommandLineArgument(String flag, Class<?> type, String helpText, Optional<Object> defaultValue, Optional<Collection<String>> choices) {
         this.flag = flag;
         this.helptext = helpText;
+        this.type = type;
         this.defaultValue = defaultValue;
         this.choices = choices;
-        this.action = action;
     }
 
-    private CommandLineArgument(String flag, String helpText, Object defaultValue, Collection<String> choices) {
-        this(flag, helpText, Optional.of(defaultValue), Optional.of(choices), Optional.empty());
+    private CommandLineArgument(String flag, Class<?> type, String helpText, Object defaultValue, Collection<String> choices) {
+        this(flag, type, helpText, Optional.of(defaultValue), Optional.of(choices));
     }
 
-    private CommandLineArgument(String flag, String helpText, Object defaultValue) {
-        this(flag, helpText, Optional.of(defaultValue), Optional.empty(), Optional.empty());
+    private CommandLineArgument(String flag, Class<?> type, String helpText, Object defaultValue) {
+        this(flag, type, helpText, Optional.of(defaultValue), Optional.empty());
     }
 
-    private CommandLineArgument(String flag, String helpText) {
-        this(flag, helpText, Optional.empty(), Optional.empty(), Optional.empty());
-    }
-
-    private CommandLineArgument(String flag, String helpText, ArgumentAction action) {
-        this(flag, helpText, Optional.empty(), Optional.empty(), Optional.of(action));
+    private CommandLineArgument(String flag, Class<?> type, String helpText) {
+        this(flag, type, helpText, Optional.empty(), Optional.empty());
     }
 
     /**
@@ -71,7 +66,21 @@ public enum CommandLineArgument {
         Argument argument = parser.addArgument(flag).help(helptext);
         choices.ifPresent(it -> argument.choices(it));
         defaultValue.ifPresent(it -> argument.setDefault(it));
-        action.ifPresent(it -> argument.action(it));
+        argument.type(type);
+        if (type == Boolean.class) {
+            argument.action(storeTrue());
+        }
+    }
+
+    /**
+     * Returns the value of this argument. Convenience method for {@link Namespace#get(String)} and
+     * {@link CommandLineArgument#flag()}.
+     * @param <T> is the argument type.
+     * @param namespace stores a value for the argument.
+     * @return the argument value.
+     */
+    public <T> T getFrom(Namespace namespace) {
+        return namespace.get(flag());
     }
 
     /**

--- a/jplag/src/main/java/jplag/CommandLineArgument.java
+++ b/jplag/src/main/java/jplag/CommandLineArgument.java
@@ -1,6 +1,8 @@
 package jplag;
 
-import static jplag.strategy.ComparisonMode.NORMAL;
+import static jplag.options.JPlagOptions.DEFAULT_COMPARISON_MODE;
+import static jplag.options.JPlagOptions.DEFAULT_SIMILARITY_THRESHOLD;
+import static jplag.options.JPlagOptions.DEFAULT_STORED_MATCHES;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import java.util.Collection;
@@ -21,22 +23,34 @@ public enum CommandLineArgument {
     ROOT_DIRECTORY("rootDir", String.class, "The root-directory that contains all submissions"),
     LANGUAGE("-l", String.class, "Select the language to parse the submissions", LanguageOption.getDefault().getDisplayName(), LanguageOption.getAllDisplayNames()),
     BASE_CODE("-bc", String.class, "Name of the directory which contains the base code (common framework used in all submissions)"),
-    VERBOSITY("-v", String.class, "Verbosity", "quiet", List.of("parser", "quiet", "long", "details")), // TODO SH: Replace verbosity when integrating  a real logging library
+    VERBOSITY("-v", String.class, "Verbosity", "quiet", List.of("parser", "quiet", "long", "details")), // TODO SH: Replace verbosity when integrating a real logging library
     DEBUG("-d", Boolean.class, "(Debug) parser. Non-parsable files will be stored"),
     SUBDIRECTORY("-S", String.class, "Look in directories <root-dir>/*/<dir> for programs"),
     SUFFIXES("-p", String.class, "comma-separated list of all filename suffixes that are included"),
     EXCLUDE_FILE("-x", String.class, "All files named in this file will be ignored in the comparison (line-separated list)"),
     MIN_TOKEN_MATCH("-t", Integer.class, "Tune the sensitivity of the comparison. A smaller <n> increases the sensitivity"),
-    SIMILARITY_THRESHOLD("-m", Float.class, "Match similarity threshold [0-100]: All matches above this threshold will be saved", 0f), // TODO TS deduplicate default values
-    STORED_MATCHES("-n", Integer.class, "Maximum number of matches that will be saved. If set to -1 all matches will be saved", 30),
+    SIMILARITY_THRESHOLD("-m", Float.class, "Match similarity threshold [0-100]: All matches above this threshold will be saved", DEFAULT_SIMILARITY_THRESHOLD),
+    STORED_MATCHES("-n", Integer.class, "Maximum number of matches that will be saved. If set to -1 all matches will be saved", DEFAULT_STORED_MATCHES),
     RESULT_FOLDER("-r", String.class, "Name of directory in which the comparison results will be stored", "result"),
-    COMPARISON_MODE("-c", String.class, "Comparison mode used to compare the programs", NORMAL.getName(), ComparisonMode.allNames());
+    COMPARISON_MODE("-c", String.class, "Comparison mode used to compare the programs", DEFAULT_COMPARISON_MODE, ComparisonMode.allNames());
 
     private final String flag;
     private final String helptext;
     private final Optional<Object> defaultValue;
     private final Optional<Collection<String>> choices;
     private final Class<?> type;
+
+    private CommandLineArgument(String flag, Class<?> type, String helpText) {
+        this(flag, type, helpText, Optional.empty(), Optional.empty());
+    }
+
+    private CommandLineArgument(String flag, Class<?> type, String helpText, Object defaultValue) {
+        this(flag, type, helpText, Optional.of(defaultValue), Optional.empty());
+    }
+
+    private CommandLineArgument(String flag, Class<?> type, String helpText, Object defaultValue, Collection<String> choices) {
+        this(flag, type, helpText, Optional.of(defaultValue), Optional.of(choices));
+    }
 
     private CommandLineArgument(String flag, Class<?> type, String helpText, Optional<Object> defaultValue, Optional<Collection<String>> choices) {
         this.flag = flag;
@@ -46,30 +60,11 @@ public enum CommandLineArgument {
         this.choices = choices;
     }
 
-    private CommandLineArgument(String flag, Class<?> type, String helpText, Object defaultValue, Collection<String> choices) {
-        this(flag, type, helpText, Optional.of(defaultValue), Optional.of(choices));
-    }
-
-    private CommandLineArgument(String flag, Class<?> type, String helpText, Object defaultValue) {
-        this(flag, type, helpText, Optional.of(defaultValue), Optional.empty());
-    }
-
-    private CommandLineArgument(String flag, Class<?> type, String helpText) {
-        this(flag, type, helpText, Optional.empty(), Optional.empty());
-    }
-
     /**
-     * Parses the command line argument with a specific parser.
-     * @param parser is that parser.
+     * @return the flag name of the command line argument without leading dashes.
      */
-    public void parseWith(ArgumentParser parser) {
-        Argument argument = parser.addArgument(flag).help(helptext);
-        choices.ifPresent(it -> argument.choices(it));
-        defaultValue.ifPresent(it -> argument.setDefault(it));
-        argument.type(type);
-        if (type == Boolean.class) {
-            argument.action(storeTrue());
-        }
+    public String flag() {
+        return flag.replace("-", "");
     }
 
     /**
@@ -84,9 +79,16 @@ public enum CommandLineArgument {
     }
 
     /**
-     * @return the flag name of the command line argument without leading dashes.
+     * Parses the command line argument with a specific parser.
+     * @param parser is that parser.
      */
-    public String flag() {
-        return flag.replace("-", "");
+    public void parseWith(ArgumentParser parser) {
+        Argument argument = parser.addArgument(flag).help(helptext);
+        choices.ifPresent(it -> argument.choices(it));
+        defaultValue.ifPresent(it -> argument.setDefault(it));
+        argument.type(type);
+        if (type == Boolean.class) {
+            argument.action(storeTrue());
+        }
     }
 }

--- a/jplag/src/main/java/jplag/CommandLineArgument.java
+++ b/jplag/src/main/java/jplag/CommandLineArgument.java
@@ -1,0 +1,83 @@
+package jplag;
+
+import static jplag.strategy.ComparisonMode.NORMAL;
+import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import jplag.options.LanguageOption;
+import jplag.strategy.ComparisonMode;
+import net.sourceforge.argparse4j.inf.Argument;
+import net.sourceforge.argparse4j.inf.ArgumentAction;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+
+/**
+ * Command line arguments for the JPlag CLI. Each argument is defined through an enuemral.
+ * @author Timur Saglam
+ */
+public enum CommandLineArgument {
+    ROOT_DIRECTORY("rootDir", "The root-directory that contains all submissions"),
+    LANGUAGE("-l", "Select the language to parse the submissions", LanguageOption.getDefault().getDisplayName(), LanguageOption.getAllDisplayNames()),
+    BASE_CODE("-bc", "Name of the directory which contains the base code (common framework used in all submissions)"),
+    VERBOSITY("-v", "Verbosity", "quiet", List.of("parser", "quiet", "long", "details")), // TODO SH: Replace verbosity when integrating a real logging library
+    DEBUG("-d", "(Debug) parser. Non-parsable files will be stored", storeTrue()),
+    SUBDIRECTORY("-S", "Look in directories <root-dir>/*/<dir> for programs"),
+    SUFFIXES("-p", "comma-separated list of all filename suffixes that are included"),
+    EXCLUDE_FILE("-x", "All files named in this file will be ignored in the comparison (line-separated list)"),
+    MIN_TOKEN_MATCH("-t", "Tune the sensitivity of the comparison. A smaller <n> increases the sensitivity"),
+    SIMILARITY_THRESHOLD("-m", "Match similarity threshold [0-100]: All matches above this threshold will be saved", 0f), // TODO TS deduplicate default values
+    STORED_MATCHES("-n", "Maximum number of matches that will be saved. If set to -1 all matches will be saved", 30), 
+    RESULT_FOLDER("-r", "Name of directory in which the comparison results will be stored", "result"),
+    COMPARISON_MODE("-c", "Comparison mode used to compare the programs", NORMAL.getName(), ComparisonMode.allNames());
+
+    private final String flag;
+    private final String helptext;
+    private final Optional<Object> defaultValue;
+    private final Optional<Collection<String>> choices;
+    private final Optional<ArgumentAction> action;
+
+    private CommandLineArgument(String flag, String helpText, Optional<Object> defaultValue, Optional<Collection<String>> choices,
+            Optional<ArgumentAction> action) {
+        this.flag = flag;
+        this.helptext = helpText;
+        this.defaultValue = defaultValue;
+        this.choices = choices;
+        this.action = action;
+    }
+
+    private CommandLineArgument(String flag, String helpText, Object defaultValue, Collection<String> choices) {
+        this(flag, helpText, Optional.of(defaultValue), Optional.of(choices), Optional.empty());
+    }
+
+    private CommandLineArgument(String flag, String helpText, Object defaultValue) {
+        this(flag, helpText, Optional.of(defaultValue), Optional.empty(), Optional.empty());
+    }
+
+    private CommandLineArgument(String flag, String helpText) {
+        this(flag, helpText, Optional.empty(), Optional.empty(), Optional.empty());
+    }
+
+    private CommandLineArgument(String flag, String helpText, ArgumentAction action) {
+        this(flag, helpText, Optional.empty(), Optional.empty(), Optional.of(action));
+    }
+
+    /**
+     * Parses the command line argument with a specific parser.
+     * @param parser is that parser.
+     */
+    public void parseWith(ArgumentParser parser) {
+        Argument argument = parser.addArgument(flag).help(helptext);
+        defaultValue.ifPresent(it -> argument.setDefault(defaultValue));
+        choices.ifPresent(it -> argument.choices(it));
+        action.ifPresent(it -> argument.action(it));
+    }
+
+    /**
+     * @return the flag name of the command line argument without leading dashes.
+     */
+    public String flag() {
+        return flag.replace("-", "");
+    }
+}

--- a/jplag/src/main/java/jplag/CommandLineArgument.java
+++ b/jplag/src/main/java/jplag/CommandLineArgument.java
@@ -69,8 +69,8 @@ public enum CommandLineArgument {
      */
     public void parseWith(ArgumentParser parser) {
         Argument argument = parser.addArgument(flag).help(helptext);
-        defaultValue.ifPresent(it -> argument.setDefault(defaultValue));
         choices.ifPresent(it -> argument.choices(it));
+        defaultValue.ifPresent(it -> argument.setDefault(it));
         action.ifPresent(it -> argument.action(it));
     }
 

--- a/jplag/src/main/java/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/jplag/options/JPlagOptions.java
@@ -48,7 +48,7 @@ public class JPlagOptions {
      * The maximum number of matches that will be saved. This does affect the generated report as well as the internally
      * saved comparisons. If set to -1 all matches will be saved.
      */
-    private int maxNumberOfMatches = 30;
+    private int maxNumberOfMatches = 30; // TODO TS deduplicate default values
 
     /**
      * TODO PB: Not happy with the name yet.

--- a/jplag/src/main/java/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/jplag/options/JPlagOptions.java
@@ -7,26 +7,19 @@ import jplag.strategy.ComparisonMode;
 
 public class JPlagOptions {
 
+    public static final ComparisonMode DEFAULT_COMPARISON_MODE = NORMAL;
+    public static final int DEFAULT_SIMILARITY_THRESHOLD = 0;
+    public static final int DEFAULT_STORED_MATCHES = 30;
+
     /**
      * Language used to parse the submissions.
      */
     private Language language;
 
     /**
-     * TODO PB: Decide what to do with this.
-     * <p>
-     * Note: Previously, this option had two effects:
-     * <ol>
-     * <li>If this option was > 0, it told JPlag to use the 'special' comparison strategy</li>
-     * <li>It specifies the number of submissions to compare each submission to during the 'special' comparison</li>
-     * </ol>
-     */
-    private int numberOfSubmissionsToCompareTo = 0; // 0 = deactivated
-
-    /**
      * Determines which strategy to use for the comparison of submissions.
      */
-    private ComparisonMode comparisonMode = NORMAL;
+    private ComparisonMode comparisonMode = DEFAULT_COMPARISON_MODE;
 
     /**
      * If true, submissions that cannot be parsed will be stored in a separate directory.
@@ -42,13 +35,13 @@ public class JPlagOptions {
      * Percentage value (must be between 0 and 100). Matches with a similarity below this threshold will be ignored. The
      * default value of 0 allows all matches to be stored.
      */
-    private float similarityThreshold = 0;
+    private float similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
 
     /**
      * The maximum number of matches that will be saved. This does affect the generated report as well as the internally
      * saved comparisons. If set to -1 all matches will be saved.
      */
-    private int maxNumberOfMatches = 30; // TODO TS deduplicate default values
+    private int maxNumberOfMatches = DEFAULT_STORED_MATCHES;
 
     /**
      * TODO PB: Not happy with the name yet.
@@ -170,10 +163,6 @@ public class JPlagOptions {
         return debugParser;
     }
 
-    public int getNumberOfSubmissionsToCompareTo() {
-        return numberOfSubmissionsToCompareTo;
-    }
-
     public float getSimilarityThreshold() {
         return similarityThreshold;
     }
@@ -188,10 +177,6 @@ public class JPlagOptions {
 
     public void setLanguage(Language language) {
         this.language = language;
-    }
-
-    public void setNumberOfSubmissionsToCompareTo(int numberOfSubmissionsToCompareTo) {
-        this.numberOfSubmissionsToCompareTo = numberOfSubmissionsToCompareTo;
     }
 
     public void setComparisonMode(ComparisonMode comparisonMode) {

--- a/jplag/src/main/java/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/jplag/options/JPlagOptions.java
@@ -236,8 +236,10 @@ public class JPlagOptions {
 
     public void setSimilarityThreshold(float similarityThreshold) {
         if (similarityThreshold > 100) {
+            System.out.println("Maximum threshold of 100 used instead of " + similarityThreshold);
             this.similarityThreshold = 100;
         } else if (similarityThreshold < 0) {
+            System.out.println("Minimum threshold of 0 used instead of " + similarityThreshold);
             this.similarityThreshold = 0;
         } else {
             this.similarityThreshold = similarityThreshold;
@@ -245,7 +247,7 @@ public class JPlagOptions {
     }
 
     public void setMaxNumberOfMatches(int maxNumberOfMatches) {
-        if(maxNumberOfMatches < -1) {
+        if (maxNumberOfMatches < -1) {
             this.maxNumberOfMatches = -1;
         } else {
             this.maxNumberOfMatches = maxNumberOfMatches;

--- a/jplag/src/main/java/jplag/options/LanguageOption.java
+++ b/jplag/src/main/java/jplag/options/LanguageOption.java
@@ -1,6 +1,9 @@
 package jplag.options;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * The available languages.
@@ -42,10 +45,10 @@ public enum LanguageOption {
                 .orElse(getDefault());
     }
 
-    public static String[] getAllDisplayNames() {
+    public static Collection<String> getAllDisplayNames() {
         return Arrays.stream(LanguageOption.values())
                 .map(languageOption -> languageOption.displayName)
-                .toArray(String[]::new);
+                .collect(toList());
     }
 
     public static LanguageOption getDefault() {


### PR DESCRIPTION
Overhauled the command line interface:
- Deduplicate CLI flags
- Deduplicate default values
- Let argparse4j do the argument type conversion
- Warn the user if the min or max similarity threshold is used instead of an invalid value