### PR TITLE
Introduce framework for CLI tests and add intial test classes.

### DIFF
--- a/jplag/pom.xml
+++ b/jplag/pom.xml
@@ -207,5 +207,11 @@
       <groupId>edu.kit.ipd.jplag</groupId>
       <artifactId>chars</artifactId>
     </dependency>
+    <dependency>
+    	<groupId>com.github.stefanbirkner</groupId>
+    	<artifactId>system-rules</artifactId>
+    	<scope>test</scope>
+    	<version>1.19.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/jplag/src/main/java/jplag/CLI.java
+++ b/jplag/src/main/java/jplag/CLI.java
@@ -53,7 +53,7 @@ public class CLI {
             JPlag program = new JPlag(options);
             System.out.println("JPlag initialized");
             JPlagResult result = program.run();
-            File reportDir = new File(arguments.getString(RESULT_FOLDER.flag()));
+            File reportDir = new File(arguments.getString(RESULT_FOLDER.flagWithoutDash()));
             Report report = new Report(reportDir);
             report.writeResult(result);
         } catch (ExitException exception) {

--- a/jplag/src/main/java/jplag/CommandLineArgument.java
+++ b/jplag/src/main/java/jplag/CommandLineArgument.java
@@ -32,7 +32,7 @@ public enum CommandLineArgument {
     SIMILARITY_THRESHOLD("-m", Float.class, "Match similarity threshold [0-100]: All matches above this threshold will be saved", DEFAULT_SIMILARITY_THRESHOLD),
     STORED_MATCHES("-n", Integer.class, "Maximum number of matches that will be saved. If set to -1 all matches will be saved", DEFAULT_STORED_MATCHES),
     RESULT_FOLDER("-r", String.class, "Name of directory in which the comparison results will be stored", "result"),
-    COMPARISON_MODE("-c", String.class, "Comparison mode used to compare the programs", DEFAULT_COMPARISON_MODE, ComparisonMode.allNames());
+    COMPARISON_MODE("-c", String.class, "Comparison mode used to compare the programs", DEFAULT_COMPARISON_MODE.getName(), ComparisonMode.allNames());
 
     private final String flag;
     private final String helptext;
@@ -59,23 +59,30 @@ public enum CommandLineArgument {
         this.defaultValue = defaultValue;
         this.choices = choices;
     }
+    
+    /**
+     * @return the flag name of the command line argument.
+     */
+    public String flag() {
+        return flag;
+    }
 
     /**
      * @return the flag name of the command line argument without leading dashes.
      */
-    public String flag() {
+    public String flagWithoutDash() {
         return flag.replace("-", "");
     }
 
     /**
      * Returns the value of this argument. Convenience method for {@link Namespace#get(String)} and
-     * {@link CommandLineArgument#flag()}.
+     * {@link CommandLineArgument#flagWithoutDash()}.
      * @param <T> is the argument type.
      * @param namespace stores a value for the argument.
      * @return the argument value.
      */
     public <T> T getFrom(Namespace namespace) {
-        return namespace.get(flag());
+        return namespace.get(flagWithoutDash());
     }
 
     /**

--- a/jplag/src/main/java/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/jplag/options/JPlagOptions.java
@@ -8,7 +8,7 @@ import jplag.strategy.ComparisonMode;
 public class JPlagOptions {
 
     public static final ComparisonMode DEFAULT_COMPARISON_MODE = NORMAL;
-    public static final int DEFAULT_SIMILARITY_THRESHOLD = 0;
+    public static final float DEFAULT_SIMILARITY_THRESHOLD = 0;
     public static final int DEFAULT_STORED_MATCHES = 30;
 
     /**

--- a/jplag/src/test/java/jplag/TestBase.java
+++ b/jplag/src/test/java/jplag/TestBase.java
@@ -4,6 +4,7 @@ import java.util.function.Consumer;
 
 import jplag.options.JPlagOptions;
 import jplag.options.LanguageOption;
+import jplag.options.Verbosity;
 
 public abstract class TestBase {
 
@@ -24,7 +25,7 @@ public abstract class TestBase {
 
     protected JPlagResult runJPlag(String testSampleName, Consumer<JPlagOptions> customization) throws ExitException {
         JPlagOptions options = new JPlagOptions(String.format(getBasePath() + "/%s", testSampleName), LanguageOption.JAVA_1_9);
-        options.setDebugParser(true);
+        options.setVerbosity(Verbosity.LONG);
         customization.accept(options);
         JPlag jplag = new JPlag(options);
         return jplag.run();

--- a/jplag/src/test/java/jplag/cli/CommandLineInterfaceTest.java
+++ b/jplag/src/test/java/jplag/cli/CommandLineInterfaceTest.java
@@ -27,6 +27,37 @@ public class CommandLineInterfaceTest {
     protected JPlagOptions options;
 
     /**
+     * Creates a string for all arguments and their values that have been succesfully parsed.F
+     */
+    private String parsedKeys(String... arguments) {
+        var keys = namespace.getAttrs().keySet().stream()
+                .filter(key -> key.equals(ROOT_DIRECTORY.flag()) || Arrays.stream(arguments).anyMatch(arg -> arg.contains("-" + key)));
+        return keys.map(it -> it + "=" + namespace.get(it)).collect(toSet()).toString();
+    }
+
+    /**
+     * Builds a CLI string for a CLI argument and a value.
+     * @param argument is the CLI argument.
+     * @param value is the value for that argument.
+     * @return <code>"flag value"</code>
+     */
+    protected String buildArgument(CommandLineArgument argument, String value) {
+        return argument.flag() + "=" + value;
+    }
+
+    /**
+     * Builds {@link JPlagOptions} via the command line interface. Sets {@link CommandLineInterfaceTest#cli},
+     * {@link CommandLineInterfaceTest#namespace}, and {@link CommandLineInterfaceTest#options}.
+     * @param arguments are the command line interface arguments.
+     */
+    protected void buildOptionsFromCLI(String... arguments) {
+        cli = new CLI();
+        namespace = cli.parseArguments(arguments);
+        System.out.println("Parsed arguments: " + parsedKeys(arguments));
+        options = cli.buildOptionsFromArguments(namespace);
+    }
+
+    /**
      * Runs JPlag via the command line interface. Sets {@link CommandLineInterfaceTest#cli},
      * {@link CommandLineInterfaceTest#namespace}, and {@link CommandLineInterfaceTest#options}.
      * @param arguments arguments are the command line interface arguments.
@@ -43,37 +74,6 @@ public class CommandLineInterfaceTest {
             e.printStackTrace();
         }
         throw new IllegalStateException("Should never be reached!");
-    }
-
-    /**
-     * Builds {@link JPlagOptions} via the command line interface. Sets {@link CommandLineInterfaceTest#cli},
-     * {@link CommandLineInterfaceTest#namespace}, and {@link CommandLineInterfaceTest#options}.
-     * @param arguments are the command line interface arguments.
-     */
-    protected void buildOptionsFromCLI(String... arguments) {
-        cli = new CLI();
-        namespace = cli.parseArguments(arguments);
-        System.out.println("Parsed arguments: " + parsedKeys(arguments));
-        options = cli.buildOptionsFromArguments(namespace);
-    }
-
-    /**
-     * Builds a CLI string for a CLI argument and a value.
-     * @param argument is the CLI argument.
-     * @param value is the value for that argument.
-     * @return <code>"flag value"</code>
-     */
-    protected String buildArgument(CommandLineArgument argument, String value) {
-        return argument.flag() + " " + value;
-    }
-
-    /**
-     * Creates a string for all arguments and their values that have been succesfully parsed.F
-     */
-    private String parsedKeys(String... arguments) {
-        var keys = namespace.getAttrs().keySet().stream()
-                .filter(key -> key.equals(ROOT_DIRECTORY.flag()) || Arrays.stream(arguments).anyMatch(arg -> arg.contains(key)));
-        return keys.map(it -> it + "=" + namespace.get(it)).collect(toSet()).toString();
     }
 
 }

--- a/jplag/src/test/java/jplag/cli/CommandLineInterfaceTest.java
+++ b/jplag/src/test/java/jplag/cli/CommandLineInterfaceTest.java
@@ -1,0 +1,79 @@
+package jplag.cli;
+
+import static java.util.stream.Collectors.toSet;
+import static jplag.CommandLineArgument.ROOT_DIRECTORY;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import jplag.CLI;
+import jplag.CommandLineArgument;
+import jplag.ExitException;
+import jplag.JPlag;
+import jplag.JPlagResult;
+import jplag.options.JPlagOptions;
+import net.sourceforge.argparse4j.inf.Namespace;
+
+/**
+ * Test base for tests regarding the {@link CLI} and any {@link CommandLineArgument}.
+ * @author Timur Saglam
+ */
+public class CommandLineInterfaceTest {
+    protected static final String CURRENT_DIRECTORY = ".";
+    protected static final float DELTA = 0.0001f;
+
+    protected CLI cli;
+    protected Namespace namespace;
+    protected JPlagOptions options;
+
+    /**
+     * Runs JPlag via the command line interface. Sets {@link CommandLineInterfaceTest#cli},
+     * {@link CommandLineInterfaceTest#namespace}, and {@link CommandLineInterfaceTest#options}.
+     * @param arguments arguments are the command line interface arguments.
+     * @return the result of the JPlag run.
+     */
+    protected JPlagResult runViaCLI(String... arguments) {
+        buildOptionsFromCLI(arguments);
+        try {
+            JPlag program = new JPlag(options);
+            return program.run();
+        } catch (ExitException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+            e.printStackTrace();
+        }
+        throw new IllegalStateException("Should never be reached!");
+    }
+
+    /**
+     * Builds {@link JPlagOptions} via the command line interface. Sets {@link CommandLineInterfaceTest#cli},
+     * {@link CommandLineInterfaceTest#namespace}, and {@link CommandLineInterfaceTest#options}.
+     * @param arguments are the command line interface arguments.
+     */
+    protected void buildOptionsFromCLI(String... arguments) {
+        cli = new CLI();
+        namespace = cli.parseArguments(arguments);
+        System.out.println("Parsed arguments: " + parsedKeys(arguments));
+        options = cli.buildOptionsFromArguments(namespace);
+    }
+
+    /**
+     * Builds a CLI string for a CLI argument and a value.
+     * @param argument is the CLI argument.
+     * @param value is the value for that argument.
+     * @return <code>"flag value"</code>
+     */
+    protected String buildArgument(CommandLineArgument argument, String value) {
+        return argument.flag() + " " + value;
+    }
+
+    /**
+     * Creates a string for all arguments and their values that have been succesfully parsed.F
+     */
+    private String parsedKeys(String... arguments) {
+        var keys = namespace.getAttrs().keySet().stream()
+                .filter(key -> key.equals(ROOT_DIRECTORY.flag()) || Arrays.stream(arguments).anyMatch(arg -> arg.contains(key)));
+        return keys.map(it -> it + "=" + namespace.get(it)).collect(toSet()).toString();
+    }
+
+}

--- a/jplag/src/test/java/jplag/cli/ComparisonModeTest.java
+++ b/jplag/src/test/java/jplag/cli/ComparisonModeTest.java
@@ -1,0 +1,47 @@
+package jplag.cli;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+import jplag.CommandLineArgument;
+import jplag.options.JPlagOptions;
+import jplag.strategy.ComparisonMode;
+
+public class ComparisonModeTest extends CommandLineInterfaceTest {
+
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Test
+    public void testDefaultMode() {
+        buildOptionsFromCLI(CURRENT_DIRECTORY);
+        assertEquals(JPlagOptions.DEFAULT_COMPARISON_MODE, options.getComparisonMode());
+    }
+
+    @Test
+    public void testInvalidMode() {
+        exit.expectSystemExitWithStatus(1);
+        String argument = buildArgument(CommandLineArgument.COMPARISON_MODE, "Test'); DROP TABLE STUDENTS; --");
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+    }
+
+    @Test
+    public void testNormalMode() {
+        ComparisonMode mode = ComparisonMode.NORMAL;
+        String argument = buildArgument(CommandLineArgument.COMPARISON_MODE, mode.getName());
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(mode, options.getComparisonMode());
+    }
+
+    @Test
+    public void testParallelMode() {
+        ComparisonMode mode = ComparisonMode.PARALLEL;
+        String argument = buildArgument(CommandLineArgument.COMPARISON_MODE, mode.getName());
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(mode, options.getComparisonMode());
+    }
+
+}

--- a/jplag/src/test/java/jplag/cli/SimiliarityThresholdTest.java
+++ b/jplag/src/test/java/jplag/cli/SimiliarityThresholdTest.java
@@ -1,0 +1,51 @@
+package jplag.cli;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+import jplag.CommandLineArgument;
+import jplag.options.JPlagOptions;
+
+public class SimiliarityThresholdTest extends CommandLineInterfaceTest {
+
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Test
+    public void testDefaultThreshold() {
+        buildOptionsFromCLI(CURRENT_DIRECTORY);
+        assertEquals(JPlagOptions.DEFAULT_SIMILARITY_THRESHOLD, options.getSimilarityThreshold(), DELTA);
+    }
+
+    @Test
+    public void testInvalidThreshold() {
+        exit.expectSystemExitWithStatus(1);
+        String argument = buildArgument(CommandLineArgument.SIMILARITY_THRESHOLD, "Not a float...");
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+    }
+
+    @Test
+    public void testLowerBound() {
+        String argument = buildArgument(CommandLineArgument.SIMILARITY_THRESHOLD, Float.toString(-1f));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(0f, options.getSimilarityThreshold(), DELTA);
+    }
+
+    @Test
+    public void testUpperBound() {
+        String argument = buildArgument(CommandLineArgument.SIMILARITY_THRESHOLD, Float.toString(101f));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(100f, options.getSimilarityThreshold(), DELTA);
+    }
+
+    @Test
+    public void testValidThreshold() {
+        float expectedValue = 50f;
+        String argument = buildArgument(CommandLineArgument.SIMILARITY_THRESHOLD, Float.toString(expectedValue));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(expectedValue, options.getSimilarityThreshold(), DELTA);
+    }
+}

--- a/jplag/src/test/java/jplag/cli/StoredMatchesTest.java
+++ b/jplag/src/test/java/jplag/cli/StoredMatchesTest.java
@@ -1,0 +1,52 @@
+package jplag.cli;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+import jplag.CommandLineArgument;
+import jplag.options.JPlagOptions;
+
+public class StoredMatchesTest extends CommandLineInterfaceTest {
+
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Test
+    public void testDefault() {
+        buildOptionsFromCLI(CURRENT_DIRECTORY);
+        assertEquals(JPlagOptions.DEFAULT_STORED_MATCHES, options.getMaxNumberOfMatches());
+    }
+
+    @Test
+    public void testValidThreshold() {
+        int expectedValue = 999;
+        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, Integer.toString(expectedValue));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(expectedValue, options.getMaxNumberOfMatches());
+    }
+
+    @Test
+    public void testAll() {
+        int expectedValue = -1;
+        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, Integer.toString(expectedValue));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(expectedValue, options.getMaxNumberOfMatches());
+    }
+
+    @Test
+    public void testLowerBound() {
+        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, Integer.toString(-2));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(-1, options.getMaxNumberOfMatches());
+    }
+
+    @Test
+    public void testInvalidThreshold() {
+        exit.expectSystemExitWithStatus(1);
+        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, "Not an integer...");
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+    }
+}


### PR DESCRIPTION
This PR adds a framework for CLI testing and some test classes, thus partly addressing #179. 
The test classes currently test the similarity threshold `-m`, the stored matches `-n`, and the comparison mode `-c`.