### PR TITLE
Fix NPE on basecode run with empty submission folder.

### DIFF
--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -154,6 +154,8 @@ public class Submission implements Comparable<Submission> {
     public boolean parse(boolean debugParser) {
         if (files == null || files.size() == 0) {
             errorCollector.print("ERROR: nothing to parse for submission \"" + name, null);
+            tokenList = null;
+            hasErrors = true; // invalidate submission
             return false;
         }
 

--- a/jplag/src/test/java/de/jplag/BaseCodeTest.java
+++ b/jplag/src/test/java/de/jplag/BaseCodeTest.java
@@ -15,6 +15,12 @@ public class BaseCodeTest extends TestBase {
     }
 
     @Test
+    public void testEmptySubmission() throws ExitException {
+        JPlagResult result = runJPlag("emptysubmission", it -> it.setBaseCodeSubmissionName("base"));
+        verifyResults(result);
+    }
+
+    @Test
     public void testAutoTrimFileSeparators() throws ExitException {
         JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName(File.separator + "base" + File.separator));
         verifyResults(result);

--- a/jplag/src/test/resources/de/jplag/samples/emptysubmission/A/TerrainType.java
+++ b/jplag/src/test/resources/de/jplag/samples/emptysubmission/A/TerrainType.java
@@ -1,0 +1,27 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ * @author Timur Saglam
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(0) + toString().substring(1).toLowerCase();
+    }
+}

--- a/jplag/src/test/resources/de/jplag/samples/emptysubmission/B/TerrainType.java
+++ b/jplag/src/test/resources/de/jplag/samples/emptysubmission/B/TerrainType.java
@@ -1,0 +1,30 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ * @author Mean Plagiarizer
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+    private static final int CONST_0 = 0;
+    private static final int CONST_1 = 1;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(CONST_0) + toString().substring(CONST_1).toLowerCase();
+    }
+}

--- a/jplag/src/test/resources/de/jplag/samples/emptysubmission/base/TerrainType.java
+++ b/jplag/src/test/resources/de/jplag/samples/emptysubmission/base/TerrainType.java
@@ -1,0 +1,12 @@
+package carcassonne.model.terrain;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+}

--- a/jplag/src/test/resources/de/jplag/samples/emptysubmission/empty/not_a_source.file
+++ b/jplag/src/test/resources/de/jplag/samples/emptysubmission/empty/not_a_source.file
@@ -1,0 +1,1 @@
+Non-source file


### PR DESCRIPTION
See below the explanation for the testcase output crashing after I removed the fix in `Submission.java`.

There is one empty submission folder in the root directory (containing only a non-source file for git)
The case is a copy of the `basecode` tree, except for the additional `empty` sub directory.

It is correctly seen as not a submission ("nothing to parse"), but the submission is not flagged as error, and thus survives the filter. In the comparison code, the basecode comparison doesn't check for `null` token lists, and crashes on an NPE.

A non-basecode run works because the strategies do explicit checking on non-null token lists before attempting comparisons.


``` text
Initialized language Javac 1.9+ based AST plugin
Basecode directory "src/test/resources/de/jplag/samples/emptysubmission/base" will be used
------ Parsing submission: A
OK
------ Parsing submission: B
OK
------ Parsing submission: empty
ERROR: nothing to parse for submission "empty
ERROR -> Submission removed
2 submissions parsed successfully!
1 parser error!
0 too short submissions!
Total time for parsing: 0 sec
Time per parsed submission: 5 msec

----- Parsing basecode submission: base
Basecode submission parsed!
Time for parsing Basecode: 0 sec
Initialized language Javac 1.9+ based AST plugin
Initialized language Javac 1.9+ based AST plugin
Basecode directory "src/test/resources/de/jplag/samples/basecode/base" will be used
------ Parsing submission: A
OK
------ Parsing submission: B
OK
2 submissions parsed successfully!
0 parser errors!
0 too short submissions!
Total time for parsing: 0 sec
Time per parsed submission: 8 msec

----- Parsing basecode submission: base
Basecode submission parsed!
Time for parsing Basecode: 0 sec
Comparing A-B: 85.0

Total time for comparing submissions: 0 sec
Initialized language Javac 1.9+ based AST plugin
Tests run: 6, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.113 sec <<< FAILURE!
testEmptySubmission(de.jplag.BaseCodeTest)  Time elapsed: 0.038 sec  <<< ERROR!
java.lang.NullPointerException
	at de.jplag.GreedyStringTiling.swapAndCompare(GreedyStringTiling.java:99)
	at de.jplag.GreedyStringTiling.compareWithBaseCode(GreedyStringTiling.java:94)
	at de.jplag.strategy.AbstractComparisonStrategy.compareSubmissionsToBaseCode(AbstractComparisonStrategy.java:30)
	at de.jplag.strategy.NormalComparisonStrategy.compareSubmissions(NormalComparisonStrategy.java:23)
	at de.jplag.JPlag.run(JPlag.java:61)
	at de.jplag.TestBase.runJPlag(TestBase.java:34)
	at de.jplag.BaseCodeTest.testEmptySubmission(BaseCodeTest.java:19)
        ...
```