### PR TITLE
Store basecode comparisons in each submission instead in the comparison strategy

### DIFF
--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -51,9 +51,9 @@ public class Submission implements Comparable<Submission> {
     private TokenList tokenList;
 
     /**
-     * baseCodeMatch
+     * Base code comparison
      */
-    private JPlagComparison baseCodeMatch;
+    private JPlagComparison baseCodeComparison;
 
     private final Language language;
     private final ErrorCollector errorCollector;
@@ -100,18 +100,18 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * Sets the base code match
-     * @param baseCodeMatch is submissions matches with the base code
+     * Sets the base code comparison
+     * @param baseCodeComparison is submissions matches with the base code
      */
-    public void setBaseCodeMatch(JPlagComparison baseCodeMatch) {
-        this.baseCodeMatch = baseCodeMatch;
+    public void setBaseCodeComparison(JPlagComparison baseCodeComparison) {
+        this.baseCodeComparison = baseCodeComparison;
     }
 
     /**
-     * @return base code match
+     * @return base code comparison
      */
-    public JPlagComparison getBaseCodeMatch() {
-        return baseCodeMatch;
+    public JPlagComparison getBaseCodeComparison() {
+        return baseCodeComparison;
     }
 
 

--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -21,26 +21,56 @@ import de.jplag.options.JPlagOptions;
  * Represents a single submission. A submission can contain multiple files.
  */
 public class Submission implements Comparable<Submission> {
-
+    /**
+     * Directory name for storing submission files with parse errors if so requested.
+     */
     private static final String ERROR_FOLDER = "errors";
 
-    private final String name; // uniquely identifies this submission (e.g. directory or file name)
+    /**
+     * Identification of the submission (often a directory or file name).
+     */
+    private final String name;
 
-    private final File submissionFile;
+    /**
+     * Root of the submission (either a file or a directory).
+     */
+    private final File submissionRoot;
 
-    private final Collection<File> files; // files of which the submission consists.
+    /**
+     * Files of the submission.
+     */
+    private final Collection<File> files;
 
+    /**
+     * Back-link to the main application.
+     */
     private final JPlag program;
 
-    private boolean hasErrors; // indicates that at least one error occurred while parsing this submission
+    /**
+     * Whether an error occurred during parsing the submission files.
+     */
+    private boolean hasErrors;
 
-    private TokenList tokenList; // parsed tokens from the files
+    /**
+     * Parse result, tokens from all files.
+     */
+    private TokenList tokenList;
 
-    public Submission(String name, File submissionFile, JPlag program) {
+     /**
+     * baseCodeMatche
+     */
+    private JPlagComparison baseCodeMatch;
+
+    /**
+     * @param name Identification of the submission (directory or filename).
+     * @param submissionRoot Root of the submission (either a file or a directory).
+     * @param program Back-link to the main application.
+     */
+    public Submission(String name, File submissionRoot, JPlag program) {
         this.name = name;
-        this.submissionFile = submissionFile;
+        this.submissionRoot = submissionRoot;
         this.program = program;
-        this.files = parseFilesRecursively(submissionFile);
+        this.files = parseFilesRecursively(submissionRoot);
     }
 
     /**
@@ -51,13 +81,15 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * @return return the name that uniquely identifies this submission. Will most commonly be the directory or file
-     * name.return the name that uniquely identifies this submission. Will most commonly be the directory or file name.
+     * @return Identification of the submission (often a directory or file name).
      */
     public String getName() {
         return name;
     }
 
+    /**
+     * @return Number of tokens in the parse result.
+     */
     public int getNumberOfTokens() {
         if (tokenList == null) {
             return 0;
@@ -66,8 +98,23 @@ public class Submission implements Comparable<Submission> {
         return tokenList.size();
     }
 
+   /**
+     * Sets the base code match
+     * @param baseCodeMatch is submissions matches with the base code
+     */
+    public void setBaseCodeMatch(JPlagComparison baseCodeMatch) {
+        this.baseCodeMatch = baseCodeMatch;
+    }
+
     /**
-     * @return list of tokens that have been parsed from the files this submission consists of.
+     * @return Number of tokens in the parse result.
+     */
+    public JPlagComparison getBaseCodeMatch() {
+        return baseCodeMatch;
+    }
+
+    /**
+     * @return Parse result of the submission.
      */
     public TokenList getTokenList() {
         return tokenList;
@@ -80,16 +127,19 @@ public class Submission implements Comparable<Submission> {
         return hasErrors;
     }
 
-    /* parse all the files... */
+    /**
+     * Parse files of the submission.
+     * @return Whether parsing was successful.
+     */
     public boolean parse() {
         if (files == null || files.size() == 0) {
             program.print("ERROR: nothing to parse for submission \"" + name + "\"\n", null);
             return false;
         }
 
-        String[] relativeFilePaths = getRelativeFilePaths(submissionFile, files);
+        String[] relativeFilePaths = getRelativeFilePaths(submissionRoot, files);
 
-        tokenList = this.program.getLanguage().parse(submissionFile, relativeFilePaths);
+        tokenList = this.program.getLanguage().parse(submissionRoot, relativeFilePaths);
         if (!program.getLanguage().hasErrors()) {
             if (tokenList.size() < 3) {
                 program.print("Submission \"" + name + "\" is too short!\n", null);
@@ -120,7 +170,7 @@ public class Submission implements Comparable<Submission> {
             text.clear();
 
             try {
-                FileInputStream fileInputStream = new FileInputStream(new File(submissionFile, files[i]));
+                FileInputStream fileInputStream = new FileInputStream(new File(submissionRoot, files[i]));
                 InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, JPlagOptions.CHARSET);
                 BufferedReader in = new BufferedReader(inputStreamReader);
 
@@ -136,7 +186,7 @@ public class Submission implements Comparable<Submission> {
                 inputStreamReader.close();
                 fileInputStream.close();
             } catch (FileNotFoundException e) {
-                System.out.println("File not found: " + ((new File(submissionFile, files[i])).toString()));
+                System.out.println("File not found: " + ((new File(submissionRoot, files[i])).toString()));
             } catch (IOException e) {
                 throw new de.jplag.ExitException("I/O exception!");
             }
@@ -158,7 +208,7 @@ public class Submission implements Comparable<Submission> {
             // If the token path is absolute, ignore the provided directory
             File file = new File(files[i]);
             if (!file.isAbsolute()) {
-                file = new File(submissionFile, files[i]);
+                file = new File(submissionRoot, files[i]);
             }
 
             try {

--- a/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
+++ b/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
@@ -27,8 +27,8 @@ public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
     protected void compareSubmissionsToBaseCode(SubmissionSet submissionSet) {
         Submission baseCodeSubmission = submissionSet.getBaseCode();
         for (Submission currentSubmission : submissionSet.getSubmissions()) {
-            JPlagComparison baseCodeMatch = greedyStringTiling.compareWithBaseCode(currentSubmission, baseCodeSubmission);
-            currentSubmission.setBaseCodeMatch(baseCodeMatch);
+            JPlagComparison baseCodeComparison = greedyStringTiling.compareWithBaseCode(currentSubmission, baseCodeSubmission);
+            currentSubmission.setBaseCodeComparison(baseCodeComparison);
             baseCodeSubmission.resetBaseCode();
         }
     }
@@ -40,8 +40,8 @@ public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
         JPlagComparison comparison = greedyStringTiling.compare(first, second);
         System.out.println("Comparing " + first.getName() + "-" + second.getName() + ": " + comparison.similarity());
         if (withBaseCode) {
-            comparison.setFirstBaseCodeMatches(comparison.getFirstSubmission().getBaseCodeMatch());
-            comparison.setSecondBaseCodeMatches(comparison.getSecondSubmission().getBaseCodeMatch());
+            comparison.setFirstBaseCodeMatches(comparison.getFirstSubmission().getBaseCodeComparison());
+            comparison.setSecondBaseCodeMatches(comparison.getSecondSubmission().getBaseCodeComparison());
         }
         if (options.getSimilarityMetric().isAboveThreshold(comparison, options.getSimilarityThreshold())) {
             return Optional.of(comparison);

--- a/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
+++ b/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
@@ -1,6 +1,5 @@
 package de.jplag.strategy;
 
-import java.util.Hashtable;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,10 +9,6 @@ import de.jplag.Submission;
 import de.jplag.options.JPlagOptions;
 
 public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
-
-    // TODO PB: I think it's better to make each submission store its own matches with the base code.
-    // Hashtable that maps the name of a submissions to its matches with the provided base code.
-    private Hashtable<String, JPlagComparison> baseCodeMatches = new Hashtable<>(30);
 
     private GreedyStringTiling greedyStringTiling;
 
@@ -27,7 +22,7 @@ public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
     protected void compareSubmissionsToBaseCode(List<Submission> submissions, Submission baseCodeSubmission) {
         for (Submission currentSubmission : submissions) {
             JPlagComparison baseCodeMatch = greedyStringTiling.compareWithBaseCode(currentSubmission, baseCodeSubmission);
-            baseCodeMatches.put(currentSubmission.getName(), baseCodeMatch);
+            currentSubmission.setBaseCodeMatch(baseCodeMatch);
             baseCodeSubmission.resetBaseCode();
         }
     }
@@ -39,8 +34,8 @@ public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
         JPlagComparison comparison = greedyStringTiling.compare(first, second);
         System.out.println("Comparing " + first.getName() + "-" + second.getName() + ": " + comparison.similarity());
         if (withBaseCode) {
-            comparison.setFirstBaseCodeMatches(baseCodeMatches.get(comparison.getFirstSubmission().getName()));
-            comparison.setSecondBaseCodeMatches(baseCodeMatches.get(comparison.getSecondSubmission().getName()));
+            comparison.setFirstBaseCodeMatches(comparison.getFirstSubmission().getBaseCodeMatch());
+            comparison.setSecondBaseCodeMatches(comparison.getSecondSubmission().getBaseCodeMatch());
         }
         if (options.getSimilarityMetric().isAboveThreshold(comparison, options.getSimilarityThreshold())) {
             return Optional.of(comparison);


### PR DESCRIPTION
The submissions store their basecode matches internally.
closes #216