### PR TITLE
Text encoding improvements

### DIFF
--- a/jplag.frontend.java-1.9/src/main/java/jplag/java19/JavacAdapter.java
+++ b/jplag.frontend.java-1.9/src/main/java/jplag/java19/JavacAdapter.java
@@ -2,6 +2,7 @@ package jplag.java19;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 
@@ -23,7 +24,7 @@ public class JavacAdapter {
     private static final JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
 
     public int parseFiles(File dir, File[] pathedFiles, final Parser parser) {
-        final StandardJavaFileManager jfm = javac.getStandardFileManager(null, null, null);
+        final StandardJavaFileManager jfm = javac.getStandardFileManager(null, null, StandardCharsets.UTF_8);
         DiagnosticCollector<? super JavaFileObject> diagListen = new DiagnosticCollector<>();
         final JavaCompiler.CompilationTask task = javac.getTask(null, jfm, diagListen, null, null, jfm.getJavaFileObjects(pathedFiles));
         Iterable<? extends CompilationUnitTree> asts = Collections.emptyList();

--- a/jplag/src/main/java/jplag/JPlag.java
+++ b/jplag/src/main/java/jplag/JPlag.java
@@ -187,11 +187,6 @@ public class JPlag implements ProgramI {
      * Find all submissions in the given root directory.
      */
     private Vector<Submission> findSubmissions(File rootDir) throws ExitException {
-        String[] fileNamesInRootDir = getSortedFileNamesInRootDir(rootDir);
-        return mapFileNamesInRootDirToSubmissions(fileNamesInRootDir, rootDir);
-    }
-
-    private String[] getSortedFileNamesInRootDir(File rootDir) throws ExitException {
         String[] fileNamesInRootDir;
 
         try {
@@ -206,7 +201,7 @@ public class JPlag implements ProgramI {
 
         Arrays.sort(fileNamesInRootDir);
 
-        return fileNamesInRootDir;
+        return mapFileNamesInRootDirToSubmissions(fileNamesInRootDir, rootDir);
     }
 
     private void initializeComparisonStrategy() throws ExitException {

--- a/jplag/src/main/java/jplag/JPlag.java
+++ b/jplag/src/main/java/jplag/JPlag.java
@@ -9,7 +9,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -426,7 +425,7 @@ public class JPlag implements ProgramI {
         excludedFileNames = new HashSet<>();
 
         try {
-            BufferedReader reader = new BufferedReader(new FileReader(options.getExclusionFileName(), StandardCharsets.UTF_8));
+            BufferedReader reader = new BufferedReader(new FileReader(options.getExclusionFileName(), JPlagOptions.CHARSET));
             String line;
 
             while ((line = reader.readLine()) != null) {

--- a/jplag/src/main/java/jplag/Submission.java
+++ b/jplag/src/main/java/jplag/Submission.java
@@ -9,13 +9,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Vector;
+
+import jplag.options.JPlagOptions;
 
 /**
  * Represents a single submission. A submission can contain multiple files.
@@ -121,7 +122,7 @@ public class Submission implements Comparable<Submission> {
 
             try {
                 FileInputStream fileInputStream = new FileInputStream(new File(submissionFile, files[i]));
-                InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, StandardCharsets.UTF_8);
+                InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, JPlagOptions.CHARSET);
                 BufferedReader in = new BufferedReader(inputStreamReader);
 
                 while ((help = in.readLine()) != null) {
@@ -165,7 +166,7 @@ public class Submission implements Comparable<Submission> {
                 int size = (int) file.length();
                 char[] buffer = new char[size];
 
-                FileReader reader = new FileReader(file, StandardCharsets.UTF_8);
+                FileReader reader = new FileReader(file, JPlagOptions.CHARSET);
 
                 if (size != reader.read(buffer)) {
                     System.out.println("Not right size read from the file, " + "but I will still continue...");

--- a/jplag/src/main/java/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/jplag/options/JPlagOptions.java
@@ -2,6 +2,9 @@ package jplag.options;
 
 import static jplag.strategy.ComparisonMode.NORMAL;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 import jplag.Language;
 import jplag.strategy.ComparisonMode;
 
@@ -10,6 +13,8 @@ public class JPlagOptions {
     public static final ComparisonMode DEFAULT_COMPARISON_MODE = NORMAL;
     public static final float DEFAULT_SIMILARITY_THRESHOLD = 0;
     public static final int DEFAULT_STORED_MATCHES = 30;
+    
+    public static final Charset CHARSET = StandardCharsets.UTF_8;
 
     /**
      * Language used to parse the submissions.

--- a/jplag/src/main/java/jplag/reporting/HTMLFile.java
+++ b/jplag/src/main/java/jplag/reporting/HTMLFile.java
@@ -5,7 +5,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
+
+import jplag.options.JPlagOptions;
 
 public class HTMLFile extends PrintWriter {
 
@@ -15,7 +16,7 @@ public class HTMLFile extends PrintWriter {
      * Static factory method to instantiate an HTMLFile objects.
      */
     public static HTMLFile fromFile(File file) throws IOException {
-        BufferedCounter counter = new BufferedCounter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8));
+        BufferedCounter counter = new BufferedCounter(new OutputStreamWriter(new FileOutputStream(file), JPlagOptions.CHARSET));
         return new HTMLFile(counter);
     }
 

--- a/jplag/src/main/java/jplag/reporting/Report.java
+++ b/jplag/src/main/java/jplag/reporting/Report.java
@@ -7,7 +7,6 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.Date;
@@ -24,6 +23,7 @@ import jplag.Match;
 import jplag.Submission;
 import jplag.Token;
 import jplag.TokenList;
+import jplag.options.JPlagOptions;
 
 /**
  * This class writes all the HTML pages.
@@ -652,7 +652,7 @@ public class Report { // Mostly legacy code with some minor improvements.
 
         try {
             csvFile.createNewFile();
-            writer = new FileWriter(csvFile, StandardCharsets.UTF_8);
+            writer = new FileWriter(csvFile, JPlagOptions.CHARSET);
 
             for (JPlagComparison comparison : comparisons) {
                 String submissionNameA = comparison.getFirstSubmission().getName();

--- a/jplag/src/test/java/jplag/VolumeTest.java
+++ b/jplag/src/test/java/jplag/VolumeTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -13,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
+
+import jplag.options.JPlagOptions;
 
 /**
  * These tests are not intended to be used automatically but rather manually prior to releases.
@@ -60,7 +61,7 @@ public class VolumeTest extends TestBase {
     }
 
     private Map<String, Float> readCSVResults(String filePathAndName) throws IOException {
-        List<String> lines = Files.readAllLines(Path.of(filePathAndName), StandardCharsets.UTF_8);
+        List<String> lines = Files.readAllLines(Path.of(filePathAndName), JPlagOptions.CHARSET);
         var results = new HashMap<String, Float>();
 
         lines.forEach(line -> {


### PR DESCRIPTION
This PR includes the following improvements:
- Enforced UTF-8 as the charset in the Java 9+ language frontend.
- Centralized the charset choice with a constant in the `JPlagOptions`.

Note that language front ends currently do not use the centralized charset as they have no dependency on the JPlag core. 
