### PR TITLE
refactor: move non generic frontend-utils code into their respective frontends

### DIFF
--- a/jplag.frontend-utils/pom.xml
+++ b/jplag.frontend-utils/pom.xml
@@ -10,10 +10,4 @@
 		<version>3.1.0-SNAPSHOT</version>
 	</parent>
 
-	<dependencies>
-		<dependency>
-			<groupId>antlr</groupId>
-			<artifactId>antlr</artifactId>
-		</dependency>
-	</dependencies>
 </project>

--- a/jplag.frontend.cpp/src/main/java/de/jplag/cpp/NewlineStream.java
+++ b/jplag.frontend.cpp/src/main/java/de/jplag/cpp/NewlineStream.java
@@ -1,4 +1,4 @@
-package de.jplag;
+package de.jplag.cpp;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/jplag.frontend.cpp/src/main/javacc/CPP.jj
+++ b/jplag.frontend.cpp/src/main/javacc/CPP.jj
@@ -21,7 +21,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
-import de.jplag.NewlineStream;
+import de.jplag.cpp.NewlineStream;
 
 public class CPPScanner implements CPPTokenConstants {
     private static Scanner scanner2;
@@ -317,15 +317,15 @@ void token(): {}
 | ">="
 | "<<"
 | ">>"
-| "+" 
-| "-" 
-| "*" 
-| "/" 
-| "%" 
+| "+"
+| "-"
+| "*"
+| "/"
+| "%"
 | "++"           { scanner2.add(C_ASSIGN,token); }
 | "--"           { scanner2.add(C_ASSIGN,token); }
-| "~" 
-| "!" 
+| "~"
+| "!"
 | "auto"         { scanner2.add(C_AUTO,token); }
 | "break"        { scanner2.add(C_BREAK,token); }
 | "case"         { scanner2.add(C_CASE,token); }
@@ -373,37 +373,37 @@ void token(): {}
 | "volatile"     { scanner2.add(C_VOLANTILE,token); }
 | "while"        { scanner2.add(C_WHILE,token); }
 | "operator"     { scanner2.add(C_OPERATOR,token); }
-| "true"         
-| "false"        
+| "true"
+| "false"
 | "throw"        { scanner2.add(C_THROW,token); }
 | "NULL"         { scanner2.add(C_NULL,token); }
 
-| <OCTALINT>                  
-| <OCTALLONG>                 
-| <UNSIGNED_OCTALINT>         
-| <UNSIGNED_OCTALLONG>        
-| <DECIMALINT>                
-| <DECIMALLONG>               
-| <UNSIGNED_DECIMALINT>       
-| <UNSIGNED_DECIMALLONG>      
+| <OCTALINT>
+| <OCTALLONG>
+| <UNSIGNED_OCTALINT>
+| <UNSIGNED_OCTALLONG>
+| <DECIMALINT>
+| <DECIMALLONG>
+| <UNSIGNED_DECIMALINT>
+| <UNSIGNED_DECIMALLONG>
 
-| <HEXADECIMALINT>            
-| <HEXADECIMALLONG>           
-| <UNSIGNED_HEXADECIMALINT>   
-| <UNSIGNED_HEXADECIMALLONG>  
+| <HEXADECIMALINT>
+| <HEXADECIMALLONG>
+| <UNSIGNED_HEXADECIMALINT>
+| <UNSIGNED_HEXADECIMALLONG>
 
-| <FLOATONE>                  
-| <FLOATTWO>                  
+| <FLOATONE>
+| <FLOATTWO>
 
-| <CHARACTER>                 
-| <STRING>                    
+| <CHARACTER>
+| <STRING>
 
 | <BACKSLASH>
 
        //| var() [LOOKAHEAD(2) "("        { scanner2.add(C_FUN,token); } ]
 | "."
-| "->" 
-| ".*" 
+| "->"
+| ".*"
 | "->*"
 | <ID>
 }
@@ -433,19 +433,19 @@ void var3(): {}
 void index(): {}
 {
   var()
-| <OCTALINT>                  
-| <OCTALLONG>                 
-| <UNSIGNED_OCTALINT>         
-| <UNSIGNED_OCTALLONG>        
-| <DECIMALINT>                
-| <DECIMALLONG>               
-| <UNSIGNED_DECIMALINT>       
-| <UNSIGNED_DECIMALLONG>      
+| <OCTALINT>
+| <OCTALLONG>
+| <UNSIGNED_OCTALINT>
+| <UNSIGNED_OCTALLONG>
+| <DECIMALINT>
+| <DECIMALLONG>
+| <UNSIGNED_DECIMALINT>
+| <UNSIGNED_DECIMALLONG>
 
-| <HEXADECIMALINT>            
-| <HEXADECIMALLONG>           
-| <UNSIGNED_HEXADECIMALINT>   
-| <UNSIGNED_HEXADECIMALLONG>  
+| <HEXADECIMALINT>
+| <HEXADECIMALLONG>
+| <UNSIGNED_HEXADECIMALINT>
+| <UNSIGNED_HEXADECIMALLONG>
 
 }
 

--- a/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/Parser.java
+++ b/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/Parser.java
@@ -7,7 +7,6 @@ import java.nio.charset.StandardCharsets;
 import antlr.Token;
 import de.jplag.AbstractParser;
 import de.jplag.TokenList;
-import de.jplag.UnicodeReader;
 import de.jplag.csharp.grammar.CSharpLexer;
 import de.jplag.csharp.grammar.CSharpParser;
 

--- a/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/UnicodeReader.java
+++ b/jplag.frontend.csharp-1.2/src/main/java/de/jplag/csharp/UnicodeReader.java
@@ -1,7 +1,7 @@
 /*
  * Original pseudocode   : Thomas Weidenfeller
  * Implementation tweaked: Aki Nieminen
- * 
+ *
  * http://www.unicode.org/unicode/faq/utf_bom.html
  * BOMs:
  * 00 00 FE FF    = UTF-32, big-endian
@@ -9,12 +9,12 @@
  * FE FF          = UTF-16, big-endian
  * FF FE          = UTF-16, little-endian
  * EF BB BF       = UTF-8
- * 
+ *
  * Win2k Notepad:
  * Unicode format = UTF-16LE
  */
 
-package de.jplag;
+package de.jplag.csharp;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets;
  * Generic unicode text reader, which will use BOM mark to identify the encoding to be used. If BOM is not found then
  * use a given default encoding. UTF-8 is used if: BOM mark is not found and defaultEnc is NULL.
  * Usage pattern:
- * 
+ *
  * <pre>
  * String defaultEnc = "UTF-16BE"; // or NULL to use system default
  * FileInputStream fis = new FileInputStream(file);

--- a/jplag.frontend.text/src/main/antlr/text.g
+++ b/jplag.frontend.text/src/main/antlr/text.g
@@ -34,8 +34,8 @@ file : ( w:WORD { parser.add(w); } | PUNCTUATION | SPECIALS )* EOF ;
 //----------------------------------------------------------------------------
 
 {
-import de.jplag.InputState;
-import de.jplag.ParserToken;
+import de.jplag.text.InputState;
+import de.jplag.text.ParserToken;
 }
 
 class TextLexer extends Lexer;
@@ -72,7 +72,7 @@ options
     }
 }
 
-WORD 
+WORD
 options { paraphrase = "an identifier"; } :
   (( '0'..'9') | ('A'..'Z') | ('a'..'z') |
    ('\300' .. '\326') | ('\330' .. '\366') | ('\370' .. '\377'))+ ;
@@ -84,7 +84,7 @@ PUNCTUATION : (	'!' | '"' | '\'' | '(' | ')' | ',' | '-' | '.' |
 SPECIALS : ('#' | '$' | '%' | '&' | '+' | '<' | '=' | '*' |
 	    '/' | '>' | '@' | '\\' | '^' | '_' | '|' | '~' |
 	    ('\241' .. '\252') | ('\254' .. '\263') | ('\265' .. '\272') |
-	    ('\274' .. '\276') | '\327' | '\367' | ('\200' .. '\237') ) ; 
+	    ('\274' .. '\276') | '\327' | '\367' | ('\200' .. '\237') ) ;
 
 // Whitespace -- ignored
 SPACE : ( ' '

--- a/jplag.frontend.text/src/main/java/de/jplag/text/InputState.java
+++ b/jplag.frontend.text/src/main/java/de/jplag/text/InputState.java
@@ -1,4 +1,4 @@
-package de.jplag;
+package de.jplag.text;
 
 import java.io.InputStream;
 import java.io.Reader;

--- a/jplag.frontend.text/src/main/java/de/jplag/text/Parser.java
+++ b/jplag.frontend.text/src/main/java/de/jplag/text/Parser.java
@@ -6,8 +6,6 @@ import java.util.Hashtable;
 
 import antlr.Token;
 import de.jplag.AbstractParser;
-import de.jplag.InputState;
-import de.jplag.ParserToken;
 import de.jplag.TokenConstants;
 import de.jplag.TokenList;
 
@@ -45,7 +43,7 @@ public class Parser extends AbstractParser implements TokenConstants {
             inputState = new InputState(inputStream);
             TextLexer lexer = new TextLexer(inputState);
             lexer.setFilename(file);
-            lexer.setTokenObjectClass("de.jplag.ParserToken");
+            lexer.setTokenObjectClass("de.jplag.text.ParserToken");
 
             // Create a parser that reads from the scanner
             TextParser parser = new TextParser(lexer);

--- a/jplag.frontend.text/src/main/java/de/jplag/text/ParserToken.java
+++ b/jplag.frontend.text/src/main/java/de/jplag/text/ParserToken.java
@@ -1,4 +1,4 @@
-package de.jplag;
+package de.jplag.text;
 
 import antlr.Token;
 


### PR DESCRIPTION
in frontend-utils, there is some classes that are only used by a specific frontend:

* NewlineStream is used by cpp
* UnicodeReader by csharp
* InputState & ParserToken only by text

This small change move them out of frontend-utils and into their respective packages