### PR TITLE
Add more CLI test cases

### DIFF
--- a/jplag/src/main/java/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/jplag/options/JPlagOptions.java
@@ -98,12 +98,12 @@ public class JPlagOptions {
      * @param language - initialized language instance
      */
     public void setLanguageDefaults(Language language) {
-        if (!this.hasMinTokenMatch()) {
-            this.minTokenMatch = language.min_token_match();
+        if (!hasMinTokenMatch()) {
+            setMinTokenMatch(language.min_token_match());
         }
 
-        if (!this.hasFileSuffixes()) {
-            this.fileSuffixes = language.suffixes();
+        if (!hasFileSuffixes()) {
+            fileSuffixes = language.suffixes();
         }
     }
 
@@ -120,11 +120,11 @@ public class JPlagOptions {
     }
 
     private boolean hasFileSuffixes() {
-        return this.fileSuffixes != null && this.fileSuffixes.length > 0;
+        return fileSuffixes != null && fileSuffixes.length > 0;
     }
 
     private boolean hasMinTokenMatch() {
-        return this.minTokenMatch != null;
+        return minTokenMatch != null;
     }
 
     public ComparisonMode getComparisonMode() {
@@ -192,7 +192,11 @@ public class JPlagOptions {
     }
 
     public void setMinTokenMatch(Integer minTokenMatch) {
-        this.minTokenMatch = minTokenMatch;
+        if (minTokenMatch != null && minTokenMatch < 1) {
+            this.minTokenMatch = 1;
+        } else {
+            this.minTokenMatch = minTokenMatch;
+        }
     }
 
     public void setExclusionFileName(String exclusionFileName) {

--- a/jplag/src/test/java/jplag/cli/BaseCodeOptionTest.java
+++ b/jplag/src/test/java/jplag/cli/BaseCodeOptionTest.java
@@ -1,0 +1,26 @@
+package jplag.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import jplag.CommandLineArgument;
+
+public class BaseCodeOptionTest extends CommandLineInterfaceTest {
+
+    private static final String NAME = "BaseCodeName";
+
+    @Test
+    public void testDefaultValue() {
+        buildOptionsFromCLI(CURRENT_DIRECTORY);
+        assertNull(options.getBaseCodeSubmissionName());
+    }
+
+    @Test
+    public void testCustomName() {
+        String argument = buildArgument(CommandLineArgument.BASE_CODE, NAME);
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(NAME, options.getBaseCodeSubmissionName());
+    }
+}

--- a/jplag/src/test/java/jplag/cli/LanguageOptionTest.java
+++ b/jplag/src/test/java/jplag/cli/LanguageOptionTest.java
@@ -1,0 +1,39 @@
+package jplag.cli;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+import jplag.CommandLineArgument;
+import jplag.options.LanguageOption;
+
+public class LanguageOptionTest extends CommandLineInterfaceTest {
+
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Test
+    public void testDefaultLanguage() {
+        buildOptionsFromCLI(CURRENT_DIRECTORY);
+        assertEquals(LanguageOption.getDefault(), options.getLanguageOption());
+    }
+
+    @Test
+    public void testInvalidLanguage() {
+        exit.expectSystemExitWithStatus(1);
+        String argument = buildArgument(CommandLineArgument.LANGUAGE, "Piet");
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+    }
+
+    @Test
+    public void testValidLanguages() {
+        for (LanguageOption language : LanguageOption.values()) {
+            String argument = buildArgument(CommandLineArgument.LANGUAGE, language.getDisplayName());
+            buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+            assertEquals(language, options.getLanguageOption());
+        }
+    }
+
+}

--- a/jplag/src/test/java/jplag/cli/MinTokenMatchTest.java
+++ b/jplag/src/test/java/jplag/cli/MinTokenMatchTest.java
@@ -1,0 +1,69 @@
+package jplag.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
+import jplag.CommandLineArgument;
+import jplag.ExitException;
+import jplag.JPlag;
+
+public class MinTokenMatchTest extends CommandLineInterfaceTest {
+
+    @Rule
+    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+
+    @Test
+    public void testLanguageDefault() {
+        // Language defaults not set yet:
+        buildOptionsFromCLI(CURRENT_DIRECTORY);
+        assertNull(options.getMinTokenMatch());
+        assertNull(options.getLanguage());
+
+        // Init JPlag:
+        try {
+            new JPlag(options);
+        } catch (ExitException e) {
+            e.printStackTrace();
+            fail("JPlag intialization failed!");
+        }
+
+        // Now the language is set:
+        assertNotNull(options.getLanguage());
+        assertEquals(options.getLanguage().min_token_match(), options.getMinTokenMatch().intValue());
+    }
+
+    @Test
+    public void testInvalidInput() {
+        exit.expectSystemExitWithStatus(1);
+        String argument = buildArgument(CommandLineArgument.MIN_TOKEN_MATCH, "Not an integer...");
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+    }
+
+    @Test
+    public void testUpperBound() {
+        exit.expectSystemExitWithStatus(1);
+        String argument = buildArgument(CommandLineArgument.MIN_TOKEN_MATCH, "2147483648"); // max value plus one
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+    }
+
+    @Test
+    public void testLowerBound() {
+        String argument = buildArgument(CommandLineArgument.MIN_TOKEN_MATCH, Integer.toString(-1));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(1, options.getMinTokenMatch().intValue());
+    }
+
+    @Test
+    public void testValidThreshold() {
+        int expectedValue = 50;
+        String argument = buildArgument(CommandLineArgument.MIN_TOKEN_MATCH, Integer.toString(expectedValue));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(expectedValue, options.getMinTokenMatch().intValue());
+    }
+}


### PR DESCRIPTION
Partly addresses #179:

- Test cases for the language option
- Test cases for the min token match option
- Test cases for the base code option
- Enforce minimal min token match value