### PR TITLE
Increase development version to 4.0.0-SNAPSHOT

### DIFF
--- a/jplag.frontend-utils/pom.xml
+++ b/jplag.frontend-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>frontend-utils</artifactId>
 

--- a/jplag.frontend.chars/pom.xml
+++ b/jplag.frontend.chars/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>chars</artifactId>
     <dependencies>

--- a/jplag.frontend.cpp/pom.xml
+++ b/jplag.frontend.cpp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>cpp</artifactId>
 

--- a/jplag.frontend.csharp-1.2/pom.xml
+++ b/jplag.frontend.csharp-1.2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>csharp-1.2</artifactId>
 

--- a/jplag.frontend.java/pom.xml
+++ b/jplag.frontend.java/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>java</artifactId>
     <dependencies>

--- a/jplag.frontend.python-3/pom.xml
+++ b/jplag.frontend.python-3/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>python-3</artifactId>
 

--- a/jplag.frontend.scheme/pom.xml
+++ b/jplag.frontend.scheme/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>scheme</artifactId>
 

--- a/jplag.frontend.text/pom.xml
+++ b/jplag.frontend.text/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>text</artifactId>
 

--- a/jplag/pom.xml
+++ b/jplag/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.jplag</groupId>
         <artifactId>aggregator</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>jplag</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.jplag</groupId>
     <artifactId>aggregator</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>JPlag Plagiarism Detector</name>


### PR DESCRIPTION
With the recent changes, the current version is API-breaking, thus the development version should be increased from 3.1.0-SNAPSHOT to 4.0.0-SNAPSHOT to reflect that.