### PR TITLE
Fix performance issues of the parallel comparison strategy

### DIFF
--- a/jplag/src/main/java/de/jplag/strategy/ParallelComparisonStrategy.java
+++ b/jplag/src/main/java/de/jplag/strategy/ParallelComparisonStrategy.java
@@ -42,7 +42,7 @@ public class ParallelComparisonStrategy extends AbstractComparisonStrategy {
         if (withBaseCode) {
             compareSubmissionsToBaseCode(submissions, baseCodeSubmission);
         }
-        threadPool = Executors.newCachedThreadPool();
+        threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
         comparisons.clear();
         submissionLocks.clear();
         successfulComparisons = 0;


### PR DESCRIPTION
Fix performance issues of the parallel comparison strategy by using a fixed-size thread pool.
Hopefully resolves the issues described by @csidirop in [PR 169](https://github.com/jplag/JPlag/pull/169#issuecomment-950998616).
