### PR TITLE
Clean comparison somewhat

### DIFF
--- a/jplag/src/main/java/de/jplag/JPlagComparison.java
+++ b/jplag/src/main/java/de/jplag/JPlagComparison.java
@@ -19,9 +19,6 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
     private final Submission firstSubmission;
     private final Submission secondSubmission;
 
-    private JPlagComparison firstBaseCodeMatches = null;
-    private JPlagComparison secondBaseCodeMatches = null;
-
     private final List<Match> matches;
 
     public JPlagComparison(Submission firstSubmission, Submission secondSubmission) {
@@ -98,7 +95,7 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      * @return the base code matches of the first submission.
      */
     public JPlagComparison getFirstBaseCodeMatches() {
-        return firstBaseCodeMatches;
+        return firstSubmission.getBaseCodeComparison();
     }
 
     /**
@@ -132,7 +129,7 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      * @return the base code matches of the second submissions.
      */
     public JPlagComparison getSecondBaseCodeMatches() {
-        return secondBaseCodeMatches;
+        return secondSubmission.getBaseCodeComparison();
     }
 
     /**
@@ -157,7 +154,7 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      * @return The requested basecode matches.
      */
     public JPlagComparison getBaseCodeMatches(boolean getFirst) {
-        return getFirst ? firstBaseCodeMatches : secondBaseCodeMatches;
+        return getSubmission(getFirst).getBaseCodeComparison();
     }
 
     /**
@@ -179,6 +176,8 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      */
     public final float similarity() {
         float sa, sb;
+        JPlagComparison firstBaseCodeMatches = firstSubmission.getBaseCodeComparison();
+        JPlagComparison secondBaseCodeMatches = secondSubmission.getBaseCodeComparison();
         if (secondBaseCodeMatches != null && firstBaseCodeMatches != null) {
             sa = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size() - firstBaseCodeMatches.getNumberOfMatchedTokens();
             sb = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size() - secondBaseCodeMatches.getNumberOfMatchedTokens();
@@ -195,6 +194,7 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      */
     public final float similarityOfFirst() {
         int divisor;
+        JPlagComparison firstBaseCodeMatches = firstSubmission.getBaseCodeComparison();
         if (firstBaseCodeMatches != null) {
             divisor = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size() - firstBaseCodeMatches.getNumberOfMatchedTokens();
         } else {
@@ -209,6 +209,7 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      */
     public final float similarityOfSecond() {
         int divisor;
+        JPlagComparison secondBaseCodeMatches = secondSubmission.getBaseCodeComparison();
         if (secondBaseCodeMatches != null) {
             divisor = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size() - secondBaseCodeMatches.getNumberOfMatchedTokens();
         } else {
@@ -239,20 +240,6 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
     }
 
     /**
-     * Sets the base code matches of the second submissions.
-     */
-    public void setFirstBaseCodeMatches(JPlagComparison firstBaseCodeMatches) {
-        this.firstBaseCodeMatches = firstBaseCodeMatches;
-    }
-
-    /**
-     * Sets the base code matches of the second submissions.
-     */
-    public void setSecondBaseCodeMatches(JPlagComparison secondBaseCodeMatches) {
-        this.secondBaseCodeMatches = secondBaseCodeMatches;
-    }
-
-    /**
      * Creates a permutation for the matches based on the indices of the matched token groups.
      * @param useFirst determines whether the start of the first or second submission is compared.
      * @return the permutation indices.
@@ -279,11 +266,13 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
 
     private final float firstBasecodeSimilarity() {
         float sa = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size();
+        JPlagComparison firstBaseCodeMatches = firstSubmission.getBaseCodeComparison();
         return firstBaseCodeMatches.getNumberOfMatchedTokens() * 100 / sa;
     }
 
     private final float secondBasecodeSimilarity() {
         float sb = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size();
+        JPlagComparison secondBaseCodeMatches = secondSubmission.getBaseCodeComparison();
         return secondBaseCodeMatches.getNumberOfMatchedTokens() * 100 / sb;
     }
 

--- a/jplag/src/main/java/de/jplag/JPlagComparison.java
+++ b/jplag/src/main/java/de/jplag/JPlagComparison.java
@@ -175,16 +175,9 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      * @return Similarity in percent (what percentage of tokens across both submissions are matched).
      */
     public final float similarity() {
-        float sa, sb;
-        JPlagComparison firstBaseCodeMatches = firstSubmission.getBaseCodeComparison();
-        JPlagComparison secondBaseCodeMatches = secondSubmission.getBaseCodeComparison();
-        if (secondBaseCodeMatches != null && firstBaseCodeMatches != null) {
-            sa = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size() - firstBaseCodeMatches.getNumberOfMatchedTokens();
-            sb = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size() - secondBaseCodeMatches.getNumberOfMatchedTokens();
-        } else {
-            sa = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size();
-            sb = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size();
-        }
+        boolean subtractBaseCode = firstSubmission.hasBaseCodeMatches() && secondSubmission.hasBaseCodeMatches();
+        float sa = firstSubmission.getSimilarityDivisor(subtractBaseCode);
+        float sb = secondSubmission.getSimilarityDivisor(subtractBaseCode);
         return (200 * getNumberOfMatchedTokens()) / (sa + sb);
     }
 
@@ -193,13 +186,7 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      * second).
      */
     public final float similarityOfFirst() {
-        int divisor;
-        JPlagComparison firstBaseCodeMatches = firstSubmission.getBaseCodeComparison();
-        if (firstBaseCodeMatches != null) {
-            divisor = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size() - firstBaseCodeMatches.getNumberOfMatchedTokens();
-        } else {
-            divisor = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size();
-        }
+        int divisor = firstSubmission.getSimilarityDivisor(true);
         return (divisor == 0 ? 0f : (getNumberOfMatchedTokens() * 100 / (float) divisor));
     }
 
@@ -208,13 +195,7 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
      * first).
      */
     public final float similarityOfSecond() {
-        int divisor;
-        JPlagComparison secondBaseCodeMatches = secondSubmission.getBaseCodeComparison();
-        if (secondBaseCodeMatches != null) {
-            divisor = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size() - secondBaseCodeMatches.getNumberOfMatchedTokens();
-        } else {
-            divisor = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size();
-        }
+        int divisor = secondSubmission.getSimilarityDivisor(true);
         return (divisor == 0 ? 0f : (getNumberOfMatchedTokens() * 100 / (float) divisor));
     }
 
@@ -275,5 +256,4 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
         JPlagComparison secondBaseCodeMatches = secondSubmission.getBaseCodeComparison();
         return secondBaseCodeMatches.getNumberOfMatchedTokens() * 100 / sb;
     }
-
 }

--- a/jplag/src/main/java/de/jplag/JPlagComparison.java
+++ b/jplag/src/main/java/de/jplag/JPlagComparison.java
@@ -246,13 +246,13 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
     }
 
     private final float firstBasecodeSimilarity() {
-        float sa = firstSubmission.getNumberOfTokens() - firstSubmission.getFiles().size();
+        float sa = firstSubmission.getSimilarityDivisor(false);
         JPlagComparison firstBaseCodeMatches = firstSubmission.getBaseCodeComparison();
         return firstBaseCodeMatches.getNumberOfMatchedTokens() * 100 / sa;
     }
 
     private final float secondBasecodeSimilarity() {
-        float sb = secondSubmission.getNumberOfTokens() - secondSubmission.getFiles().size();
+        float sb = secondSubmission.getSimilarityDivisor(false);
         JPlagComparison secondBaseCodeMatches = secondSubmission.getBaseCodeComparison();
         return secondBaseCodeMatches.getNumberOfMatchedTokens() * 100 / sb;
     }

--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -338,5 +338,4 @@ public class Submission implements Comparable<Submission> {
 
         return files.stream().map(File::toPath).map(baseFilePath::relativize).map(Path::toString).toArray(String[]::new);
     }
-
 }

--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -114,6 +114,24 @@ public class Submission implements Comparable<Submission> {
         return baseCodeComparison;
     }
 
+    /**
+     * @return Whether a comparison between the submission and the base code is available.
+     */
+    public boolean hasBaseCodeMatches() {
+        return baseCodeComparison != null;
+    }
+
+    /**
+     * @param subtractBaseCode If true subtract basecode matches if possible.
+     * @return Similarity divisor for the submission.
+     */
+    public int getSimilarityDivisor(boolean subtractBaseCode) {
+        int divisor = getNumberOfTokens() - getFiles().size();
+        if (subtractBaseCode && baseCodeComparison != null) {
+            divisor -= baseCodeComparison.getNumberOfMatchedTokens();
+        }
+        return divisor;
+    }
 
     /**
      * @return Parse result of the submission.

--- a/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
+++ b/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
@@ -39,14 +39,10 @@ public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
     protected Optional<JPlagComparison> compareSubmissions(Submission first, Submission second, boolean withBaseCode) {
         JPlagComparison comparison = greedyStringTiling.compare(first, second);
         System.out.println("Comparing " + first.getName() + "-" + second.getName() + ": " + comparison.similarity());
-        if (withBaseCode) {
-            comparison.setFirstBaseCodeMatches(comparison.getFirstSubmission().getBaseCodeComparison());
-            comparison.setSecondBaseCodeMatches(comparison.getSecondSubmission().getBaseCodeComparison());
-        }
+
         if (options.getSimilarityMetric().isAboveThreshold(comparison, options.getSimilarityThreshold())) {
             return Optional.of(comparison);
         }
         return Optional.empty();
     }
-
 }


### PR DESCRIPTION
Eliminated the hashmap in the abstract comparison strategy base class as suggested, and moved similarity divisor computing as well. 

_Maintainer edit: Resolves #198_