### PR TITLE
Rename misleading option "maximumNumberOfMatches" and clean up JPlagResult interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ named arguments:
   -x X                   All files named in this file will be ignored in the comparison (line-separated list)
   -t T                   Tune the sensitivity of the comparison. A smaller <n> increases the sensitivity
   -m M                   Match similarity Threshold [0-100]: All matches above this threshold will be saved (Standard: 0.0)
-  -n N                   Maximum number of matches that will be saved. If set to -1 all matches will be saved (Standard: 30)
+  -n N                   The maximum number of comparisons that will be shown in the generated report, if set to -1 all comparisons will be shown (Standard: 30)
   -r R                   Name of the directory in which the comparison results will be stored (Standard: result)
   -c {normal,parallel}   Comparison mode used to compare the programs (Standard: normal)
 ```

--- a/jplag/src/main/java/de/jplag/CLI.java
+++ b/jplag/src/main/java/de/jplag/CLI.java
@@ -9,7 +9,7 @@ import static de.jplag.CommandLineArgument.MIN_TOKEN_MATCH;
 import static de.jplag.CommandLineArgument.RESULT_FOLDER;
 import static de.jplag.CommandLineArgument.ROOT_DIRECTORY;
 import static de.jplag.CommandLineArgument.SIMILARITY_THRESHOLD;
-import static de.jplag.CommandLineArgument.STORED_MATCHES;
+import static de.jplag.CommandLineArgument.SHOWN_COMPARISONS;
 import static de.jplag.CommandLineArgument.SUBDIRECTORY;
 import static de.jplag.CommandLineArgument.SUFFIXES;
 import static de.jplag.CommandLineArgument.VERBOSITY;
@@ -110,7 +110,7 @@ public class CLI {
         options.setExclusionFileName(EXCLUDE_FILE.getFrom(namespace));
         options.setMinimumTokenMatch(MIN_TOKEN_MATCH.getFrom(namespace));
         options.setSimilarityThreshold(SIMILARITY_THRESHOLD.getFrom(namespace));
-        options.setMaximumNumberOfMatches(STORED_MATCHES.getFrom(namespace));
+        options.setMaximumNumberOfComparisons(SHOWN_COMPARISONS.getFrom(namespace));
         ComparisonMode.fromName(COMPARISON_MODE.getFrom(namespace)).ifPresentOrElse(it -> options.setComparisonMode(it),
                 () -> System.out.println("Unknown comparison mode, using default mode!"));
         return options;

--- a/jplag/src/main/java/de/jplag/CLI.java
+++ b/jplag/src/main/java/de/jplag/CLI.java
@@ -56,7 +56,7 @@ public class CLI {
             System.out.println("JPlag initialized");
             JPlagResult result = program.run();
             File reportDir = new File(arguments.getString(RESULT_FOLDER.flagWithoutDash()));
-            Report report = new Report(reportDir);
+            Report report = new Report(reportDir, options);
             report.writeResult(result);
         } catch (ExitException exception) {
             System.out.println("Error: " + exception.getReport());

--- a/jplag/src/main/java/de/jplag/CommandLineArgument.java
+++ b/jplag/src/main/java/de/jplag/CommandLineArgument.java
@@ -2,7 +2,7 @@ package de.jplag;
 
 import static de.jplag.options.JPlagOptions.DEFAULT_COMPARISON_MODE;
 import static de.jplag.options.JPlagOptions.DEFAULT_SIMILARITY_THRESHOLD;
-import static de.jplag.options.JPlagOptions.DEFAULT_STORED_MATCHES;
+import static de.jplag.options.JPlagOptions.DEFAULT_SHOWN_COMPARISONS;
 import static net.sourceforge.argparse4j.impl.Arguments.storeTrue;
 
 import java.util.Collection;
@@ -30,7 +30,7 @@ public enum CommandLineArgument {
     EXCLUDE_FILE("-x", String.class, "All files named in this file will be ignored in the comparison (line-separated list)"),
     MIN_TOKEN_MATCH("-t", Integer.class, "Tune the sensitivity of the comparison. A smaller <n> increases the sensitivity"),
     SIMILARITY_THRESHOLD("-m", Float.class, "Match similarity threshold [0-100]: All matches above this threshold will be saved", DEFAULT_SIMILARITY_THRESHOLD),
-    STORED_MATCHES("-n", Integer.class, "Maximum number of matches that will be saved. If set to -1 all matches will be saved", DEFAULT_STORED_MATCHES),
+    SHOWN_COMPARISONS("-n", Integer.class, "The maximum number of comparisons that will be shown in the generated report, if set to -1 all comparisons will be shown", DEFAULT_SHOWN_COMPARISONS),
     RESULT_FOLDER("-r", String.class, "Name of directory in which the comparison results will be stored", "result"),
     COMPARISON_MODE("-c", String.class, "Comparison mode used to compare the programs", DEFAULT_COMPARISON_MODE.getName(), ComparisonMode.allNames());
 

--- a/jplag/src/main/java/de/jplag/JPlagResult.java
+++ b/jplag/src/main/java/de/jplag/JPlagResult.java
@@ -77,10 +77,10 @@ public class JPlagResult {
      * settings set in JPlagOptions
      */
     public List<JPlagComparison> getComparisons() {
-        if (this.options.getMaximumNumberOfMatches() == -1) {
+        if (this.options.getMaximumNumberOfComparisons() == -1) {
             return this.getAllComparisons();
         } else {
-            return this.getComparisons(this.options.getMaximumNumberOfMatches());
+            return this.getComparisons(this.options.getMaximumNumberOfComparisons());
         }
     }
 

--- a/jplag/src/main/java/de/jplag/JPlagResult.java
+++ b/jplag/src/main/java/de/jplag/JPlagResult.java
@@ -66,22 +66,10 @@ public class JPlagResult {
     }
 
     /**
-     * @return a list of all comparisons sorted by percentage (descending).
-     */
-    public List<JPlagComparison> getAllComparisons() {
-        return comparisons;
-    }
-
-    /**
-     * @return a list of comparisons sorted by percentage (descending). the maximum number of comparisons is limited by the
-     * settings set in JPlagOptions
+     * @return a list of all comparisons sorted by percentage (descending)
      */
     public List<JPlagComparison> getComparisons() {
-        if (this.options.getMaximumNumberOfComparisons() == -1) {
-            return this.getAllComparisons();
-        } else {
-            return this.getComparisons(this.options.getMaximumNumberOfComparisons());
-        }
+        return comparisons;
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -12,7 +12,7 @@ public class JPlagOptions {
 
     public static final ComparisonMode DEFAULT_COMPARISON_MODE = NORMAL;
     public static final float DEFAULT_SIMILARITY_THRESHOLD = 0;
-    public static final int DEFAULT_STORED_MATCHES = 30;
+    public static final int DEFAULT_SHOWN_COMPARISONS = 30;
     
     public static final Charset CHARSET = StandardCharsets.UTF_8;
 
@@ -44,10 +44,9 @@ public class JPlagOptions {
     private float similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
 
     /**
-     * The maximum number of matches that will be saved. This does affect the generated report. If set to -1 all matches will be saved.
-     * TODO TS: First, this should be called maximumNumberOfComparisons, as matches are something else. Also, this should only affect the report.
+     * The maximum number of comparisons that will be shown in the generated report. If set to -1 all comparisons will be shown.
      */
-    private int maximumNumberOfMatches = DEFAULT_STORED_MATCHES;
+    private int maximumNumberOfComparisons = DEFAULT_SHOWN_COMPARISONS;
 
     /**
      * The similarity metric determines how the minimum similarity threshold required for a comparison (of two submissions) is calculated.
@@ -174,9 +173,9 @@ public class JPlagOptions {
     public float getSimilarityThreshold() {
         return similarityThreshold;
     }
-
-    public int getMaximumNumberOfMatches() {
-        return this.maximumNumberOfMatches;
+    
+    public int getMaximumNumberOfComparisons() {
+        return this.maximumNumberOfComparisons;
     }
 
     public SimilarityMetric getSimilarityMetric() {
@@ -243,11 +242,11 @@ public class JPlagOptions {
         }
     }
 
-    public void setMaximumNumberOfMatches(int maximumNumberOfMatches) {
-        if (maximumNumberOfMatches < -1) {
-            this.maximumNumberOfMatches = -1;
+    public void setMaximumNumberOfComparisons(int maximumNumberOfComparisons) {
+        if (maximumNumberOfComparisons < -1) {
+            this.maximumNumberOfComparisons = -1;
         } else {
-            this.maximumNumberOfMatches = maximumNumberOfMatches;
+            this.maximumNumberOfComparisons = maximumNumberOfComparisons;
         }
     }
 

--- a/jplag/src/test/java/de/jplag/NormalComparisonTest.java
+++ b/jplag/src/test/java/de/jplag/NormalComparisonTest.java
@@ -32,7 +32,7 @@ public class NormalComparisonTest extends TestBase {
         assertEquals(3, result.getNumberOfSubmissions());
         assertEquals(3, result.getComparisons().size());
 
-        result.getAllComparisons().forEach(comparison -> {
+        result.getComparisons().forEach(comparison -> {
             assertEquals(0f, comparison.similarity(), 0.1f);
         });
     }
@@ -50,10 +50,10 @@ public class NormalComparisonTest extends TestBase {
         JPlagResult result = runJPlagWithDefaultOptions("PartialPlagiarism");
 
         assertEquals(5, result.getNumberOfSubmissions());
-        assertEquals(10, result.getAllComparisons().size());
+        assertEquals(10, result.getComparisons().size());
 
         // All comparisons with E shall have no matches
-        result.getAllComparisons()
+        result.getComparisons()
                 .stream()
                 .filter(comparison ->
                         comparison.getSecondSubmission().getName().equals("E") ||
@@ -86,7 +86,7 @@ public class NormalComparisonTest extends TestBase {
     }
 
     private Optional<JPlagComparison> getSelectedComparison(JPlagResult result, String nameA, String nameB) {
-        return result.getAllComparisons().stream()
+        return result.getComparisons().stream()
                 .filter(comparison ->
                         comparison.getFirstSubmission().getName().equals(nameA) &&
                                 comparison.getSecondSubmission().getName().equals(nameB) ||

--- a/jplag/src/test/java/de/jplag/ParallelComparisonTest.java
+++ b/jplag/src/test/java/de/jplag/ParallelComparisonTest.java
@@ -39,7 +39,7 @@ public class ParallelComparisonTest extends TestBase {
         assertEquals(3, result.getNumberOfSubmissions());
         assertEquals(3, result.getComparisons().size());
 
-        result.getAllComparisons().forEach(comparison -> {
+        result.getComparisons().forEach(comparison -> {
             assertEquals(0f, comparison.similarity(), DELTA);
         });
     }
@@ -54,10 +54,10 @@ public class ParallelComparisonTest extends TestBase {
         JPlagResult result = runJPlag("PartialPlagiarism", it -> it.setComparisonMode(PARALLEL));
 
         assertEquals(5, result.getNumberOfSubmissions());
-        assertEquals(10, result.getAllComparisons().size());
+        assertEquals(10, result.getComparisons().size());
 
         // All comparisons with E shall have no matches
-        result.getAllComparisons().stream()
+        result.getComparisons().stream()
                 .filter(comparison -> comparison.getSecondSubmission().getName().equals("E") || comparison.getFirstSubmission().getName().equals("E"))
                 .forEach(comparison -> assertEquals(0f, comparison.similarity(), DELTA));
 
@@ -83,7 +83,7 @@ public class ParallelComparisonTest extends TestBase {
     }
 
     private Optional<JPlagComparison> getSelectedComparison(JPlagResult result, String nameA, String nameB) {
-        return result.getAllComparisons().stream()
+        return result.getComparisons().stream()
                 .filter(comparison -> comparison.getFirstSubmission().getName().equals(nameA) && comparison.getSecondSubmission().getName().equals(nameB)
                         || comparison.getFirstSubmission().getName().equals(nameB) && comparison.getSecondSubmission().getName().equals(nameA))
                 .findFirst();

--- a/jplag/src/test/java/de/jplag/VolumeTest.java
+++ b/jplag/src/test/java/de/jplag/VolumeTest.java
@@ -44,7 +44,7 @@ public class VolumeTest extends TestBase {
         }
 
         var results = runJPlag("data",
-                jPlagOptions -> jPlagOptions.setMaximumNumberOfMatches(-1));
+                jPlagOptions -> jPlagOptions.setMaximumNumberOfComparisons(-1));
 
         var csv = readCSVResults(String.format("%s/%s", this.getBasePath(), "matches_avg.csv"));
 

--- a/jplag/src/test/java/de/jplag/VolumeTest.java
+++ b/jplag/src/test/java/de/jplag/VolumeTest.java
@@ -48,10 +48,10 @@ public class VolumeTest extends TestBase {
 
         var csv = readCSVResults(String.format("%s/%s", this.getBasePath(), "matches_avg.csv"));
 
-        assertEquals(csv.size(), results.getAllComparisons().size());
+        assertEquals(csv.size(), results.getComparisons().size());
         System.out.println("Volume test size: " + csv.size());
 
-        results.getAllComparisons().forEach(result -> {
+        results.getComparisons().forEach(result -> {
             var key = result.getFirstSubmission().getName() + result.getSecondSubmission().getName();
 
             assertTrue(csv.containsKey(key));

--- a/jplag/src/test/java/de/jplag/cli/StoredMatchesTest.java
+++ b/jplag/src/test/java/de/jplag/cli/StoredMatchesTest.java
@@ -17,36 +17,36 @@ public class StoredMatchesTest extends CommandLineInterfaceTest {
     @Test
     public void testDefault() {
         buildOptionsFromCLI(CURRENT_DIRECTORY);
-        assertEquals(JPlagOptions.DEFAULT_STORED_MATCHES, options.getMaximumNumberOfMatches());
+        assertEquals(JPlagOptions.DEFAULT_SHOWN_COMPARISONS, options.getMaximumNumberOfComparisons());
     }
 
     @Test
     public void testValidThreshold() {
         int expectedValue = 999;
-        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, Integer.toString(expectedValue));
+        String argument = buildArgument(CommandLineArgument.SHOWN_COMPARISONS, Integer.toString(expectedValue));
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
-        assertEquals(expectedValue, options.getMaximumNumberOfMatches());
+        assertEquals(expectedValue, options.getMaximumNumberOfComparisons());
     }
 
     @Test
     public void testAll() {
         int expectedValue = -1;
-        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, Integer.toString(expectedValue));
+        String argument = buildArgument(CommandLineArgument.SHOWN_COMPARISONS, Integer.toString(expectedValue));
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
-        assertEquals(expectedValue, options.getMaximumNumberOfMatches());
+        assertEquals(expectedValue, options.getMaximumNumberOfComparisons());
     }
 
     @Test
     public void testLowerBound() {
-        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, Integer.toString(-2));
+        String argument = buildArgument(CommandLineArgument.SHOWN_COMPARISONS, Integer.toString(-2));
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
-        assertEquals(-1, options.getMaximumNumberOfMatches());
+        assertEquals(-1, options.getMaximumNumberOfComparisons());
     }
 
     @Test
     public void testInvalidThreshold() {
         exit.expectSystemExitWithStatus(1);
-        String argument = buildArgument(CommandLineArgument.STORED_MATCHES, "Not an integer...");
+        String argument = buildArgument(CommandLineArgument.SHOWN_COMPARISONS, "Not an integer...");
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
     }
 }


### PR DESCRIPTION
Resolves #217:
- Rename the option `maximumNumberOfMatches` to `maximumNumberOfComparisons`, adapt its access methods and documentation
- Rename the corresponding CLI argument `STORED_MATCHES` to `SHOWN_COMPARISONS`, adapt its CLI description and the readme
- Adapt JPlag so this option and CLI argument only affects the report generation and not the functionality of the `JPlagResult`:
    - `JPlagResult.getComparisons()` now returns **all comparisons** and is no longer dependent on the options
    - `JPlagResult.getAllComparisons()` was removed as it now matches the functionality of `JPlagResult.getComparisons()`
    - `JPlagResult.getComparisons(int maxCount)` still returns the first `maxCount` comparisons sorted by similarity (descending)