### PR TITLE
Refactor submission set building

### DIFF
--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -33,7 +33,7 @@ public class Submission implements Comparable<Submission> {
     private final String name;
 
     /**
-     * Root of the submission (either a file or a directory).
+     * Root of the submission files (including the subdir if used).
      */
     private final File submissionRoot;
 


### PR DESCRIPTION
With the additional variations on `-bc` in #255 we need case distinctions, but the various pieces of information that we need seemed to be scattered between `JPlag.java` and `SubmissionSetBuilder.java`.

There didn't seem tot be an easy path for this, as decision making and checking is scattered between functions. So I concluded we could use a single point with all available information, simplifying the decision process.  
That spot ended up to be `SubmissionSetBuilder.buildSubmissionSet`. That function now does all error checking (including what was in `JPlag`), and finding and checking submissions. Near the end, it then finds the base code submission (which is at that time then already found to be a valid submission).
The more low-level code has been moved to other functions to avoid getting lost in the details.

For reviewing, this patch shouldn't do functional changes.
You may want to read the new `SubmissionSetBuilder` class by itself rather than trying to understand the diff, as it was heavily modified.

I haven't tried putting #255 on top of this, but I am pretty sure the job will less difficult than before.
