### PR TITLE
Enforce the removal of submissions with invalid length 

### DIFF
--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -364,6 +364,7 @@ public class JPlag implements Program {
                 subm.setTokenList(null);
                 invalid++;
                 removed = true;
+                iter.remove();
             }
 
             if (ok && !removed) {
@@ -379,7 +380,7 @@ public class JPlag implements Program {
         if (invalid != 0) {
             print(null,
                     invalid + ((invalid == 1) ? " submission is not valid because it contains" : " submissions are not valid because they contain")
-                            + " fewer tokens\nthan minimum match length allows.\n");
+                            + " fewer tokens than minimum match length allows.\n");
         }
 
         long time = System.currentTimeMillis() - msec;

--- a/jplag/src/main/java/de/jplag/JPlagResult.java
+++ b/jplag/src/main/java/de/jplag/JPlagResult.java
@@ -74,11 +74,14 @@ public class JPlagResult {
 
     /**
      * Returns the first n comparisons (sorted by percentage, descending), limited by the specified parameter.
-     * @param maxCount the maximum number of yield comparisons
-     * @return a list of comparisons with a size of maxCount or less
+     * @param numberOfComparisons specifies the number of requested comparisons. If set to -1, all comparisons will be returned.
+     * @return a list of comparisons sorted descending by percentage.
      */
-    public List<JPlagComparison> getComparisons(int maxCount) {
-        return comparisons.subList(0, Math.min(maxCount, comparisons.size()));
+    public List<JPlagComparison> getComparisons(int numberOfComparisons) {
+        if (numberOfComparisons == -1) {
+            return comparisons;
+        }
+        return comparisons.subList(0, Math.min(numberOfComparisons, comparisons.size()));
     }
 
     /**


### PR DESCRIPTION
Previously, submissions with invalid length (token of submission < minimum token match value) were not properly removed from the list of submissions. Instead, their token list was just set to `null`. This PR enforces the removal and thus resolves #225.