### PR TITLE
Use generic List interface as declared type instead of ArrayList

### DIFF
--- a/jplag.frontend-utils/src/main/java/de/jplag/TokenHashMap.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/TokenHashMap.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * that is larger or equal to the specified size (see {@link TokenHashMap#Table(int)}).
  */
 public class TokenHashMap {
-    private final Map<Integer, ArrayList<Integer>> mappedEntries;
+    private final Map<Integer, List<Integer>> mappedEntries;
     private final int primeNumber;
 
     /**
@@ -50,7 +50,7 @@ public class TokenHashMap {
         if (mappedEntries.containsKey(actualKey)) {
             mappedEntries.get(actualKey).add(value);
         } else {
-            ArrayList<Integer> entries = new ArrayList<>();
+            List<Integer> entries = new ArrayList<>();
             entries.add(value);
             mappedEntries.put(actualKey, entries);
         }

--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import de.jplag.options.JPlagOptions;
 
@@ -184,7 +185,7 @@ public class Submission implements Comparable<Submission> {
     public String[][] readFiles(String[] files) throws de.jplag.ExitException {
         String[][] result = new String[files.length][];
         String help;
-        ArrayList<String> text = new ArrayList<>();
+        List<String> text = new ArrayList<>();
 
         for (int i = 0; i < files.length; i++) {
             text.clear();

--- a/jplag/src/main/java/de/jplag/reporting/Report.java
+++ b/jplag/src/main/java/de/jplag/reporting/Report.java
@@ -332,7 +332,7 @@ public class Report { // Mostly legacy code with some minor improvements.
             String tmp = text[markup.fileIndex][markup.lineIndex];
             // is there any &quot;, &amp;, &gt; or &lt; in the String?
             if (tmp.indexOf('&') >= 0) {
-                ArrayList<String> tmpV = new ArrayList<>();
+                List<String> tmpV = new ArrayList<>();
                 // convert the string into a vector
                 int strLength = tmp.length();
                 for (int k = 0; k < strLength; k++) {


### PR DESCRIPTION
Cleaning up usage of lists.

First commit replaces use of `ArrayList` in a type instead of the `List` interface.
I noted that `SubmissionSetBuilder.parseFilesRecursively(File file)` returns a more generic `Collection<File>` type instead of a list. Not sure why but I left it untouched. This commit is probably fully acceptable.

Second commit introduces a few small almost-wrapper list functions, and uses them. I think it improves the code but I am used to this style of code :) 
I can live without this change.

Obviously you can extend the idea to other areas in the code to reduce clutter. (I have one for assertion checking too, it's barely used currently, as the `ExitException` isn't entirely clear what it covers (end-user errors or developer-oriented errors).