### PR TITLE
Cleaning up rootdir checking and subdir sanity

### DIFF
--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -87,7 +87,6 @@ public class JPlag {
                             ExitException.BAD_PARAMETER);
                 }
             }
-            options.setBaseCodeSubmissionName(baseCode);
             System.out.println("Basecode directory \"" + baseCodePath + "\" will be used");
         }
     }

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -51,7 +51,7 @@ public class JPlag {
         if (!rootDir.isDirectory()) {
             throw new ExitException(options.getRootDirectoryName() + " is not a directory!");
         }
-        
+
         // 2. Parse and validate submissions:
         SubmissionSetBuilder builder = new SubmissionSetBuilder(language, options, errorCollector);
         SubmissionSet submissionSet = builder.buildSubmissionSet(rootDir);
@@ -72,14 +72,6 @@ public class JPlag {
         System.out.println("Total time for comparing submissions: " + TimeUtil.formatDuration(result.getDuration()));
         return result;
     }
-
-    /**
-     * @return the configured language in which the submissions are written.
-     */
-    public Language getLanguage() {
-        return language;
-    }
-
 
     /**
      * This method checks whether the base code directory value is valid.
@@ -142,8 +134,8 @@ public class JPlag {
             throw new ExitException("Language instantiation failed", ExitException.BAD_LANGUAGE_ERROR);
         }
 
-        this.options.setLanguageDefaults(this.getLanguage());
+        this.options.setLanguageDefaults(this.language);
 
-        System.out.println("Initialized language " + this.getLanguage().getName());
+        System.out.println("Initialized language " + this.language.getName());
     }
 }

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -71,7 +71,7 @@ public class JPlag {
         getRootDirectory(); // Performs checks on the root directory.
 
         if (options.hasBaseCode()) {
-            String baseCode = options.getBaseCodeSubmissionName().replace(File.separator, ""); // trim problematic file separators
+            String baseCode = options.getBaseCodeSubmissionName();
             if (baseCode.contains(".")) {
                 throw new ExitException("The basecode directory name \"" + baseCode + "\" cannot contain dots!", ExitException.BAD_PARAMETER);
             }

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -43,18 +43,9 @@ public class JPlag {
      * @throws ExitException if the JPlag exits preemptively.
      */
     public JPlagResult run() throws ExitException {
-        // 1. Preparation:
-        File rootDir = new File(options.getRootDirectoryName());
-        if (!rootDir.exists()) {
-            throw new ExitException("Root directory " + options.getRootDirectoryName() + " does not exist!");
-        }
-        if (!rootDir.isDirectory()) {
-            throw new ExitException(options.getRootDirectoryName() + " is not a directory!");
-        }
-
-        // 2. Parse and validate submissions:
+        // Parse and validate submissions.
         SubmissionSetBuilder builder = new SubmissionSetBuilder(language, options, errorCollector);
-        SubmissionSet submissionSet = builder.buildSubmissionSet(rootDir);
+        SubmissionSet submissionSet = builder.buildSubmissionSet(getRootDirectory());
 
         if (submissionSet.hasBaseCode()) {
             coreAlgorithm.createHashes(submissionSet.getBaseCode().getTokenList(), options.getMinimumTokenMatch(), true);
@@ -67,7 +58,7 @@ public class JPlag {
                     ExitException.NOT_ENOUGH_SUBMISSIONS_ERROR);
         }
 
-        // 3. Compare valid submissions:
+        // Compare valid submissions.
         JPlagResult result = comparisonStrategy.compareSubmissions(submissionSet);
         System.out.println("Total time for comparing submissions: " + TimeUtil.formatDuration(result.getDuration()));
         return result;
@@ -77,11 +68,9 @@ public class JPlag {
      * This method checks whether the base code directory value is valid.
      */
     private void checkBaseCodeOption() throws ExitException {
-        if (options.hasBaseCode()) {
-            if (!new File(options.getRootDirectoryName()).exists()) {
-                throw new ExitException("Root directory \"" + options.getRootDirectoryName() + "\" doesn't exist!", ExitException.BAD_PARAMETER);
-            }
+        getRootDirectory(); // Performs checks on the root directory.
 
+        if (options.hasBaseCode()) {
             String baseCode = options.getBaseCodeSubmissionName().replace(File.separator, ""); // trim problematic file separators
             if (baseCode.contains(".")) {
                 throw new ExitException("The basecode directory name \"" + baseCode + "\" cannot contain dots!", ExitException.BAD_PARAMETER);
@@ -101,6 +90,23 @@ public class JPlag {
             options.setBaseCodeSubmissionName(baseCode);
             System.out.println("Basecode directory \"" + baseCodePath + "\" will be used");
         }
+    }
+
+    /**
+     * Check sanity of the root directory name in the options, and construct file system access to it.
+     */
+    private File getRootDirectory() throws ExitException {
+        String rootDirectoryName = options.getRootDirectoryName();
+        File rootDir = new File(rootDirectoryName);
+        if (!rootDir.exists()) {
+            String msg = String.format("Root directory \"%s\" does not exist!", rootDirectoryName);
+            throw new ExitException(msg, ExitException.BAD_PARAMETER);
+        }
+        if (!rootDir.isDirectory()) {
+            String msg = String.format("Root directory \"%s\" is not a directory!", rootDirectoryName);
+            throw new ExitException(msg, ExitException.BAD_PARAMETER);
+        }
+        return rootDir;
     }
 
     private void initializeComparisonStrategy() throws ExitException {

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -223,7 +223,7 @@ public class JPlagOptions {
     }
 
     public void setSubdirectoryName(String subdirectoryName) {
-        this.subdirectoryName = subdirectoryName;
+        this.subdirectoryName = subdirectoryName.replace(File.separator, ""); // Trim problematic file separators.
     }
 
     public void setLanguageOption(LanguageOption languageOption) {

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -2,6 +2,7 @@ package de.jplag.options;
 
 import static de.jplag.strategy.ComparisonMode.NORMAL;
 
+import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -218,7 +219,7 @@ public class JPlagOptions {
     }
 
     public void setBaseCodeSubmissionName(String baseCodeSubmissionName) {
-        this.baseCodeSubmissionName = baseCodeSubmissionName;
+        this.baseCodeSubmissionName = baseCodeSubmissionName.replace(File.separator, ""); // Trim problematic file separators.
     }
 
     public void setSubdirectoryName(String subdirectoryName) {

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -219,11 +219,13 @@ public class JPlagOptions {
     }
 
     public void setBaseCodeSubmissionName(String baseCodeSubmissionName) {
-        this.baseCodeSubmissionName = baseCodeSubmissionName.replace(File.separator, ""); // Trim problematic file separators.
+        // Trim problematic file separators.
+        this.baseCodeSubmissionName = (baseCodeSubmissionName == null) ? null : baseCodeSubmissionName.replace(File.separator, "");
     }
 
     public void setSubdirectoryName(String subdirectoryName) {
-        this.subdirectoryName = subdirectoryName.replace(File.separator, ""); // Trim problematic file separators.
+        // Trim problematic file separators.
+        this.subdirectoryName = (subdirectoryName == null) ? null : subdirectoryName.replace(File.separator, "");
     }
 
     public void setLanguageOption(LanguageOption languageOption) {


### PR DESCRIPTION
ADDED:

- `JPlag.getLanguage()` was now the only place where it was used, and asking for a variable of its own instance variable through a public method is a bit weird then, so I deleted the function (Perhaps a left-over from not deriving from `Program` any more?)
- Root directory sanity was checked at several places in different ways which begs for unitfication.
- Basecode option value got sneakily changed while checking sanity of supplied values. Changing it inside the `Options` is more robust.
- I saw the  subdirectory too there, and just added that change there too, as somewhere an equality test against a directory name from the file system is performed so any directory-separators in the name won't do any good.

I forgot to run the tests, and promptly the patch was rejected, as the above names can be `null` since they are optional.