### PR TITLE
Add global basecode option

### DIFF
--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -13,7 +13,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import de.jplag.exceptions.ExitException;
 import de.jplag.exceptions.ReportGenerationException;
+import de.jplag.exceptions.SubmissionException;
 import de.jplag.options.JPlagOptions;
 
 /**
@@ -86,6 +88,18 @@ public class Submission implements Comparable<Submission> {
      */
     public String getName() {
         return name;
+    }
+
+    public File getRoot() {
+        return submissionRoot;
+    }
+
+    public File getCanonicalRoot() throws ExitException {
+        try {
+            return submissionRoot.getCanonicalFile();
+        } catch (IOException e) {
+            throw new SubmissionException(String.format("Cannot compute canonical file path of \"%s\".", submissionRoot.toString()));
+        }
     }
 
     /**
@@ -300,11 +314,11 @@ public class Submission implements Comparable<Submission> {
             }
         }
     }
-    
+
     private File createSubdirectory(File parent, String... subdirectoryNames) {
         File subdirectory = parent;
         for (String name : subdirectoryNames) {
-            subdirectory = new File(subdirectory, name); 
+            subdirectory = new File(subdirectory, name);
         }
         if (!subdirectory.exists()) {
             subdirectory.mkdirs();

--- a/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -59,7 +59,7 @@ public class SubmissionSetBuilder {
         // Extract the basecode submission if necessary.
         Optional<Submission> baseCodeSubmission = Optional.empty();
         if (options.hasBaseCode()) {
-            Submission baseCode = tryLoadBaseCodeAsPath(rootDirectory);
+            Submission baseCode = tryLoadBaseCodeAsPath();
             if (baseCode == null) {
                 baseCode = tryLoadBaseCodeAsRootSubDirectory(foundSubmissions);
 
@@ -113,9 +113,9 @@ public class SubmissionSetBuilder {
      * @return Base code submission if the option value can be interpreted as global path, else {@code null}.
      * @throws ExitException when the option value is a path with errors.
      */
-    private Submission tryLoadBaseCodeAsPath(File rootDirectory) throws ExitException {
+    private Submission tryLoadBaseCodeAsPath() throws ExitException {
         String baseCodeName = options.getBaseCodeSubmissionName().get();
-        File basecodeSubmission = new File(rootDirectory, baseCodeName);
+        File basecodeSubmission = new File(baseCodeName);
         if (!basecodeSubmission.exists()) {
             return null;
         }

--- a/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -70,7 +70,7 @@ public class SubmissionSetBuilder {
                             String.format("Basecode path \"%s\" relative to the working directory could not be found.", baseCodeName));
                 } else {
                     // Found a base code as a submission, report about obsolete usage.
-                    System.out.printf("Deprecated use of the -bc option found, please specify the basecode as \"%s%c%s\" instead.",
+                    System.out.printf("Deprecated use of the -bc option found, please specify the basecode as \"%s%s%s\" instead.\n",
                             rootDirectory.toString(), File.separator, baseCodeName);
                 }
             }
@@ -153,7 +153,7 @@ public class SubmissionSetBuilder {
         }
 
         // Grab the basecode submission from the regular submissions.
-        return foundSubmissions.get(baseCodeName);
+        return foundSubmissions.get(name);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -79,11 +79,11 @@ public class SubmissionSetBuilder {
 
             // Basecode may also be registered as a user submission. If so, remove the latter.
             File baseCodeRoot = baseCode.getCanonicalRoot(); // Use canonical form for a more sane equality notion.
-            Iterator<Entry<String, Submission>> submIter = foundSubmissions.entrySet().iterator();
-            while (submIter.hasNext()) {
-                Entry<String, Submission> entry = submIter.next();
+            Iterator<Entry<String, Submission>> submissionIterator = foundSubmissions.entrySet().iterator();
+            while (submissionIterator.hasNext()) {
+                Entry<String, Submission> entry = submissionIterator.next();
                 if (baseCodeRoot.equals(entry.getValue().getCanonicalRoot())) {
-                    submIter.remove();
+                    submissionIterator.remove();
                     System.out.println(String.format("Skipping \"%s\" as user submission.", entry.getValue().getRoot().toString()));
                     break;
                 }
@@ -145,8 +145,16 @@ public class SubmissionSetBuilder {
         String baseCodeName = options.getBaseCodeSubmissionName().get();
 
         // Is the option value a single name after trimming spurious separators?
-        String name = trimLeft(trimRight(baseCodeName, File.separatorChar), File.separatorChar);
-        if (name.contains(File.separator)) return null; // Not a single name, cannot be a sub-directory.
+        String name = baseCodeName;
+        while (name.startsWith(File.separator)) {
+            name = name.substring(1);
+        }
+        while (name.endsWith(File.separator)) {
+            name = name.substring(0, name.length() - 1);
+        }
+
+        // If it is not a name of a single sub-directory, bail out.
+        if (name.isEmpty() || name.contains(File.separator)) return null;
 
         if (name.contains(".")) {
             throw new BasecodeException("The basecode directory name \"" + name + "\" cannot contain dots!");
@@ -154,30 +162,6 @@ public class SubmissionSetBuilder {
 
         // Grab the basecode submission from the regular submissions.
         return foundSubmissions.get(name);
-    }
-
-    /**
-     * Trim characters k from the left of the string.
-     */
-    private String trimLeft(String s, char k) {
-        int i = 0;
-        while (i < s.length() && s.charAt(i) == k) {
-            i++;
-        }
-        if (i == 0) return s;
-        return s.substring(i);
-    }
-
-    /**
-     * Trim characters k from the right of the string.
-     */
-    private String trimRight(String s, char k) {
-        int i = s.length() - 1;
-        while (i >= 0 && s.charAt(i) == k) {
-            i--;
-        }
-        if (i == s.length() - 1) return s;
-        return s.substring(0, i + 1);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 import de.jplag.Language;
@@ -70,7 +71,7 @@ public class JPlagOptions {
      * Name of the file that contains the names of files to exclude from comparison.
      */
     private String exclusionFileName;
-    
+
     /**
      * Names of the excluded files.
      */
@@ -82,9 +83,19 @@ public class JPlagOptions {
     private String rootDirectoryName;
 
     /**
-     * Name of the directory which contains the base code.
+     * Path name of the directory containing the base code.
+     * <p>
+     * For backwards compatibility it may also be a directory name inside the root directory.
+     * Condition for the latter is
+     * <ul><li>Specified path does not exist.</li>
+     *     <li>Name has not have a separator character after trimming them from both ends (leaving at least a one-character name).</li>
+     *     <li>A submission with the specified name exists in the root directory.</li>
+     * </ul>
+     * It's an error if a string has been provided but it is neither an existing path nor does it fulfill all the
+     * conditions of the compatibility fallback listed above.
+     * </p>
      */
-    private String baseCodeSubmissionName;
+    private Optional<String> baseCodeSubmissionName = Optional.empty();
 
     /**
      * Example: If the subdirectoryName is 'src', only the code inside submissionDir/src of each submission will be used for
@@ -110,7 +121,7 @@ public class JPlagOptions {
         this.languageOption = languageOption;
     }
 
-    public String getBaseCodeSubmissionName() {
+    public Optional<String> getBaseCodeSubmissionName() {
         return baseCodeSubmissionName;
     }
 
@@ -167,7 +178,7 @@ public class JPlagOptions {
     }
 
     public boolean hasBaseCode() {
-        return this.baseCodeSubmissionName != null;
+        return this.baseCodeSubmissionName.isPresent();
     }
 
     public boolean isDebugParser() {
@@ -175,8 +186,11 @@ public class JPlagOptions {
     }
 
     public void setBaseCodeSubmissionName(String baseCodeSubmissionName) {
-        // Trim problematic file separators.
-        this.baseCodeSubmissionName = (baseCodeSubmissionName == null) ? null : baseCodeSubmissionName.replace(File.separator, "");
+        if (baseCodeSubmissionName == null || baseCodeSubmissionName.isEmpty()) {
+            this.baseCodeSubmissionName = Optional.empty();
+        } else {
+            this.baseCodeSubmissionName = Optional.of(baseCodeSubmissionName);
+        }
     }
 
     public void setComparisonMode(ComparisonMode comparisonMode) {

--- a/jplag/src/main/java/de/jplag/reporting/Report.java
+++ b/jplag/src/main/java/de/jplag/reporting/Report.java
@@ -161,7 +161,7 @@ public class Report { // Mostly legacy code with some minor improvements.
                     + "',3)\" NAME=\"" + i + "\">");
             htmlFile.print(new String(startA.file.getBytes()));
 
-            if (result.getOptions().getLanguage().usesIndex()) {
+            if (options.getLanguage().usesIndex()) {
                 htmlFile.print("(" + startA.getIndex() + "-" + endA.getIndex() + ")");
             } else {
                 htmlFile.print("(" + startA.getLine() + "-" + endA.getLine() + ")");
@@ -171,7 +171,7 @@ public class Report { // Mostly legacy code with some minor improvements.
                     + "',3)\" NAME=\"" + i + "\">");
             htmlFile.print(startB.file);
 
-            if (result.getOptions().getLanguage().usesIndex()) {
+            if (options.getLanguage().usesIndex()) {
                 htmlFile.print("(" + startB.getIndex() + "-" + endB.getIndex());
             } else {
                 htmlFile.print("(" + startB.getLine() + "-" + endB.getLine());
@@ -181,7 +181,7 @@ public class Report { // Mostly legacy code with some minor improvements.
                     ")</A><TD ALIGN=center>" + "<FONT COLOR=\"" + comparison.color(match.getLength()) + "\">" + match.getLength() + "</FONT>");
         }
 
-        if (result.getOptions().hasBaseCode()) {
+        if (options.hasBaseCode()) {
             htmlFile.print(
                     "<TR><TD BGCOLOR=\"#C0C0C0\"><TD>" + msg.getString("AllMatches.Basecode") + " " + comparison.basecodeSimilarityOfFirst() + "%");
             htmlFile.println("<TD>" + msg.getString("AllMatches.Basecode") + " " + comparison.basecodeSimilarityOfSecond() + "%<TD>&nbsp;");
@@ -306,7 +306,7 @@ public class Report { // Mostly legacy code with some minor improvements.
             }
         }
 
-        if (result.getOptions().hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
+        if (options.hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
             JPlagComparison baseCodeComparison = comparison.getBaseCodeMatches(j == 0);
 
             for (Match match : baseCodeComparison.getMatches()) {
@@ -386,18 +386,18 @@ public class Report { // Mostly legacy code with some minor improvements.
             f.println("</center>");
             f.println("</h3>");
             f.println("<HR>");
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (options.getLanguage().isPreformatted()) {
                 f.println("<PRE>");
             }
             for (int y = 0; y < text[x].length; y++) {
                 f.print(text[x][y]);
-                if (!result.getOptions().getLanguage().isPreformatted()) {
+                if (!options.getLanguage().isPreformatted()) {
                     f.println("<BR>");
                 } else {
                     f.println();
                 }
             }
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (options.getLanguage().isPreformatted()) {
                 f.println("</PRE>");
             }
         }
@@ -437,20 +437,20 @@ public class Report { // Mostly legacy code with some minor improvements.
         htmlFile.println("<TD><H1><BIG>" + title + "</BIG></H1></TD></TR>");
 
         htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Language") + ":</TD><TD>"
-                + result.getOptions().getLanguageOption().name() + "</TD></TR>");
+                + options.getLanguageOption().name() + "</TD></TR>");
         htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Submissions") + ":</TD><TD>" + result.getNumberOfSubmissions());
 
         htmlFile.println("</TD></TR>");
 
-        if (result.getOptions().hasBaseCode()) {
+        if (options.hasBaseCode()) {
             htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Basecode_submission") + ":</TD>" + "<TD>"
-                    + result.getOptions().getBaseCodeSubmissionName() + "</TD></TR>");
+                    + options.getBaseCodeSubmissionName() + "</TD></TR>");
         }
 
         if (options.getMaximumNumberOfComparisons() > 0) {
             htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Matches_displayed") + ":</TD>" + "<TD>");
             htmlFile.println(options.getMaximumNumberOfComparisons() + " of " + result.getComparisons().size() + " ("
-                    + msg.getString("Report.Treshold") + ": " + result.getOptions().getSimilarityThreshold() + "%)<br>");
+                    + msg.getString("Report.Treshold") + ": " + options.getSimilarityThreshold() + "%)<br>");
 
             htmlFile.println("</TD></TR>");
         }
@@ -460,10 +460,10 @@ public class Report { // Mostly legacy code with some minor improvements.
         htmlFile.println(
                 "<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Date") + ":</TD><TD>" + dateFormat.format(new Date()) + "</TD></TR>");
         htmlFile.println("<TR BGCOLOR=#aaaaff>" + "<TD><EM>" + msg.getString("Report.Minimum_Match_Length") + "</EM> ("
-                + msg.getString("Report.sensitivity") + "):</TD><TD>" + result.getOptions().getMinimumTokenMatch() + "</TD></TR>");
+                + msg.getString("Report.sensitivity") + "):</TD><TD>" + options.getMinimumTokenMatch() + "</TD></TR>");
         htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Suffixes") + ":</TD><TD>");
 
-        String[] fileSuffixes = result.getOptions().getFileSuffixes();
+        String[] fileSuffixes = options.getFileSuffixes();
 
         for (int i = 0; i < fileSuffixes.length; i++) {
             htmlFile.print(fileSuffixes[i] + (i < fileSuffixes.length - 1 ? ", " : "</TD></TR>\n"));
@@ -619,10 +619,10 @@ public class Report { // Mostly legacy code with some minor improvements.
 
         htmlFile.println("  <div style=\"display: flex;\">");
 
-        if (result.getOptions().getLanguage().usesIndex()) {
+        if (options.getLanguage().usesIndex()) {
             writeIndexedSubmission(htmlFile, i, comparison, 0);
             writeIndexedSubmission(htmlFile, i, comparison, 1);
-        } else if (result.getOptions().getLanguage().supportsColumns()) {
+        } else if (options.getLanguage().supportsColumns()) {
             writeImprovedSubmission(htmlFile, i, comparison, 0);
             writeImprovedSubmission(htmlFile, i, comparison, 1);
         } else {
@@ -723,7 +723,7 @@ public class Report { // Mostly legacy code with some minor improvements.
             }
         }
 
-        if (result.getOptions().hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
+        if (options.hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
             JPlagComparison baseCodeComparison = comparison.getBaseCodeMatches(j == 0);
 
             for (Match currentMatch : baseCodeComparison.getMatches()) {
@@ -763,18 +763,18 @@ public class Report { // Mostly legacy code with some minor improvements.
             f.println("</center>");
             f.println("</h3>");
             f.println("<HR>");
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (options.getLanguage().isPreformatted()) {
                 f.println("<PRE>");
             }
             for (int y = 0; y < text[x].length; y++) {
                 f.print(text[x][y]);
-                if (!result.getOptions().getLanguage().isPreformatted()) {
+                if (!options.getLanguage().isPreformatted()) {
                     f.println("<BR>");
                 } else {
                     f.println();
                 }
             }
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (options.getLanguage().isPreformatted()) {
                 f.println("</PRE>");
             }
         }

--- a/jplag/src/main/java/de/jplag/reporting/Report.java
+++ b/jplag/src/main/java/de/jplag/reporting/Report.java
@@ -444,7 +444,7 @@ public class Report { // Mostly legacy code with some minor improvements.
 
         if (options.hasBaseCode()) {
             htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Basecode_submission") + ":</TD>" + "<TD>"
-                    + options.getBaseCodeSubmissionName() + "</TD></TR>");
+                    + options.getBaseCodeSubmissionName().get() + "</TD></TR>");
         }
 
         if (options.getMaximumNumberOfComparisons() > 0) {

--- a/jplag/src/main/resources/de/jplag/messages.properties
+++ b/jplag/src/main/resources/de/jplag/messages.properties
@@ -1,4 +1,4 @@
-CommandLineArgument.BaseCode=Name of the subdirectory of the root directory which contains the base code (common framework used in all submissions)
+CommandLineArgument.BaseCode=Path of the directory containing the base code (common framework used in all submissions)
 CommandLineArgument.ComparisonMode=Comparison mode used to compare the programs
 CommandLineArgument.Debug=Debug parser. Non-parsable files will be stored
 CommandLineArgument.Suffixes=comma-separated list of all filename suffixes that are included

--- a/jplag/src/test/java/de/jplag/BaseCodeTest.java
+++ b/jplag/src/test/java/de/jplag/BaseCodeTest.java
@@ -13,11 +13,11 @@ import de.jplag.exceptions.RootDirectoryException;
 public class BaseCodeTest extends TestBase {
 
     @Test
-    public void testBasecodeComparison() throws ExitException {
+    public void testBasecodeUserSubmissionComparison() throws ExitException {
         JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName("base"));
         verifyResults(result);
     }
-    
+
     @Test(expected = BasecodeException.class)
     public void testTinyBasecode() throws ExitException {
         runJPlag("TinyBasecode", it -> it.setBaseCodeSubmissionName("base"));
@@ -43,6 +43,12 @@ public class BaseCodeTest extends TestBase {
         assertEquals(85f, result.getComparisons().get(0).similarity(), DELTA);
     }
 
+    @Test
+    public void testBasecodePathComparison() throws ExitException {
+        JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName(".." + File.separator + "basecode-base"));
+        assertEquals(3, result.getNumberOfSubmissions()); // "basecode/base" is now a user submission.
+    }
+
     @Test(expected = RootDirectoryException.class)
     public void testInvalidRoot() throws ExitException {
         runJPlag("basecode", it -> it.setRootDirectoryName("WrongRoot"));
@@ -53,8 +59,13 @@ public class BaseCodeTest extends TestBase {
         runJPlag("basecode", it -> it.setBaseCodeSubmissionName("WrongBasecode"));
     }
 
-    @Test(expected = BasecodeException.class)
-    public void testBasecodeWithDots() throws ExitException {
+    @Test()
+    public void testBasecodePathWithDots() throws ExitException { // Dots are fine for paths.
         runJPlag("basecode", it -> it.setBaseCodeSubmissionName("." + File.separator + "base"));
+    }
+
+    @Test(expected = BasecodeException.class)
+    public void testBasecodeUserSubmissionWithDots() throws ExitException {
+        runJPlag("basecode", it -> it.setBaseCodeSubmissionName("base.ext"));
     }
 }

--- a/jplag/src/test/java/de/jplag/BaseCodeTest.java
+++ b/jplag/src/test/java/de/jplag/BaseCodeTest.java
@@ -45,7 +45,7 @@ public class BaseCodeTest extends TestBase {
 
     @Test
     public void testBasecodePathComparison() throws ExitException {
-        JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName(".." + File.separator + "basecode-base"));
+        JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName(getBasePath("basecode-base")));
         assertEquals(3, result.getNumberOfSubmissions()); // "basecode/base" is now a user submission.
     }
 
@@ -57,11 +57,6 @@ public class BaseCodeTest extends TestBase {
     @Test(expected = BasecodeException.class)
     public void testInvalidBasecode() throws ExitException {
         runJPlag("basecode", it -> it.setBaseCodeSubmissionName("WrongBasecode"));
-    }
-
-    @Test()
-    public void testBasecodePathWithDots() throws ExitException { // Dots are fine for paths.
-        runJPlag("basecode", it -> it.setBaseCodeSubmissionName("." + File.separator + "base"));
     }
 
     @Test(expected = BasecodeException.class)

--- a/jplag/src/test/java/de/jplag/TestBase.java
+++ b/jplag/src/test/java/de/jplag/TestBase.java
@@ -1,5 +1,6 @@
 package de.jplag;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
@@ -15,6 +16,14 @@ public abstract class TestBase {
 
     protected String getBasePath() {
         return BASE_PATH;
+    }
+
+    protected String getBasePath(String... subs) {
+        String path = BASE_PATH;
+        for (String sub: subs) {
+            path += File.separator + sub;
+        }
+        return path;
     }
 
     protected JPlagResult runJPlagWithExclusionFile(String testSampleName, String exclusionFileName) throws ExitException {

--- a/jplag/src/test/java/de/jplag/cli/BaseCodeOptionTest.java
+++ b/jplag/src/test/java/de/jplag/cli/BaseCodeOptionTest.java
@@ -1,7 +1,8 @@
 package de.jplag.cli;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+
+import java.util.Optional;
 
 import org.junit.Test;
 
@@ -14,13 +15,13 @@ public class BaseCodeOptionTest extends CommandLineInterfaceTest {
     @Test
     public void testDefaultValue() {
         buildOptionsFromCLI(CURRENT_DIRECTORY);
-        assertNull(options.getBaseCodeSubmissionName());
+        assertEquals(Optional.empty(), options.getBaseCodeSubmissionName());
     }
 
     @Test
     public void testCustomName() {
         String argument = buildArgument(CommandLineArgument.BASE_CODE, NAME);
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
-        assertEquals(NAME, options.getBaseCodeSubmissionName());
+        assertEquals(NAME, options.getBaseCodeSubmissionName().get());
     }
 }

--- a/jplag/src/test/resources/de/jplag/samples/basecode-base/TerrainType.java
+++ b/jplag/src/test/resources/de/jplag/samples/basecode-base/TerrainType.java
@@ -1,0 +1,12 @@
+package carcassonne.model.terrain;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+}


### PR DESCRIPTION
Dropping `-bc` directory and adding `-g` path for the global basecode submission directory.
If available, the basecode gets parsed before the user submission parsing, and each of the latter gets the basecode submission.

Also changed reporting to use its own `JplagOptions` instance and changed a `HashSet` variable type to its interface class.