### PR TITLE
De-tangle main class to separate concerns.

### DIFF
--- a/jplag.frontend-utils/src/main/java/de/jplag/AbstractParser.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/AbstractParser.java
@@ -5,7 +5,7 @@ package de.jplag;
  * @date 22.01.2005
  */
 public abstract class AbstractParser { // TODO TS: We should rename this class, as all concrete parsers shadow its name.
-    protected Program program;
+    protected ErrorReporting program;
     protected int errors = 0;
     private int errorsSum = 0;
 
@@ -21,11 +21,11 @@ public abstract class AbstractParser { // TODO TS: We should rename this class, 
         errorsSum += errors;
     }
 
-    public Program getProgram() {
+    public ErrorReporting getProgram() {
         return program;
     }
 
-    public void setProgram(Program prog) {
+    public void setProgram(ErrorReporting prog) {
         this.program = prog;
     }
 }

--- a/jplag.frontend-utils/src/main/java/de/jplag/AbstractParser.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/AbstractParser.java
@@ -4,7 +4,7 @@ package de.jplag;
  * @author Emeric Kwemou
  * @date 22.01.2005
  */
-public abstract class AbstractParser { // TODO TS: We should rename this class, as all concrete parsers shadow its name.
+public abstract class AbstractParser {
     protected ErrorConsumer program;
     protected int errors = 0;
     private int errorsSum = 0;

--- a/jplag.frontend-utils/src/main/java/de/jplag/AbstractParser.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/AbstractParser.java
@@ -5,7 +5,7 @@ package de.jplag;
  * @date 22.01.2005
  */
 public abstract class AbstractParser { // TODO TS: We should rename this class, as all concrete parsers shadow its name.
-    protected ErrorReporting program;
+    protected ErrorConsumer program;
     protected int errors = 0;
     private int errorsSum = 0;
 
@@ -21,11 +21,11 @@ public abstract class AbstractParser { // TODO TS: We should rename this class, 
         errorsSum += errors;
     }
 
-    public ErrorReporting getProgram() {
+    public ErrorConsumer getProgram() {
         return program;
     }
 
-    public void setProgram(ErrorReporting prog) {
+    public void setProgram(ErrorConsumer prog) {
         this.program = prog;
     }
 }

--- a/jplag.frontend-utils/src/main/java/de/jplag/ErrorConsumer.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/ErrorConsumer.java
@@ -1,6 +1,6 @@
 package de.jplag;
 
-public interface ErrorReporting {
+public interface ErrorConsumer {
 
     /**
      * Print and store an error.

--- a/jplag.frontend-utils/src/main/java/de/jplag/ErrorReporting.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/ErrorReporting.java
@@ -1,6 +1,6 @@
 package de.jplag;
 
-public interface Program {
+public interface ErrorReporting {
 
     /**
      * Print and store an error.

--- a/jplag.frontend.chars/src/main/java/de/jplag/chars/Language.java
+++ b/jplag.frontend.chars/src/main/java/de/jplag/chars/Language.java
@@ -2,7 +2,7 @@ package de.jplag.chars;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.Token;
 import de.jplag.TokenList;
 
@@ -10,11 +10,11 @@ import de.jplag.TokenList;
  * read in text files as characters
  */
 public class Language implements de.jplag.Language {
-	private Program program;
+	private ErrorReporting program;
 
 	private de.jplag.chars.Parser parser = new Parser();
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.program = program;
 		this.parser.setProgram(this.program);
 	}

--- a/jplag.frontend.chars/src/main/java/de/jplag/chars/Language.java
+++ b/jplag.frontend.chars/src/main/java/de/jplag/chars/Language.java
@@ -2,7 +2,7 @@ package de.jplag.chars;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.Token;
 import de.jplag.TokenList;
 
@@ -10,11 +10,11 @@ import de.jplag.TokenList;
  * read in text files as characters
  */
 public class Language implements de.jplag.Language {
-	private ErrorReporting program;
+	private ErrorConsumer program;
 
 	private de.jplag.chars.Parser parser = new Parser();
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.program = program;
 		this.parser.setProgram(this.program);
 	}

--- a/jplag.frontend.cpp/src/main/java/de/jplag/cpp/Language.java
+++ b/jplag.frontend.cpp/src/main/java/de/jplag/cpp/Language.java
@@ -2,7 +2,7 @@ package de.jplag.cpp;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 /*
@@ -11,7 +11,7 @@ import de.jplag.TokenList;
 public class Language implements de.jplag.Language {
 	private Scanner scanner;
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.scanner = new Scanner();
 		this.scanner.setProgram(program);
 

--- a/jplag.frontend.cpp/src/main/java/de/jplag/cpp/Language.java
+++ b/jplag.frontend.cpp/src/main/java/de/jplag/cpp/Language.java
@@ -2,7 +2,7 @@ package de.jplag.cpp;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 /*
@@ -11,7 +11,7 @@ import de.jplag.TokenList;
 public class Language implements de.jplag.Language {
 	private Scanner scanner;
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.scanner = new Scanner();
 		this.scanner.setProgram(program);
 

--- a/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/Language.java
+++ b/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/Language.java
@@ -2,13 +2,13 @@ package de.jplag.csharp;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 

--- a/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/Language.java
+++ b/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/Language.java
@@ -2,13 +2,13 @@ package de.jplag.csharp;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 

--- a/jplag.frontend.java-1.1exp/src/main/java/de/jplag/javax/Language.java
+++ b/jplag.frontend.java-1.1exp/src/main/java/de/jplag/javax/Language.java
@@ -2,13 +2,13 @@ package de.jplag.javax;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 

--- a/jplag.frontend.java-1.1exp/src/main/java/de/jplag/javax/Language.java
+++ b/jplag.frontend.java-1.1exp/src/main/java/de/jplag/javax/Language.java
@@ -2,13 +2,13 @@ package de.jplag.javax;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 

--- a/jplag.frontend.java-1.2/src/main/java/de/jplag/java/Language.java
+++ b/jplag.frontend.java-1.2/src/main/java/de/jplag/java/Language.java
@@ -2,13 +2,13 @@ package de.jplag.java;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.2/src/main/java/de/jplag/java/Language.java
+++ b/jplag.frontend.java-1.2/src/main/java/de/jplag/java/Language.java
@@ -2,13 +2,13 @@ package de.jplag.java;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/Language.java
+++ b/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/Language.java
@@ -2,13 +2,13 @@ package de.jplag.java15;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.parser = new Parser(false);
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/Language.java
+++ b/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/Language.java
@@ -2,13 +2,13 @@ package de.jplag.java15;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.parser = new Parser(false);
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/LanguageWithDelimitedMethods.java
+++ b/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/LanguageWithDelimitedMethods.java
@@ -3,7 +3,7 @@ package de.jplag.java15;
 import java.io.File;
 
 import de.jplag.Language;
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 /**
@@ -14,7 +14,7 @@ import de.jplag.TokenList;
 public class LanguageWithDelimitedMethods implements Language {
 	private Parser parser;
 
-	public LanguageWithDelimitedMethods(ErrorReporting program) {
+	public LanguageWithDelimitedMethods(ErrorConsumer program) {
 		this.parser = new Parser(true);
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/LanguageWithDelimitedMethods.java
+++ b/jplag.frontend.java-1.5/src/main/java/de/jplag/java15/LanguageWithDelimitedMethods.java
@@ -3,7 +3,7 @@ package de.jplag.java15;
 import java.io.File;
 
 import de.jplag.Language;
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 /**
@@ -14,7 +14,7 @@ import de.jplag.TokenList;
 public class LanguageWithDelimitedMethods implements Language {
 	private Parser parser;
 
-	public LanguageWithDelimitedMethods(Program program) {
+	public LanguageWithDelimitedMethods(ErrorReporting program) {
 		this.parser = new Parser(true);
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.7/src/main/java/de/jplag/java17/Language.java
+++ b/jplag.frontend.java-1.7/src/main/java/de/jplag/java17/Language.java
@@ -2,13 +2,13 @@ package de.jplag.java17;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.7/src/main/java/de/jplag/java17/Language.java
+++ b/jplag.frontend.java-1.7/src/main/java/de/jplag/java17/Language.java
@@ -2,13 +2,13 @@ package de.jplag.java17;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 	private Parser parser;
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 	}

--- a/jplag.frontend.java-1.7/src/test/java/de/jplag/StrippedProgram.java
+++ b/jplag.frontend.java-1.7/src/test/java/de/jplag/StrippedProgram.java
@@ -1,9 +1,9 @@
 package de.jplag;
 
 /**
- * This is a stripped version of the JPlag main class ErrorReporting to be used during front end development only.
+ * This is a stripped version of the JPlag main class ErrorConsumer to be used during front end development only.
  */
-public class StrippedProgram implements ErrorReporting {
+public class StrippedProgram implements ErrorConsumer {
     @Override
     public void addError(String errorMsg) {
         System.err.println(errorMsg);

--- a/jplag.frontend.java-1.7/src/test/java/de/jplag/StrippedProgram.java
+++ b/jplag.frontend.java-1.7/src/test/java/de/jplag/StrippedProgram.java
@@ -1,9 +1,9 @@
 package de.jplag;
 
 /**
- * This is a stripped version of the JPlag main class Program to be used during front end development only.
+ * This is a stripped version of the JPlag main class ErrorReporting to be used during front end development only.
  */
-public class StrippedProgram implements Program {
+public class StrippedProgram implements ErrorReporting {
     @Override
     public void addError(String errorMsg) {
         System.err.println(errorMsg);

--- a/jplag.frontend.java-1.9/src/main/java/de/jplag/java19/Language.java
+++ b/jplag.frontend.java-1.9/src/main/java/de/jplag/java19/Language.java
@@ -2,7 +2,7 @@ package de.jplag.java19;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 /**
@@ -11,7 +11,7 @@ import de.jplag.TokenList;
 public class Language implements de.jplag.Language {
     private Parser parser;
 
-    public Language(ErrorReporting program) {
+    public Language(ErrorConsumer program) {
         this.parser = new Parser();
         this.parser.setProgram(program);
     }

--- a/jplag.frontend.java-1.9/src/main/java/de/jplag/java19/Language.java
+++ b/jplag.frontend.java-1.9/src/main/java/de/jplag/java19/Language.java
@@ -2,7 +2,7 @@ package de.jplag.java19;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 /**
@@ -11,7 +11,7 @@ import de.jplag.TokenList;
 public class Language implements de.jplag.Language {
     private Parser parser;
 
-    public Language(Program program) {
+    public Language(ErrorReporting program) {
         this.parser = new Parser();
         this.parser.setProgram(program);
     }

--- a/jplag.frontend.python-3/src/main/java/de/jplag/python3/Language.java
+++ b/jplag.frontend.python-3/src/main/java/de/jplag/python3/Language.java
@@ -2,14 +2,14 @@ package de.jplag.python3;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 
     private Parser parser;
 
-    public Language(ErrorReporting program) {
+    public Language(ErrorConsumer program) {
         this.parser = new Parser();
         this.parser.setProgram(program);
     }

--- a/jplag.frontend.python-3/src/main/java/de/jplag/python3/Language.java
+++ b/jplag.frontend.python-3/src/main/java/de/jplag/python3/Language.java
@@ -2,14 +2,14 @@ package de.jplag.python3;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 
     private Parser parser;
 
-    public Language(Program program) {
+    public Language(ErrorReporting program) {
         this.parser = new Parser();
         this.parser.setProgram(program);
     }

--- a/jplag.frontend.scheme/src/main/java/de/jplag/scheme/Language.java
+++ b/jplag.frontend.scheme/src/main/java/de/jplag/scheme/Language.java
@@ -2,12 +2,12 @@ package de.jplag.scheme;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 

--- a/jplag.frontend.scheme/src/main/java/de/jplag/scheme/Language.java
+++ b/jplag.frontend.scheme/src/main/java/de/jplag/scheme/Language.java
@@ -2,12 +2,12 @@ package de.jplag.scheme;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 public class Language implements de.jplag.Language {
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.parser = new Parser();
 		this.parser.setProgram(program);
 

--- a/jplag.frontend.text/src/main/java/de/jplag/text/Language.java
+++ b/jplag.frontend.text/src/main/java/de/jplag/text/Language.java
@@ -3,7 +3,7 @@ package de.jplag.text;
 
 import java.io.File;
 
-import de.jplag.Program;
+import de.jplag.ErrorReporting;
 import de.jplag.TokenList;
 
 /**
@@ -12,11 +12,11 @@ import de.jplag.TokenList;
  */
 public class Language implements de.jplag.Language {
 
-	private Program program;
+	private ErrorReporting program;
 
 	private Parser parser = new Parser();
 
-	public Language(Program program) {
+	public Language(ErrorReporting program) {
 		this.program = program;
 		this.parser.setProgram(this.program);
 	}

--- a/jplag.frontend.text/src/main/java/de/jplag/text/Language.java
+++ b/jplag.frontend.text/src/main/java/de/jplag/text/Language.java
@@ -3,7 +3,7 @@ package de.jplag.text;
 
 import java.io.File;
 
-import de.jplag.ErrorReporting;
+import de.jplag.ErrorConsumer;
 import de.jplag.TokenList;
 
 /**
@@ -12,11 +12,11 @@ import de.jplag.TokenList;
  */
 public class Language implements de.jplag.Language {
 
-	private ErrorReporting program;
+	private ErrorConsumer program;
 
 	private Parser parser = new Parser();
 
-	public Language(ErrorReporting program) {
+	public Language(ErrorConsumer program) {
 		this.program = program;
 		this.parser.setProgram(this.program);
 	}

--- a/jplag/src/main/java/de/jplag/ErrorCollector.java
+++ b/jplag/src/main/java/de/jplag/ErrorCollector.java
@@ -9,7 +9,7 @@ import java.util.List;
 import de.jplag.options.JPlagOptions;
 import de.jplag.options.Verbosity;
 
-public class ErrorCollector implements ErrorReporting {
+public class ErrorCollector implements ErrorConsumer { // TODO TS should be eventually replaced with a true logger/logging manager
 
     private final List<String> errorVector; // List of errors that occurred during the execution of the program.
     private final JPlagOptions options;

--- a/jplag/src/main/java/de/jplag/ErrorCollector.java
+++ b/jplag/src/main/java/de/jplag/ErrorCollector.java
@@ -1,0 +1,60 @@
+package de.jplag;
+
+import static de.jplag.options.Verbosity.LONG;
+import static de.jplag.options.Verbosity.QUIET;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.jplag.options.JPlagOptions;
+import de.jplag.options.Verbosity;
+
+public class ErrorCollector implements ErrorReporting {
+
+    private final List<String> errorVector; // List of errors that occurred during the execution of the program.
+    private final JPlagOptions options;
+    private String currentSubmissionName;
+
+    public ErrorCollector(JPlagOptions options) {
+        this.options = options;
+        errorVector = new ArrayList<>();
+        currentSubmissionName = "<Unknown submission>";
+    }
+
+    @Override
+    public void addError(String errorMessage) {
+        errorVector.add("[" + currentSubmissionName + "]\n" + errorMessage);
+        print(errorMessage, null);
+    }
+
+    @Override
+    public void print(String message, String longMessage) {
+        Verbosity verbosity = options.getVerbosity();
+        if (verbosity != QUIET) {
+            if (message != null) {
+                System.out.print(message);
+            }
+            if (longMessage != null && verbosity == LONG) {
+                System.out.print(longMessage);
+            }
+        }
+    }
+
+    /**
+     * Print all errors from the errorVector.
+     */
+    public void printErrors() {
+        StringBuilder errorStr = new StringBuilder();
+
+        for (String str : errorVector) {
+            errorStr.append(str);
+            errorStr.append('\n');
+        }
+
+        System.out.println(errorStr.toString());
+    }
+
+    public void setCurrentSubmissionName(String currentSubmissionName) {
+        this.currentSubmissionName = currentSubmissionName;
+    }
+}

--- a/jplag/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/jplag/src/main/java/de/jplag/GreedyStringTiling.java
@@ -3,6 +3,8 @@ package de.jplag;
 import java.util.ArrayList;
 import java.util.List;
 
+import de.jplag.options.JPlagOptions;
+
 /**
  * This class implements the Greedy String Tiling algorithm as introduced by Michael Wise. However, it is very specific
  * to the classes {@link TokenList}, {@link Token}, and {@link Match}. While this class was reworked, it still contains
@@ -13,10 +15,10 @@ import java.util.List;
  */
 public class GreedyStringTiling implements TokenConstants {
 
-    private JPlag program;
+    private final JPlagOptions options;
 
-    public GreedyStringTiling(JPlag program) {
-        this.program = program;
+    public GreedyStringTiling(JPlagOptions options) {
+        this.options = options;
     }
 
     /**
@@ -124,7 +126,7 @@ public class GreedyStringTiling implements TokenConstants {
 
         // Initialize:
         JPlagComparison comparison = new JPlagComparison(firstSubmission, secondSubmission);
-        int minimumTokenMatch = program.getOptions().getMinimumTokenMatch(); // minimal required token match
+        int minimumTokenMatch = options.getMinimumTokenMatch(); // minimal required token match
 
         if (first.size() <= minimumTokenMatch || second.size() <= minimumTokenMatch) { // <= because of pivots!
             return comparison;
@@ -214,7 +216,7 @@ public class GreedyStringTiling implements TokenConstants {
             if (withBaseCode) {
                 token.marked = token.type == FILE_END || token.type == SEPARATOR_TOKEN;
             } else {
-                token.marked = token.type == FILE_END || token.type == SEPARATOR_TOKEN || (token.basecode && program.getOptions().hasBaseCode());
+                token.marked = token.type == FILE_END || token.type == SEPARATOR_TOKEN || (token.basecode && options.hasBaseCode());
             }
         }
     }

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -191,7 +191,7 @@ public class JPlag {
         LanguageOption languageOption = this.options.getLanguageOption();
 
         try {
-            Constructor<?> constructor = Class.forName(languageOption.getClassPath()).getConstructor(ErrorReporting.class);
+            Constructor<?> constructor = Class.forName(languageOption.getClassPath()).getConstructor(ErrorConsumer.class);
             Object[] constructorParams = {errorCollector};
 
             Language language = (Language) constructor.newInstance(constructorParams);

--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -230,6 +230,10 @@ public class Submission implements Comparable<Submission> {
     public void setTokenList(TokenList tokenList) {
         this.tokenList = tokenList;
     }
+    
+    public void markAsErroneous() {
+        hasErrors = true;
+    }
 
     @Override
     public int compareTo(Submission other) {

--- a/jplag/src/main/java/de/jplag/SubmissionSet.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSet.java
@@ -1,11 +1,12 @@
 package de.jplag;
 
-import static java.util.Collections.emptyList;
-
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import de.jplag.options.JPlagOptions;
 
 /**
  * Collection of submissions and their basecode if it exists.
@@ -21,13 +22,24 @@ public class SubmissionSet {
      */
     private final Optional<Submission> baseCodeSubmission;
 
+    private final ErrorCollector errorCollector;
+    private final JPlagOptions options;
+
+    private int errors = 0;
+    private String currentSubmissionName;
+
     /**
      * @param submissions Submissions to check for plagiarism.
-     * @param baseCodeSubmission Base code submission if it exists.
+     * @param baseCode Base code submission if it exists.
      */
-    public SubmissionSet(List<Submission> submissions, Optional<Submission> baseCodeSubmission) {
+    public SubmissionSet(List<Submission> submissions, Optional<Submission> baseCode, ErrorCollector errorCollector, JPlagOptions options)
+            throws ExitException {
         this.submissions = submissions;
-        this.baseCodeSubmission = baseCodeSubmission;
+        this.baseCodeSubmission = baseCode;
+        this.errorCollector = errorCollector;
+        this.options = options;
+        parseAllSubmissions();
+        filterValidSubmissions(); // TODO TS: Keep filtered Submissions
     }
 
     /**
@@ -53,7 +65,7 @@ public class SubmissionSet {
     /**
      * @return The number of submissions.
      */
-    public int numberOfSubmissions() {
+    public int numberOfSubmissions() { // Ensure this is the right value (filtered vs. all)
         return submissions.size();
     }
 
@@ -61,14 +73,117 @@ public class SubmissionSet {
      * Obtain the submissions.
      * @note Changes in the list are reflected in this instance.
      */
-    public List<Submission> getSubmissions() {
+    public List<Submission> getSubmissions() { // TODO TS: Ensure this is the right value
         return submissions;
     }
 
     /**
      * Remove invalid submissions from the set.
      */
-    public void filterValidSubmissions() {
+    private void filterValidSubmissions() {
         submissions = submissions.stream().filter(submission -> !submission.hasErrors()).collect(Collectors.toCollection(ArrayList::new));
     }
+
+    /**
+     * TODO PB: Find a better way to separate parseSubmissions(...) and parseBaseCodeSubmission(...)
+     */
+    private void parseAllSubmissions() throws ExitException {
+        try {
+            parseSubmissions(submissions);
+            if (baseCodeSubmission.isPresent()) {
+                parseBaseCodeSubmission(baseCodeSubmission.get()); // cannot use ifPresent because of throws declaration
+            }
+
+        } catch (OutOfMemoryError e) {
+            throw new ExitException("Out of memory during parsing of submission \"" + currentSubmissionName + "\"");
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw new ExitException("Unknown exception during parsing of " + "submission \"" + currentSubmissionName + "\"");
+        }
+    }
+
+    /**
+     * Parse the given base code submission.
+     */
+    private void parseBaseCodeSubmission(Submission baseCode) throws ExitException {
+
+        long startTime = System.currentTimeMillis();
+        errorCollector.print("----- Parsing basecode submission: " + baseCode.getName() + "\n", null);
+
+        if (!baseCode.parse()) {
+            errorCollector.printErrors();
+            throw new ExitException("Bad basecode submission");
+        }
+
+        if (baseCode.getTokenList() != null && baseCode.getNumberOfTokens() < options.getMinimumTokenMatch()) {
+            throw new ExitException("Basecode submission contains fewer tokens than minimum match length allows!\n");
+        }
+
+        errorCollector.print("\nBasecode submission parsed!\n", null);
+
+        long duration = System.currentTimeMillis() - startTime;
+        errorCollector.print("\n", "\nTime for parsing Basecode: " + TimeUtil.formatDuration(duration) + "\n");
+
+    }
+
+    /**
+     * Parse all given submissions.
+     */
+    private void parseSubmissions(List<Submission> submissions) {
+        if (submissions.isEmpty()) {
+            System.out.println("No submissions to parse!");
+            return;
+        }
+
+        int count = 0;
+
+        long startTime = System.currentTimeMillis();
+        Iterator<Submission> iter = submissions.iterator();
+
+        int invalid = 0;
+        while (iter.hasNext()) {
+            boolean ok;
+            boolean removed = false;
+            Submission subm = iter.next();
+
+            errorCollector.print(null, "------ Parsing submission: " + subm.getName() + "\n");
+            currentSubmissionName = subm.getName();
+            errorCollector.setCurrentSubmissionName(currentSubmissionName);
+
+            if (!(ok = subm.parse())) {
+                errors++;
+            }
+
+            count++;
+
+            if (subm.getTokenList() != null && subm.getNumberOfTokens() < options.getMinimumTokenMatch()) {
+                errorCollector.print(null, "Submission contains fewer tokens than minimum match length allows!\n");
+                subm.setTokenList(null);
+                invalid++;
+                removed = true;
+                iter.remove(); // TODO TS: Keep filtered Submissions
+            }
+
+            if (ok && !removed) {
+                errorCollector.print(null, "OK\n");
+            } else {
+                errorCollector.print(null, "ERROR -> Submission removed\n");
+            }
+        }
+
+        errorCollector.print(
+                "\n" + (count - errors - invalid) + " submissions parsed successfully!\n" + errors + " parser error" + (errors != 1 ? "s!\n" : "!\n"),
+                null);
+
+        if (invalid != 0) {
+            errorCollector.print(null,
+                    invalid + ((invalid == 1) ? " submission is not valid because it contains" : " submissions are not valid because they contain")
+                            + " fewer tokens than minimum match length allows.\n");
+        }
+
+        long duration = System.currentTimeMillis() - startTime;
+        errorCollector.print("\n\n", "\nTotal time for parsing: " + TimeUtil.formatDuration(duration) + "\n" + "Time per parsed submission: "
+                + (count > 0 ? (duration / count) : "n/a") + " msec\n\n");
+    }
+
 }

--- a/jplag/src/main/java/de/jplag/SubmissionSet.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSet.java
@@ -28,7 +28,6 @@ public class SubmissionSet {
 
     private final ErrorCollector errorCollector;
     private final JPlagOptions options;
-
     private int errors = 0;
     private String currentSubmissionName;
 
@@ -94,9 +93,6 @@ public class SubmissionSet {
         return allSubmissions.stream().filter(submission -> submission.hasErrors()).collect(toList());
     }
 
-    /**
-     * TODO PB: Find a better way to separate parseSubmissions(...) and parseBaseCodeSubmission(...)
-     */
     private void parseAllSubmissions() throws ExitException {
         try {
             parseSubmissions(allSubmissions);
@@ -115,21 +111,16 @@ public class SubmissionSet {
      * Parse the given base code submission.
      */
     private void parseBaseCodeSubmission(Submission baseCode) throws ExitException {
-
         long startTime = System.currentTimeMillis();
         errorCollector.print("----- Parsing basecode submission: " + baseCode.getName() + "\n", null);
-
-        if (!baseCode.parse()) {
+        if (!baseCode.parse(options.isDebugParser())) {
             errorCollector.printErrors();
             throw new ExitException("Bad basecode submission");
         }
-
         if (baseCode.getTokenList() != null && baseCode.getNumberOfTokens() < options.getMinimumTokenMatch()) {
             throw new ExitException("Basecode submission contains fewer tokens than minimum match length allows!\n");
         }
-
         errorCollector.print("\nBasecode submission parsed!\n", null);
-
         long duration = System.currentTimeMillis() - startTime;
         errorCollector.print("\n", "\nTime for parsing Basecode: " + TimeUtil.formatDuration(duration) + "\n");
 
@@ -159,7 +150,7 @@ public class SubmissionSet {
             currentSubmissionName = subm.getName();
             errorCollector.setCurrentSubmissionName(currentSubmissionName);
 
-            if (!(ok = subm.parse())) {
+            if (!(ok = subm.parse(options.isDebugParser()))) {
                 errors++;
             }
 
@@ -184,8 +175,8 @@ public class SubmissionSet {
                 + (errors != 1 ? "s!\n" : "!\n"), null);
 
         if (invalid != 0) {
-            errorCollector.print(null,
-                    invalid + ((invalid == 1) ? " submission is not valid because it contains" : " allSubmissions are not valid because they contain")
+            errorCollector.print(null, invalid + ((invalid == 1)
+                    ? " submission is not valid because it contains" : " allSubmissions are not valid because they contain")
                             + " fewer tokens than minimum match length allows.\n");
         }
 

--- a/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -1,0 +1,190 @@
+package de.jplag;
+
+import static de.jplag.options.Verbosity.LONG;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
+import de.jplag.options.JPlagOptions;
+
+/**
+ * Builder class for the creation of a {@link SubmissionSet}.
+ * @author Timur Saglam
+ */
+public class SubmissionSetBuilder {
+
+    private final Language language;
+    private final JPlagOptions options;
+    private final ErrorCollector errorCollector;
+    private final HashSet<String> excludedFileNames; // Set of file names to be excluded in comparison.
+
+    /**
+     * Creates a builder for submission sets.
+     * @param language is the language of the submissions.
+     * @param options are the configured options.
+     * @param errorCollector is the interface for error reporting.
+     */
+    public SubmissionSetBuilder(Language language, JPlagOptions options, ErrorCollector errorCollector) {
+        this.language = language;
+        this.options = options;
+        this.errorCollector = errorCollector;
+        excludedFileNames = readExclusionFile();
+    }
+
+    /**
+     * Builds a submission set for all submissions of a specific directory.
+     * @param rootDirectory is the specific directory.
+     * @return the newly built submission set.
+     * @throws ExitException if the directory cannot be read.
+     */
+    public SubmissionSet buildSubmissionSet(File rootDirectory) throws ExitException {
+        String[] fileNames;
+
+        try {
+            fileNames = rootDirectory.list();
+        } catch (SecurityException exception) {
+            throw new ExitException("Cannot list files of the root directory! " + exception.getMessage());
+        }
+
+        if (fileNames == null) {
+            throw new ExitException("Cannot list files of the root directory! " + "Make sure the specified root directory is in fact a directory.");
+        }
+
+        Arrays.sort(fileNames);
+
+        return mapFileNamesToSubmissions(fileNames, rootDirectory);
+    }
+
+    /**
+     * Checks if a file has a valid suffix for the current language.
+     * @param file is the file to check.
+     * @return true if the file suffix matches the language.
+     */
+    private boolean hasValidSuffix(File file) {
+        String[] validSuffixes = options.getFileSuffixes();
+
+        // This is the case if either the language frontends or the CLI did not set the valid suffixes array in options
+        if (validSuffixes == null || validSuffixes.length == 0) {
+            return true;
+        }
+        return Arrays.stream(validSuffixes).anyMatch(suffix -> file.getName().endsWith(suffix));
+    }
+
+    /**
+     * Checks if a file is excluded or not.
+     */
+    private boolean isFileExcluded(File file) {
+        return excludedFileNames.stream().anyMatch(excludedName -> file.getName().endsWith(excludedName));
+    }
+
+    private SubmissionSet mapFileNamesToSubmissions(String[] fileNames, File rootDirectory) throws ExitException {
+        List<Submission> submissions = new ArrayList<>();
+        Optional<Submission> baseCodeSubmission = Optional.empty();
+
+        for (String fileName : fileNames) {
+            File submissionFile = new File(rootDirectory, fileName);
+
+            if (isFileExcluded(submissionFile)) {
+                System.out.println("Exclude submission: " + submissionFile.getName());
+                continue;
+            }
+
+            if (submissionFile.isFile() && !hasValidSuffix(submissionFile)) {
+                System.out.println("Ignore submission with invalid suffix: " + submissionFile.getName());
+                continue;
+            }
+
+            if (submissionFile.isDirectory() && options.getSubdirectoryName() != null) {
+                // Use subdirectory instead
+                submissionFile = new File(submissionFile, options.getSubdirectoryName());
+
+                if (!submissionFile.exists()) {
+                    throw new ExitException(
+                            String.format("Submission %s does not contain the given subdirectory '%s'", fileName, options.getSubdirectoryName()));
+                }
+
+                if (!submissionFile.isDirectory()) {
+                    throw new ExitException(String.format("The given subdirectory '%s' is not a directory!", options.getSubdirectoryName()));
+                }
+            }
+
+            Submission submission = new Submission(fileName, submissionFile, parseFilesRecursively(submissionFile), language, errorCollector);
+
+            if (options.hasBaseCode() && options.getBaseCodeSubmissionName().equals(fileName)) {
+                baseCodeSubmission = Optional.of(submission);
+            } else {
+                submissions.add(submission);
+            }
+        }
+
+        return new SubmissionSet(submissions, baseCodeSubmission, errorCollector, options);
+    }
+
+    /**
+     * Recursively scan the given directory for nested files. Excluded files and files with an invalid suffix are ignored.
+     * <p>
+     * If the given file is not a directory, the input will be returned as a singleton list.
+     * @param file - File to start the scan from.
+     * @return a list of nested files.
+     */
+    private Collection<File> parseFilesRecursively(File file) {
+        if (isFileExcluded(file)) {
+            return Collections.emptyList();
+        }
+
+        if (file.isFile() && hasValidSuffix(file)) {
+            return Collections.singletonList(file);
+        }
+
+        String[] nestedFileNames = file.list();
+
+        if (nestedFileNames == null) {
+            return Collections.emptyList();
+        }
+
+        Collection<File> files = new ArrayList<>();
+
+        for (String fileName : nestedFileNames) {
+            files.addAll(parseFilesRecursively(new File(file, fileName)));
+        }
+
+        return files;
+    }
+
+    /**
+     * If an exclusion file is given, it is read in and all strings are saved in the set "excluded".
+     */
+    private HashSet<String> readExclusionFile() {
+        HashSet<String> excludedFileNames = new HashSet<>();
+        if (options.getExclusionFileName() != null) {
+            try {
+                BufferedReader reader = new BufferedReader(new FileReader(options.getExclusionFileName(), JPlagOptions.CHARSET));
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    excludedFileNames.add(line.trim());
+                }
+                reader.close();
+            } catch (IOException exception) {
+                System.out.println("Could not read exclusion file: " + exception.getMessage());
+            }
+
+            if (options.getVerbosity() == LONG) {
+                errorCollector.print(null, "Excluded files:\n");
+
+                for (String excludedFileName : excludedFileNames) {
+                    errorCollector.print(null, "  " + excludedFileName + "\n");
+                }
+            }
+        }
+        return excludedFileNames;
+    }
+}

--- a/jplag/src/main/java/de/jplag/TimeUtil.java
+++ b/jplag/src/main/java/de/jplag/TimeUtil.java
@@ -1,0 +1,21 @@
+package de.jplag;
+
+public final class TimeUtil {
+
+    private TimeUtil() {
+        // private constructor to prevent instantiation
+    }
+
+    /**
+     * Convert a duration in milli-seconds to a human-readable representation.
+     * @param durationInMiliseconds Number of milli-seconds to convert.
+     * @return Readable representation of the time interval.
+     */
+    public static String formatDuration(long durationInMiliseconds) {
+        int timeInSeconds = (int) (durationInMiliseconds / 1000);
+        String hours = (timeInSeconds / 3600 > 0) ? (timeInSeconds / 3600) + " h " : "";
+        String minutes = (timeInSeconds / 60 > 0) ? ((timeInSeconds / 60) % 60) + " min " : "";
+        String seconds = (timeInSeconds % 60) + " sec";
+        return hours + minutes + seconds;
+    }
+}

--- a/jplag/src/main/java/de/jplag/reporting/Report.java
+++ b/jplag/src/main/java/de/jplag/reporting/Report.java
@@ -449,7 +449,6 @@ public class Report { // Mostly legacy code with some minor improvements.
 
         if (options.getMaximumNumberOfComparisons() > 0) {
             htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Matches_displayed") + ":</TD>" + "<TD>");
-            // TODO TS every instance of getComparisons must be replaced by get N in this class!
             htmlFile.println(options.getMaximumNumberOfComparisons() + " of " + result.getComparisons().size() + " ("
                     + msg.getString("Report.Treshold") + ": " + result.getOptions().getSimilarityThreshold() + "%)<br>");
 


### PR DESCRIPTION
Depends on #231 and should be merged after it!
Separates the different concerns of the main class `JPlag`:

- The error collecting capabilities defined by `Program` (now called `ErrorConsumer`) are moved into the new class `ErrorCollector`
- The submission parsing is mostly moved into the `SubmissionSet` (thus depending on #231)
- The submission reading is moved into a dedicated class called `SubmissionSetBuilder`
- The language frontends no longer need to hold a dependency on the `JPlag` class
- Other classes also no longer have a reference on the `JPlag` class
- Resolves #232 by ensuring proper filtering without removal during iteration and keeping invalid submissions for the report