### PR TITLE
Fix wrong error message when basecode smaller than min token match

### DIFF
--- a/jplag/src/main/java/de/jplag/SubmissionSet.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSet.java
@@ -102,11 +102,8 @@ public class SubmissionSet {
             if (baseCodeSubmission.isPresent()) {
                 parseBaseCodeSubmission(baseCodeSubmission.get()); // cannot use ifPresent because of throws declaration
             }
-        } catch (OutOfMemoryError e) {
+        } catch (OutOfMemoryError exception) {
             throw new ExitException("Out of memory during parsing of submission \"" + currentSubmissionName + "\"");
-        } catch (Throwable e) {
-            e.printStackTrace();
-            throw new ExitException("Unknown exception during parsing of " + "submission \"" + currentSubmissionName + "\"");
         }
         if (errorCollector.hasErrors()) {
             errorCollector.printCollectedErrors();
@@ -122,8 +119,7 @@ public class SubmissionSet {
         if (!baseCode.parse(options.isDebugParser())) {
             errorCollector.printCollectedErrors();
             throw new ExitException("Bad basecode submission");
-        }
-        if (baseCode.getTokenList() != null && baseCode.getNumberOfTokens() < options.getMinimumTokenMatch()) {
+        } else if (baseCode.getNumberOfTokens() < options.getMinimumTokenMatch()) {
             throw new ExitException("Basecode submission contains fewer tokens than minimum match length allows!");
         }
         errorCollector.print("Basecode submission parsed!", null);

--- a/jplag/src/test/java/de/jplag/BaseCodeTest.java
+++ b/jplag/src/test/java/de/jplag/BaseCodeTest.java
@@ -13,6 +13,11 @@ public class BaseCodeTest extends TestBase {
         JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName("base"));
         verifyResults(result);
     }
+    
+    @Test(expected = ExitException.class)
+    public void testTinyBasecode() throws ExitException {
+        runJPlag("TinyBasecode", it -> it.setBaseCodeSubmissionName("base"));
+    }
 
     @Test
     public void testEmptySubmission() throws ExitException {

--- a/jplag/src/test/resources/de/jplag/samples/TinyBasecode/A/TerrainType.java
+++ b/jplag/src/test/resources/de/jplag/samples/TinyBasecode/A/TerrainType.java
@@ -1,0 +1,27 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ * @author Timur Saglam
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(0) + toString().substring(1).toLowerCase();
+    }
+}

--- a/jplag/src/test/resources/de/jplag/samples/TinyBasecode/B/TerrainType.java
+++ b/jplag/src/test/resources/de/jplag/samples/TinyBasecode/B/TerrainType.java
@@ -1,0 +1,30 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ * @author Mean Plagiarizer
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+    private static final int CONST_0 = 0;
+    private static final int CONST_1 = 1;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(CONST_0) + toString().substring(CONST_1).toLowerCase();
+    }
+}

--- a/jplag/src/test/resources/de/jplag/samples/TinyBasecode/base/TerrainType.java
+++ b/jplag/src/test/resources/de/jplag/samples/TinyBasecode/base/TerrainType.java
@@ -1,0 +1,7 @@
+package carcassonne.model.terrain;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ */
+public enum TerrainType {
+}


### PR DESCRIPTION
- Fix a bug where basecode smaller than the minimum token match does not lead to a descriptive error message.
- Add a corresponding test case to ensure an exception is thrown

_Note that tiny basecodes will not work due to the fact how the similarity calculation is implemented. Even when removing the check that throws the exit exception, the results of the comparison will be as if no basecode was used at all. This issue is documented in #161._