### PR TITLE
Make JPlagOptions read only

### DIFF
--- a/jplag/src/main/java/de/jplag/CLI.java
+++ b/jplag/src/main/java/de/jplag/CLI.java
@@ -57,7 +57,7 @@ public class CLI {
             System.out.println("JPlag initialized");
             JPlagResult result = program.run();
             File reportDir = new File(arguments.getString(RESULT_FOLDER.flagWithoutDash()));
-            Report report = new Report(reportDir, options);
+            Report report = new Report(reportDir, program.getLanguage(), options);
             report.writeResult(result);
         } catch (ExitException exception) {
             System.out.println("Error: " + exception.getMessage());

--- a/jplag/src/main/java/de/jplag/CLI.java
+++ b/jplag/src/main/java/de/jplag/CLI.java
@@ -101,20 +101,24 @@ public class CLI {
         if (fileSuffixString != null) {
             fileSuffixes = fileSuffixString.replaceAll("\\s+", "").split(",");
         }
-        LanguageOption language = LanguageOption.fromDisplayName(LANGUAGE.getFrom(namespace));
-        JPlagOptions options = new JPlagOptions(ROOT_DIRECTORY.getFrom(namespace), language);
-        options.setBaseCodeSubmissionName(BASE_CODE.getFrom(namespace));
-        options.setVerbosity(Verbosity.fromOption(VERBOSITY.getFrom(namespace)));
-        options.setDebugParser(DEBUG.getFrom(namespace));
-        options.setSubdirectoryName(SUBDIRECTORY.getFrom(namespace));
-        options.setFileSuffixes(fileSuffixes);
-        options.setExclusionFileName(EXCLUDE_FILE.getFrom(namespace));
-        options.setMinimumTokenMatch(MIN_TOKEN_MATCH.getFrom(namespace));
-        options.setSimilarityThreshold(SIMILARITY_THRESHOLD.getFrom(namespace));
-        options.setMaximumNumberOfComparisons(SHOWN_COMPARISONS.getFrom(namespace));
-        ComparisonMode.fromName(COMPARISON_MODE.getFrom(namespace)).ifPresentOrElse(it -> options.setComparisonMode(it),
+
+        var builder = JPlagOptions.builder()
+                .setRootDirectoryName(ROOT_DIRECTORY.getFrom(namespace))
+                .setLanguageOption(LanguageOption.fromDisplayName(LANGUAGE.getFrom(namespace)))
+                .setBaseCodeSubmissionName(BASE_CODE.getFrom(namespace))
+                .setVerbosity(Verbosity.fromOption(VERBOSITY.getFrom(namespace)))
+                .setDebugParser(DEBUG.getFrom(namespace))
+                .setSubdirectoryName(SUBDIRECTORY.getFrom(namespace))
+                .setFileSuffixes(fileSuffixes)
+                .setExclusionFileName(EXCLUDE_FILE.getFrom(namespace))
+                .setMinimumTokenMatch(MIN_TOKEN_MATCH.getFrom(namespace))
+                .setSimilarityThreshold(SIMILARITY_THRESHOLD.getFrom(namespace))
+                .setMaximumNumberOfComparisons(SHOWN_COMPARISONS.getFrom(namespace));
+
+        ComparisonMode.fromName(COMPARISON_MODE.getFrom(namespace)).ifPresentOrElse(builder::setComparisonMode,
                 () -> System.out.println("Unknown comparison mode, using default mode!"));
-        return options;
+
+        return builder.build();
     }
 
     private String generateDescription() {

--- a/jplag/src/main/java/de/jplag/ConfigurationReport.java
+++ b/jplag/src/main/java/de/jplag/ConfigurationReport.java
@@ -1,0 +1,41 @@
+package de.jplag;
+
+import de.jplag.options.JPlagOptions;
+
+import java.util.Set;
+
+public class ConfigurationReport {
+    private final JPlagOptions options;
+    private final Language language;
+    private final Set<String> excludedFileNames;
+    private final String[] fileSuffixes;
+    private final int minimumTokenMatch;
+
+    public ConfigurationReport(JPlagOptions options, Language language, Set<String> excludedFileNames, String[] fileSuffixes, int minimumTokenMatch) {
+        this.options = options;
+        this.language = language;
+        this.excludedFileNames = excludedFileNames;
+        this.fileSuffixes = fileSuffixes;
+        this.minimumTokenMatch = minimumTokenMatch;
+    }
+
+    public JPlagOptions getOptions() {
+        return options;
+    }
+
+    public Language getLanguage() {
+        return language;
+    }
+
+    public Set<String> getExcludedFileNames() {
+        return excludedFileNames;
+    }
+
+    public String[] getFileSuffixes() {
+        return fileSuffixes;
+    }
+
+    public int getMinimumTokenMatch() {
+        return minimumTokenMatch;
+    }
+}

--- a/jplag/src/main/java/de/jplag/ErrorCollector.java
+++ b/jplag/src/main/java/de/jplag/ErrorCollector.java
@@ -15,13 +15,13 @@ import de.jplag.options.Verbosity;
 public class ErrorCollector implements ErrorConsumer { // TODO TS should be eventually replaced with a true logger/logging manager
 
     private final List<String> collectedErrors; // List of errors that occurred during the execution of the errorConsumer.
-    private final JPlagOptions options;
+    private final Verbosity verbosity;
     private String currentSubmissionName;
 
-    public ErrorCollector(JPlagOptions options) {
-        this.options = options;
+    public ErrorCollector(Verbosity verbosity) {
         collectedErrors = new ArrayList<>();
         currentSubmissionName = "<Unknown submission>";
+        this.verbosity = verbosity;
     }
 
     @Override
@@ -35,7 +35,6 @@ public class ErrorCollector implements ErrorConsumer { // TODO TS should be even
         if (message == null && longMessage == null) {
             throw new IllegalArgumentException("At least one message parameter needs to be non-null!");
         }
-        Verbosity verbosity = options.getVerbosity();
         if (message != null) {
             System.out.println(message);
         }

--- a/jplag/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/jplag/src/main/java/de/jplag/GreedyStringTiling.java
@@ -16,9 +16,11 @@ import de.jplag.options.JPlagOptions;
 public class GreedyStringTiling implements TokenConstants {
 
     private final JPlagOptions options;
+    private final int minimumTokenMatch;
 
-    public GreedyStringTiling(JPlagOptions options) {
+    public GreedyStringTiling(JPlagOptions options, int minimumTokenMatch) {
         this.options = options;
+        this.minimumTokenMatch = minimumTokenMatch;
     }
 
     /**
@@ -126,7 +128,6 @@ public class GreedyStringTiling implements TokenConstants {
 
         // Initialize:
         JPlagComparison comparison = new JPlagComparison(firstSubmission, secondSubmission);
-        int minimumTokenMatch = options.getMinimumTokenMatch(); // minimal required token match
 
         if (first.size() <= minimumTokenMatch || second.size() <= minimumTokenMatch) { // <= because of pivots!
             return comparison;

--- a/jplag/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/jplag/src/main/java/de/jplag/GreedyStringTiling.java
@@ -15,12 +15,12 @@ import de.jplag.options.JPlagOptions;
  */
 public class GreedyStringTiling implements TokenConstants {
 
-    private final JPlagOptions options;
     private final int minimumTokenMatch;
+    private final boolean hasBaseCode;
 
-    public GreedyStringTiling(JPlagOptions options, int minimumTokenMatch) {
-        this.options = options;
+    public GreedyStringTiling(int minimumTokenMatch, boolean hasBaseCode) {
         this.minimumTokenMatch = minimumTokenMatch;
+        this.hasBaseCode = hasBaseCode;
     }
 
     /**
@@ -222,7 +222,7 @@ public class GreedyStringTiling implements TokenConstants {
             if (isBaseCodeComparison) {
                 token.marked = token.type == FILE_END || token.type == SEPARATOR_TOKEN;
             } else {
-                token.marked = token.type == FILE_END || token.type == SEPARATOR_TOKEN || (token.basecode && options.hasBaseCode());
+                token.marked = token.type == FILE_END || token.type == SEPARATOR_TOKEN || (token.basecode && hasBaseCode);
             }
         }
     }

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -68,6 +68,10 @@ public class JPlag {
         }
     }
 
+    public Language getLanguage() {
+        return language;
+    }
+
     /**
      * Main procedure, executes the comparison of source code submissions.
      * @return the results of the comparison, specifically the submissions whose similarity exceeds a set threshold.

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -55,7 +55,8 @@ public class JPlag {
 
         System.out.println("Initialized language " + language.getName());
 
-        coreAlgorithm = new GreedyStringTiling(options, minimumTokenMatch);
+        // TODO: remove option.hasBaseCode() usage in GreedyStringTiling
+        coreAlgorithm = new GreedyStringTiling(minimumTokenMatch, options.hasBaseCode());
 
         comparisonStrategy = initializeComparisonStrategy(options.getComparisonMode(), options.getSimilarityMetric(), options.getSimilarityThreshold());
         excludedFileNames = Optional.ofNullable(options.getExclusionFileName()).map(this::readExclusionFile).orElse(Collections.emptySet());

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -41,8 +41,13 @@ public class JPlag {
     public JPlag(JPlagOptions options) throws ExitException {
         this.options = options;
         errorCollector = new ErrorCollector(options);
+
+        language = loadLanguage(errorCollector, options.getLanguageOption().getClassPath());
+        this.options.setLanguageDefaults(language);
+        System.out.println("Initialized language " + language.getName());
+
         coreAlgorithm = new GreedyStringTiling(options);
-        initializeLanguage(this.options.getLanguageOption(), errorCollector);
+
         comparisonStrategy = initializeComparisonStrategy(options.getComparisonMode());
         excludedFileNames = Optional.ofNullable(this.options.getExclusionFileName()).map(this::readExclusionFile).orElse(Collections.emptySet());
         options.setExcludedFiles(excludedFileNames); // store for report
@@ -102,14 +107,6 @@ public class JPlag {
             case NORMAL -> new NormalComparisonStrategy(options, coreAlgorithm);
             case PARALLEL -> new ParallelComparisonStrategy(options, coreAlgorithm);
         };
-    }
-
-    private void initializeLanguage(final LanguageOption languageOption, final ErrorCollector errorCollector) {
-        language = loadLanguage(errorCollector, languageOption.getClassPath());
-        options.setLanguage(language);
-        options.setLanguageDefaults(language);
-
-        System.out.println("Initialized language " + language.getName());
     }
 
     private Language loadLanguage(final ErrorCollector errorCollector, final String classPath) {

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -59,9 +59,6 @@ public class JPlag {
 
         comparisonStrategy = initializeComparisonStrategy(options.getComparisonMode(), options.getSimilarityMetric(), options.getSimilarityThreshold());
         excludedFileNames = Optional.ofNullable(options.getExclusionFileName()).map(this::readExclusionFile).orElse(Collections.emptySet());
-
-        options.setLanguageDefaults(language);
-        options.setExcludedFiles(excludedFileNames); // store for report
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/JPlag.java
+++ b/jplag/src/main/java/de/jplag/JPlag.java
@@ -62,6 +62,13 @@ public class JPlag {
     }
 
     /**
+     * return a Summary of all the used configuration
+     */
+    public ConfigurationReport getConfigurationReport() {
+        return new ConfigurationReport(options, language, excludedFileNames, fileSuffixes, minimumTokenMatch);
+    }
+
+    /**
      * If an exclusion file is given, it is read in and all strings are saved in the set "excluded".
      * @param exclusionFileName
      */

--- a/jplag/src/main/java/de/jplag/JPlagResult.java
+++ b/jplag/src/main/java/de/jplag/JPlagResult.java
@@ -13,17 +13,14 @@ public class JPlagResult {
 
     private final SubmissionSet submissions;
 
-    private final JPlagOptions options;
-
     private final long durationInMillis;
 
     private final int[] similarityDistribution; // 10-element array representing the similarity distribution of the detected matches.
 
-    public JPlagResult(List<JPlagComparison> comparisons, SubmissionSet submissions, long durationInMillis, JPlagOptions options) {
+    public JPlagResult(List<JPlagComparison> comparisons, SubmissionSet submissions, long durationInMillis) {
         this.comparisons = comparisons;
         this.submissions = submissions;
         this.durationInMillis = durationInMillis;
-        this.options = options;
         similarityDistribution = calculateSimilarityDistribution(comparisons);
         comparisons.sort((first, second) -> Float.compare(second.similarity(), first.similarity())); // Sort by percentage (descending).
     }
@@ -79,13 +76,6 @@ public class JPlagResult {
     }
 
     /**
-     * @return the JPlag options with which the JPlag run was configured.
-     */
-    public JPlagOptions getOptions() {
-        return options;
-    }
-
-    /**
      * Returns the similarity distribution of detected matches in a 10-element array. Each entry represents the absolute
      * frequency of matches whose similarity lies within the respective interval. Intervals: 0: [0% - 10%), 1: [10% - 20%),
      * 2: [20% - 30%), ..., 9: [90% - 100%]
@@ -97,8 +87,8 @@ public class JPlagResult {
 
     @Override
     public String toString() {
-        return String.format("JPlagResult { comparisons: %d, duration: %d ms, language: %s, submissions: %d }", getComparisons().size(),
-                getDuration(), getOptions().getLanguageOption(), submissions.numberOfSubmissions());
+        return String.format("JPlagResult { comparisons: %d, duration: %d ms, submissions: %d }", getComparisons().size(),
+                getDuration(), submissions.numberOfSubmissions());
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -27,6 +27,8 @@ public class SubmissionSetBuilder {
     private final JPlagOptions options;
     private final ErrorCollector errorCollector;
     private final Set<String> excludedFileNames; // Set of file names to be excluded in comparison.
+    private final int minimumTokenMatch;
+    private final String[] fileSuffixes;
 
     /**
      * Creates a builder for submission sets.
@@ -34,12 +36,17 @@ public class SubmissionSetBuilder {
      * @param options are the configured options.
      * @param errorCollector is the interface for error reporting.
      * @param excludedFileNames
+     * @param minimumTokenMatch
+     * @param fileSuffixes
      */
-    public SubmissionSetBuilder(Language language, JPlagOptions options, ErrorCollector errorCollector, Set<String> excludedFileNames) {
+    public SubmissionSetBuilder(Language language, JPlagOptions options, ErrorCollector errorCollector, Set<String> excludedFileNames,
+            Integer minimumTokenMatch, String[] fileSuffixes) {
         this.language = language;
         this.options = options;
         this.errorCollector = errorCollector;
         this.excludedFileNames = excludedFileNames;
+        this.minimumTokenMatch = minimumTokenMatch;
+        this.fileSuffixes = fileSuffixes;
     }
 
     /**
@@ -75,7 +82,7 @@ public class SubmissionSetBuilder {
 
         // Merge everything in a submission set.
         List<Submission> submissions = new ArrayList<>(foundSubmissions.values());
-        return new SubmissionSet(submissions, baseCodeSubmission, errorCollector, options);
+        return new SubmissionSet(submissions, baseCodeSubmission, errorCollector, minimumTokenMatch, options.isDebugParser());
     }
 
     /**
@@ -173,13 +180,12 @@ public class SubmissionSetBuilder {
      * @return true if the file suffix matches the language.
      */
     private boolean hasValidSuffix(File file) {
-        String[] validSuffixes = options.getFileSuffixes();
 
         // This is the case if either the language frontends or the CLI did not set the valid suffixes array in options
-        if (validSuffixes == null || validSuffixes.length == 0) {
+        if (fileSuffixes == null || fileSuffixes.length == 0) {
             return true;
         }
-        return Arrays.stream(validSuffixes).anyMatch(suffix -> file.getName().endsWith(suffix));
+        return Arrays.stream(fileSuffixes).anyMatch(suffix -> file.getName().endsWith(suffix));
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -20,11 +20,6 @@ public class JPlagOptions {
     public static final Charset CHARSET = StandardCharsets.UTF_8;
 
     /**
-     * Language used to parse the submissions.
-     */
-    private Language language;
-
-    /**
      * Determines which strategy to use for the comparison of submissions.
      */
     private ComparisonMode comparisonMode = DEFAULT_COMPARISON_MODE;
@@ -130,10 +125,6 @@ public class JPlagOptions {
         return fileSuffixes;
     }
 
-    public Language getLanguage() {
-        return language;
-    }
-
     public LanguageOption getLanguageOption() {
         return languageOption;
     }
@@ -197,10 +188,6 @@ public class JPlagOptions {
 
     public void setFileSuffixes(String[] fileSuffixes) {
         this.fileSuffixes = fileSuffixes;
-    }
-
-    public void setLanguage(Language language) {
-        this.language = language;
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -1,6 +1,6 @@
 package de.jplag.options;
 
-import static de.jplag.strategy.ComparisonMode.NORMAL;
+import de.jplag.strategy.ComparisonMode;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -8,8 +8,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
 
-import de.jplag.Language;
-import de.jplag.strategy.ComparisonMode;
+import static de.jplag.strategy.ComparisonMode.NORMAL;
 
 public class JPlagOptions {
 
@@ -22,87 +21,105 @@ public class JPlagOptions {
     /**
      * Determines which strategy to use for the comparison of submissions.
      */
-    private ComparisonMode comparisonMode = DEFAULT_COMPARISON_MODE;
+    private final ComparisonMode comparisonMode;
 
     /**
      * If true, submissions that cannot be parsed will be stored in a separate directory.
      */
-    private boolean debugParser = false;
+    private final boolean debugParser;
 
     /**
      * Array of file suffixes that should be included.
      */
-    private String[] fileSuffixes;
+    private final String[] fileSuffixes;
 
     /**
      * Percentage value (must be between 0 and 100). Comparisons (of submissions pairs) with a similarity below this
      * threshold will be ignored. The default value of 0 allows all matches to be stored. This affects which comparisons are
      * stored and thus make it into the result object.
+     *
      * @see JPlagOptions.similarityMetric
      */
-    private float similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
+    private final float similarityThreshold;
 
     /**
      * The maximum number of comparisons that will be shown in the generated report. If set to -1 all comparisons will be
      * shown.
      */
-    private int maximumNumberOfComparisons = DEFAULT_SHOWN_COMPARISONS;
+    private final int maximumNumberOfComparisons;
 
     /**
      * The similarity metric determines how the minimum similarity threshold required for a comparison (of two submissions)
      * is calculated. This affects which comparisons are stored and thus make it into the result object.
+     *
      * @see JPlagOptions.similarityThreshold
      */
-    private SimilarityMetric similarityMetric = SimilarityMetric.AVG;
+    private final SimilarityMetric similarityMetric;
 
     /**
      * Tunes the comparison sensitivity by adjusting the minimum token required to be counted as matching section. A smaller
      * <n> increases the sensitivity but might lead to more false-positves.
      */
-    private Integer minimumTokenMatch;
+    private final Integer minimumTokenMatch;
 
     /**
      * Name of the file that contains the names of files to exclude from comparison.
      */
-    private String exclusionFileName;
-    
+    private final String exclusionFileName;
+
     /**
      * Names of the excluded files.
      */
-    private Set<String> excludedFiles = Collections.emptySet();
+    private final Set<String> excludedFiles;
 
     /**
      * Directory that contains all submissions.
      */
-    private String rootDirectoryName;
+    private final String rootDirectoryName;
 
     /**
      * Name of the directory which contains the base code.
      */
-    private String baseCodeSubmissionName;
+    private final String baseCodeSubmissionName;
 
     /**
      * Example: If the subdirectoryName is 'src', only the code inside submissionDir/src of each submission will be used for
      * comparison.
      */
-    private String subdirectoryName;
+    private final String subdirectoryName;
 
     /**
      * Language to use when parsing the submissions.
      */
-    private LanguageOption languageOption;
+    private final LanguageOption languageOption;
 
     /**
      * Level of output verbosity.
      */
-    private Verbosity verbosity;
+    private final Verbosity verbosity;
 
-    /**
-     * Constructor with required attributes.
-     */
-    public JPlagOptions(String rootDirectoryName, LanguageOption languageOption) {
+    private JPlagOptions(ComparisonMode comparisonMode, boolean debugParser, String[] fileSuffixes, float similarityThreshold,
+            int maximumNumberOfComparisons, SimilarityMetric similarityMetric, Integer minimumTokenMatch, String exclusionFileName,
+            Set<String> excludedFiles, String rootDirectoryName, String baseCodeSubmissionName, String subdirectoryName,
+            LanguageOption languageOption, Verbosity verbosity) {
+        this.comparisonMode = comparisonMode;
+        this.debugParser = debugParser;
+        this.fileSuffixes = fileSuffixes;
+        this.similarityThreshold = similarityThreshold;
+        this.maximumNumberOfComparisons = maximumNumberOfComparisons;
+        this.similarityMetric = similarityMetric;
+        this.minimumTokenMatch = minimumTokenMatch;
+        this.exclusionFileName = exclusionFileName;
+        this.excludedFiles = excludedFiles;
         this.rootDirectoryName = rootDirectoryName;
+        this.baseCodeSubmissionName = baseCodeSubmissionName;
+        this.subdirectoryName = subdirectoryName;
         this.languageOption = languageOption;
+        this.verbosity = verbosity;
+    }
+
+    public static JPlagOptionsBuilder builder() {
+        return new JPlagOptionsBuilder();
     }
 
     public String getBaseCodeSubmissionName() {
@@ -165,100 +182,109 @@ public class JPlagOptions {
         return debugParser;
     }
 
-    public void setBaseCodeSubmissionName(String baseCodeSubmissionName) {
-        // Trim problematic file separators.
-        this.baseCodeSubmissionName = (baseCodeSubmissionName == null) ? null : baseCodeSubmissionName.replace(File.separator, "");
-    }
+    public static class JPlagOptionsBuilder {
+        private ComparisonMode comparisonMode = DEFAULT_COMPARISON_MODE;
+        private boolean debugParser = false;
+        private String[] fileSuffixes;
+        private float similarityThreshold = DEFAULT_SIMILARITY_THRESHOLD;
+        private int maximumNumberOfComparisons = DEFAULT_SHOWN_COMPARISONS;
+        private SimilarityMetric similarityMetric = SimilarityMetric.AVG;
+        private Integer minimumTokenMatch;
+        private String exclusionFileName;
+        private Set<String> excludedFiles = Collections.emptySet();
+        private String rootDirectoryName;
+        private String baseCodeSubmissionName;
+        private String subdirectoryName;
+        private LanguageOption languageOption;
+        private Verbosity verbosity;
 
-    public void setComparisonMode(ComparisonMode comparisonMode) {
-        this.comparisonMode = comparisonMode;
-    }
-
-    public void setDebugParser(boolean debugParser) {
-        this.debugParser = debugParser;
-    }
-
-    public void setExcludedFiles(Set<String> excludedFiles) {
-        this.excludedFiles = excludedFiles;
-    }
-
-    public void setExclusionFileName(String exclusionFileName) {
-        this.exclusionFileName = exclusionFileName;
-    }
-
-    public void setFileSuffixes(String[] fileSuffixes) {
-        this.fileSuffixes = fileSuffixes;
-    }
-
-    /**
-     * After the selected language has been initialized, this method is called by JPlag to set default values for options
-     * not set by the user.
-     * @param language - initialized language instance
-     */
-    public void setLanguageDefaults(Language language) {
-        if (!hasMinimumTokenMatch()) {
-            setMinimumTokenMatch(language.minimumTokenMatch());
+        public JPlagOptionsBuilder setComparisonMode(ComparisonMode comparisonMode) {
+            this.comparisonMode = comparisonMode;
+            return this;
         }
 
-        if (!hasFileSuffixes()) {
-            fileSuffixes = language.suffixes();
+        public JPlagOptionsBuilder setDebugParser(boolean debugParser) {
+            this.debugParser = debugParser;
+            return this;
         }
-    }
 
-    public void setLanguageOption(LanguageOption languageOption) {
-        this.languageOption = languageOption;
-    }
-
-    public void setMaximumNumberOfComparisons(int maximumNumberOfComparisons) {
-        if (maximumNumberOfComparisons < -1) {
-            this.maximumNumberOfComparisons = -1;
-        } else {
-            this.maximumNumberOfComparisons = maximumNumberOfComparisons;
+        public JPlagOptionsBuilder setFileSuffixes(String[] fileSuffixes) {
+            this.fileSuffixes = fileSuffixes;
+            return this;
         }
-    }
 
-    public void setMinimumTokenMatch(Integer minimumTokenMatch) {
-        if (minimumTokenMatch != null && minimumTokenMatch < 1) {
-            this.minimumTokenMatch = 1;
-        } else {
-            this.minimumTokenMatch = minimumTokenMatch;
+        public JPlagOptionsBuilder setSimilarityThreshold(float similarityThreshold) {
+            if (similarityThreshold > 100) {
+                System.out.println("Maximum threshold of 100 used instead of " + similarityThreshold);
+                this.similarityThreshold = 100;
+            } else if (similarityThreshold < 0) {
+                System.out.println("Minimum threshold of 0 used instead of " + similarityThreshold);
+                this.similarityThreshold = 0;
+            } else {
+                this.similarityThreshold = similarityThreshold;
+            }
+            return this;
         }
-    }
 
-    public void setRootDirectoryName(String rootDirectoryName) {
-        this.rootDirectoryName = rootDirectoryName;
-    }
-
-    public void setSimilarityMetric(SimilarityMetric similarityMetric) {
-        this.similarityMetric = similarityMetric;
-    }
-
-    public void setSimilarityThreshold(float similarityThreshold) {
-        if (similarityThreshold > 100) {
-            System.out.println("Maximum threshold of 100 used instead of " + similarityThreshold);
-            this.similarityThreshold = 100;
-        } else if (similarityThreshold < 0) {
-            System.out.println("Minimum threshold of 0 used instead of " + similarityThreshold);
-            this.similarityThreshold = 0;
-        } else {
-            this.similarityThreshold = similarityThreshold;
+        public JPlagOptionsBuilder setMaximumNumberOfComparisons(int maximumNumberOfComparisons) {
+            this.maximumNumberOfComparisons = Math.max(maximumNumberOfComparisons, -1);
+            return this;
         }
-    }
 
-    public void setSubdirectoryName(String subdirectoryName) {
-        // Trim problematic file separators.
-        this.subdirectoryName = (subdirectoryName == null) ? null : subdirectoryName.replace(File.separator, "");
-    }
+        public JPlagOptionsBuilder setSimilarityMetric(SimilarityMetric similarityMetric) {
+            this.similarityMetric = similarityMetric;
+            return this;
+        }
 
-    public void setVerbosity(Verbosity verbosity) {
-        this.verbosity = verbosity;
-    }
+        public JPlagOptionsBuilder setMinimumTokenMatch(Integer minimumTokenMatch) {
+            if (minimumTokenMatch != null && minimumTokenMatch < 1) {
+                this.minimumTokenMatch = 1;
+            } else {
+                this.minimumTokenMatch = minimumTokenMatch;
+            }
+            return this;
+        }
 
-    private boolean hasFileSuffixes() {
-        return fileSuffixes != null && fileSuffixes.length > 0;
-    }
+        public JPlagOptionsBuilder setExclusionFileName(String exclusionFileName) {
+            this.exclusionFileName = exclusionFileName;
+            return this;
+        }
 
-    private boolean hasMinimumTokenMatch() {
-        return minimumTokenMatch != null;
+        public JPlagOptionsBuilder setExcludedFiles(Set<String> excludedFiles) {
+            this.excludedFiles = excludedFiles;
+            return this;
+        }
+
+        public JPlagOptionsBuilder setRootDirectoryName(String rootDirectoryName) {
+            this.rootDirectoryName = rootDirectoryName;
+            return this;
+        }
+
+        public JPlagOptionsBuilder setBaseCodeSubmissionName(String baseCodeSubmissionName) {
+            this.baseCodeSubmissionName = (baseCodeSubmissionName == null) ? null : baseCodeSubmissionName.replace(File.separator, "");
+            return this;
+        }
+
+        public JPlagOptionsBuilder setSubdirectoryName(String subdirectoryName) {
+            // Trim problematic file separators.
+            this.subdirectoryName = (subdirectoryName == null) ? null : subdirectoryName.replace(File.separator, "");
+            return this;
+        }
+
+        public JPlagOptionsBuilder setLanguageOption(LanguageOption languageOption) {
+            this.languageOption = languageOption;
+            return this;
+        }
+
+        public JPlagOptionsBuilder setVerbosity(Verbosity verbosity) {
+            this.verbosity = verbosity;
+            return this;
+        }
+
+        public JPlagOptions build() {
+            return new JPlagOptions(comparisonMode, debugParser, fileSuffixes, similarityThreshold, maximumNumberOfComparisons, similarityMetric,
+                    minimumTokenMatch, exclusionFileName, excludedFiles, rootDirectoryName, baseCodeSubmissionName, subdirectoryName, languageOption,
+                    verbosity);
+        }
     }
 }

--- a/jplag/src/main/java/de/jplag/reporting/Report.java
+++ b/jplag/src/main/java/de/jplag/reporting/Report.java
@@ -40,15 +40,17 @@ public class Report { // Mostly legacy code with some minor improvements.
     private final File reportDir;
     private final JPlagOptions options;
 
+    private final Language language;
     private JPlagResult result;
 
     private int currentComparisonIndex = 0;
     private int matchWritingProgess = 0;
     private int matchesWritten = 0;
 
-    public Report(File reportDir, JPlagOptions options) throws ReportGenerationException {
+    public Report(File reportDir, final Language language, JPlagOptions options) throws ReportGenerationException {
         this.reportDir = reportDir;
         this.options = options;
+        this.language = language;
         msg = new Messages("en");
 
         validateReportDir();
@@ -68,7 +70,7 @@ public class Report { // Mostly legacy code with some minor improvements.
     }
 
     private Language getLanguage() {
-        return options.getLanguage();
+        return language;
     }
 
     /*

--- a/jplag/src/main/java/de/jplag/reporting/Report.java
+++ b/jplag/src/main/java/de/jplag/reporting/Report.java
@@ -18,6 +18,7 @@ import java.util.TreeMap;
 
 import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
+import de.jplag.Language;
 import de.jplag.Match;
 import de.jplag.Submission;
 import de.jplag.Token;
@@ -58,8 +59,16 @@ public class Report { // Mostly legacy code with some minor improvements.
         System.out.println("\nWriting report...");
         writeIndex();
         copyStaticFiles();
-        writeMatches(result.getComparisons(options.getMaximumNumberOfComparisons()));
+        writeMatches(result.getComparisons(getOptions().getMaximumNumberOfComparisons()));
         System.out.println("Report exported to " + reportDir.getAbsolutePath());
+    }
+
+    private JPlagOptions getOptions() {
+        return options;
+    }
+
+    private Language getLanguage() {
+        return options.getLanguage();
     }
 
     /*
@@ -161,7 +170,7 @@ public class Report { // Mostly legacy code with some minor improvements.
                     + "',3)\" NAME=\"" + i + "\">");
             htmlFile.print(new String(startA.file.getBytes()));
 
-            if (result.getOptions().getLanguage().usesIndex()) {
+            if (getLanguage().usesIndex()) {
                 htmlFile.print("(" + startA.getIndex() + "-" + endA.getIndex() + ")");
             } else {
                 htmlFile.print("(" + startA.getLine() + "-" + endA.getLine() + ")");
@@ -171,7 +180,7 @@ public class Report { // Mostly legacy code with some minor improvements.
                     + "',3)\" NAME=\"" + i + "\">");
             htmlFile.print(startB.file);
 
-            if (result.getOptions().getLanguage().usesIndex()) {
+            if (getLanguage().usesIndex()) {
                 htmlFile.print("(" + startB.getIndex() + "-" + endB.getIndex());
             } else {
                 htmlFile.print("(" + startB.getLine() + "-" + endB.getLine());
@@ -181,7 +190,7 @@ public class Report { // Mostly legacy code with some minor improvements.
                     ")</A><TD ALIGN=center>" + "<FONT COLOR=\"" + comparison.color(match.getLength()) + "\">" + match.getLength() + "</FONT>");
         }
 
-        if (result.getOptions().hasBaseCode()) {
+        if (getOptions().hasBaseCode()) {
             htmlFile.print(
                     "<TR><TD BGCOLOR=\"#C0C0C0\"><TD>" + msg.getString("AllMatches.Basecode") + " " + comparison.basecodeSimilarityOfFirst() + "%");
             htmlFile.println("<TD>" + msg.getString("AllMatches.Basecode") + " " + comparison.basecodeSimilarityOfSecond() + "%<TD>&nbsp;");
@@ -189,6 +198,8 @@ public class Report { // Mostly legacy code with some minor improvements.
 
         htmlFile.println("</TABLE>");
     }
+
+
 
     private synchronized void reportMatchWritingProgress(List<JPlagComparison> comparisons) {
         matchesWritten++;
@@ -306,7 +317,7 @@ public class Report { // Mostly legacy code with some minor improvements.
             }
         }
 
-        if (result.getOptions().hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
+        if (getOptions().hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
             JPlagComparison baseCodeComparison = comparison.getBaseCodeMatches(j == 0);
 
             for (Match match : baseCodeComparison.getMatches()) {
@@ -386,18 +397,18 @@ public class Report { // Mostly legacy code with some minor improvements.
             f.println("</center>");
             f.println("</h3>");
             f.println("<HR>");
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (getLanguage().isPreformatted()) {
                 f.println("<PRE>");
             }
             for (int y = 0; y < text[x].length; y++) {
                 f.print(text[x][y]);
-                if (!result.getOptions().getLanguage().isPreformatted()) {
+                if (!getLanguage().isPreformatted()) {
                     f.println("<BR>");
                 } else {
                     f.println();
                 }
             }
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (getLanguage().isPreformatted()) {
                 f.println("</PRE>");
             }
         }
@@ -437,20 +448,20 @@ public class Report { // Mostly legacy code with some minor improvements.
         htmlFile.println("<TD><H1><BIG>" + title + "</BIG></H1></TD></TR>");
 
         htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Language") + ":</TD><TD>"
-                + result.getOptions().getLanguageOption().name() + "</TD></TR>");
+                         + getLanguage().getName() + "</TD></TR>");
         htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Submissions") + ":</TD><TD>" + result.getNumberOfSubmissions());
 
         htmlFile.println("</TD></TR>");
 
-        if (result.getOptions().hasBaseCode()) {
+        if (getOptions().hasBaseCode()) {
             htmlFile.print("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Basecode_submission") + ":</TD>" + "<TD>"
-                    + result.getOptions().getBaseCodeSubmissionName() + "</TD></TR>");
+                           + getOptions().getBaseCodeSubmissionName() + "</TD></TR>");
         }
 
-        if (options.getMaximumNumberOfComparisons() > 0) {
+        if (getOptions().getMaximumNumberOfComparisons() > 0) {
             htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Matches_displayed") + ":</TD>" + "<TD>");
-            htmlFile.println(options.getMaximumNumberOfComparisons() + " of " + result.getComparisons().size() + " ("
-                    + msg.getString("Report.Treshold") + ": " + result.getOptions().getSimilarityThreshold() + "%)<br>");
+            htmlFile.println(getOptions().getMaximumNumberOfComparisons() + " of " + result.getComparisons().size() + " ("
+                             + msg.getString("Report.Treshold") + ": " + getOptions().getSimilarityThreshold() + "%)<br>");
 
             htmlFile.println("</TD></TR>");
         }
@@ -460,10 +471,10 @@ public class Report { // Mostly legacy code with some minor improvements.
         htmlFile.println(
                 "<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Date") + ":</TD><TD>" + dateFormat.format(new Date()) + "</TD></TR>");
         htmlFile.println("<TR BGCOLOR=#aaaaff>" + "<TD><EM>" + msg.getString("Report.Minimum_Match_Length") + "</EM> ("
-                + msg.getString("Report.sensitivity") + "):</TD><TD>" + result.getOptions().getMinimumTokenMatch() + "</TD></TR>");
+                         + msg.getString("Report.sensitivity") + "):</TD><TD>" + getOptions().getMinimumTokenMatch() + "</TD></TR>");
         htmlFile.println("<TR BGCOLOR=#aaaaff VALIGN=top><TD>" + msg.getString("Report.Suffixes") + ":</TD><TD>");
 
-        String[] fileSuffixes = result.getOptions().getFileSuffixes();
+        String[] fileSuffixes = getOptions().getFileSuffixes();
 
         for (int i = 0; i < fileSuffixes.length; i++) {
             htmlFile.print(fileSuffixes[i] + (i < fileSuffixes.length - 1 ? ", " : "</TD></TR>\n"));
@@ -555,7 +566,7 @@ public class Report { // Mostly legacy code with some minor improvements.
     }
 
     private void writeLinksToComparisons(HTMLFile htmlFile, String headerStr, String csvFile) {
-        List<JPlagComparison> comparisons = result.getComparisons(options.getMaximumNumberOfComparisons()); // should be already sorted!
+        List<JPlagComparison> comparisons = result.getComparisons(getOptions().getMaximumNumberOfComparisons()); // should be already sorted!
 
         htmlFile.println(headerStr + " (<a href=\"help-sim-" + "en" // Country tag
                 + ".html\"><small><font color=\"#000088\">" + msg.getString("Report.WhatIsThis") + "</font></small></a>):</H4>");
@@ -619,10 +630,10 @@ public class Report { // Mostly legacy code with some minor improvements.
 
         htmlFile.println("  <div style=\"display: flex;\">");
 
-        if (result.getOptions().getLanguage().usesIndex()) {
+        if (getLanguage().usesIndex()) {
             writeIndexedSubmission(htmlFile, i, comparison, 0);
             writeIndexedSubmission(htmlFile, i, comparison, 1);
-        } else if (result.getOptions().getLanguage().supportsColumns()) {
+        } else if (getLanguage().supportsColumns()) {
             writeImprovedSubmission(htmlFile, i, comparison, 0);
             writeImprovedSubmission(htmlFile, i, comparison, 1);
         } else {
@@ -651,7 +662,7 @@ public class Report { // Mostly legacy code with some minor improvements.
     private void writeMatchesCSV(String fileName) {
         FileWriter writer = null;
         File csvFile = new File(reportDir, fileName);
-        List<JPlagComparison> comparisons = result.getComparisons(options.getMaximumNumberOfComparisons());
+        List<JPlagComparison> comparisons = result.getComparisons(getOptions().getMaximumNumberOfComparisons());
 
         try {
             csvFile.createNewFile();
@@ -723,7 +734,7 @@ public class Report { // Mostly legacy code with some minor improvements.
             }
         }
 
-        if (result.getOptions().hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
+        if (getOptions().hasBaseCode() && comparison.getFirstBaseCodeMatches() != null && comparison.getSecondBaseCodeMatches() != null) {
             JPlagComparison baseCodeComparison = comparison.getBaseCodeMatches(j == 0);
 
             for (Match currentMatch : baseCodeComparison.getMatches()) {
@@ -763,18 +774,18 @@ public class Report { // Mostly legacy code with some minor improvements.
             f.println("</center>");
             f.println("</h3>");
             f.println("<HR>");
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (getLanguage().isPreformatted()) {
                 f.println("<PRE>");
             }
             for (int y = 0; y < text[x].length; y++) {
                 f.print(text[x][y]);
-                if (!result.getOptions().getLanguage().isPreformatted()) {
+                if (!getLanguage().isPreformatted()) {
                     f.println("<BR>");
                 } else {
                     f.println();
                 }
             }
-            if (result.getOptions().getLanguage().isPreformatted()) {
+            if (getLanguage().isPreformatted()) {
                 f.println("</PRE>");
             }
         }

--- a/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
+++ b/jplag/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
@@ -6,17 +6,19 @@ import de.jplag.GreedyStringTiling;
 import de.jplag.JPlagComparison;
 import de.jplag.Submission;
 import de.jplag.SubmissionSet;
-import de.jplag.options.JPlagOptions;
+import de.jplag.options.SimilarityMetric;
 
 public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
 
-    private GreedyStringTiling greedyStringTiling;
+    private final GreedyStringTiling greedyStringTiling;
 
-    protected JPlagOptions options;
+    private final SimilarityMetric similarityMetric;
+    private final float similarityThreshold;
 
-    public AbstractComparisonStrategy(JPlagOptions options, GreedyStringTiling greedyStringTiling) {
+    public AbstractComparisonStrategy(GreedyStringTiling greedyStringTiling, SimilarityMetric similarityMetric, float similarityThreshold) {
         this.greedyStringTiling = greedyStringTiling;
-        this.options = options;
+        this.similarityMetric = similarityMetric;
+        this.similarityThreshold = similarityThreshold;
     }
 
     /**
@@ -40,7 +42,7 @@ public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
         JPlagComparison comparison = greedyStringTiling.compare(first, second);
         System.out.println("Comparing " + first.getName() + "-" + second.getName() + ": " + comparison.similarity());
 
-        if (options.getSimilarityMetric().isAboveThreshold(comparison, options.getSimilarityThreshold())) {
+        if (similarityMetric.isAboveThreshold(comparison, similarityThreshold)) {
             return Optional.of(comparison);
         }
         return Optional.empty();

--- a/jplag/src/main/java/de/jplag/strategy/NormalComparisonStrategy.java
+++ b/jplag/src/main/java/de/jplag/strategy/NormalComparisonStrategy.java
@@ -8,12 +8,12 @@ import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
 import de.jplag.Submission;
 import de.jplag.SubmissionSet;
-import de.jplag.options.JPlagOptions;
+import de.jplag.options.SimilarityMetric;
 
 public class NormalComparisonStrategy extends AbstractComparisonStrategy {
 
-    public NormalComparisonStrategy(JPlagOptions options, GreedyStringTiling greedyStringTiling) {
-        super(options, greedyStringTiling);
+    public NormalComparisonStrategy(GreedyStringTiling greedyStringTiling, SimilarityMetric similarityMetric, float similarityThreshold) {
+        super(greedyStringTiling, similarityMetric, similarityThreshold);
     }
 
     @Override
@@ -39,12 +39,12 @@ public class NormalComparisonStrategy extends AbstractComparisonStrategy {
                 if (second.getTokenList() == null) {
                     continue;
                 }
-                compareSubmissions(first, second, withBaseCode).ifPresent(it -> comparisons.add(it));
+                compareSubmissions(first, second, withBaseCode).ifPresent(comparisons::add);
             }
         }
 
         long durationInMillis = System.currentTimeMillis() - timeBeforeStartInMillis;
-        return new JPlagResult(comparisons, submissionSet, durationInMillis, options);
+        return new JPlagResult(comparisons, submissionSet, durationInMillis);
     }
 
 }

--- a/jplag/src/test/java/de/jplag/TestBase.java
+++ b/jplag/src/test/java/de/jplag/TestBase.java
@@ -27,11 +27,13 @@ public abstract class TestBase {
         });
     }
 
-    protected JPlagResult runJPlag(String testSampleName, Consumer<JPlagOptions> customization) throws ExitException {
-        JPlagOptions options = new JPlagOptions(Path.of(BASE_PATH, testSampleName).toString(), LanguageOption.JAVA);
-        options.setVerbosity(Verbosity.LONG);
-        customization.accept(options);
-        JPlag jplag = new JPlag(options);
+    protected JPlagResult runJPlag(String testSampleName, Consumer<JPlagOptions.JPlagOptionsBuilder> customization) throws ExitException {
+        var optionBuilder = JPlagOptions.builder()
+                .setRootDirectoryName(Path.of(BASE_PATH, testSampleName).toString())
+                .setLanguageOption(LanguageOption.JAVA)
+                .setVerbosity(Verbosity.LONG);
+        customization.accept(optionBuilder);
+        JPlag jplag = new JPlag(optionBuilder.build());
         return jplag.run();
     }
 }

--- a/jplag/src/test/java/de/jplag/cli/MinTokenMatchTest.java
+++ b/jplag/src/test/java/de/jplag/cli/MinTokenMatchTest.java
@@ -23,19 +23,19 @@ public class MinTokenMatchTest extends CommandLineInterfaceTest {
         // Language defaults not set yet:
         buildOptionsFromCLI(CURRENT_DIRECTORY);
         assertNull(options.getMinimumTokenMatch());
-        assertNull(options.getLanguage());
 
+        JPlag jplag = null;
         // Init JPlag:
         try {
-            new JPlag(options);
+            jplag = new JPlag(options);
         } catch (ExitException e) {
             e.printStackTrace();
             fail("JPlag intialization failed!");
         }
 
         // Now the language is set:
-        assertNotNull(options.getLanguage());
-        assertEquals(options.getLanguage().minimumTokenMatch(), options.getMinimumTokenMatch().intValue());
+        assertNotNull(jplag.getLanguage());
+        assertEquals(jplag.getLanguage().minimumTokenMatch(), options.getMinimumTokenMatch().intValue());
     }
 
     @Test

--- a/jplag/src/test/java/de/jplag/cli/MinTokenMatchTest.java
+++ b/jplag/src/test/java/de/jplag/cli/MinTokenMatchTest.java
@@ -35,7 +35,7 @@ public class MinTokenMatchTest extends CommandLineInterfaceTest {
 
         // Now the language is set:
         assertNotNull(jplag.getLanguage());
-        assertEquals(jplag.getLanguage().minimumTokenMatch(), options.getMinimumTokenMatch().intValue());
+        assertEquals(jplag.getLanguage().minimumTokenMatch(), jplag.getConfigurationReport().getMinimumTokenMatch());
     }
 
     @Test


### PR DESCRIPTION
This patchset refactor JPlagOptions usage out of the main classes, in order to keep it outside of these classes.

* create a builder for JPlagOptions
* make JPlagOptions read-only
* move all rewritten fields inside JPlag class
* inject only the necessary options into the rest of the code
* add a ConfigurationReport class, accessible from JPlag directly, that will gives all the parameters used for the Report subsystem (unused for the moment)

## issues

* `GreedyStringTiling` still use `hasBaseCode`, I don't really know why. For me it should not be necessary, but the code it a bit hairy, and there is not enough test to have complete trust when changing the code.
* The JPlagOptions builder is horribly long, I really miss lombok here


Closes: #274 