### PR TITLE
Changed all dependencies to the name of the main branch

### DIFF
--- a/.github/workflows/report-viewer.yml
+++ b/.github/workflows/report-viewer.yml
@@ -4,7 +4,7 @@ on:
  workflow_dispatch: # Use this to dispatch from the Actions Tab
  push:
     branches:
-      - master
+      - main
       
 jobs:
   build-and-deploy:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI Build](https://github.com/jplag/jplag/actions/workflows/maven.yml/badge.svg)](https://github.com/jplag/jplag/actions/workflows/maven.yml)
 [![Latest Release](https://img.shields.io/github/release/jplag/jplag.svg)](https://github.com/jplag/jplag/releases/latest)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/de.jplag/jplag/badge.svg)](https://maven-badges.herokuapp.com/maven-central/de.jplag/jplag)
-[![License](https://img.shields.io/github/license/jplag/jplag.svg)](https://github.com/jplag/jplag/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/jplag/jplag.svg)](https://github.com/jplag/jplag/blob/main/LICENSE)
 [![Lines of code](https://img.shields.io/tokei/lines/github/jplag/jplag)](https://github.com/jplag/jplag/graphs/contributors)
 
 ## Download and Installation

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <scm>
         <connection>scm:git:git://github.com/jplag/JPlag.git</connection>
         <developerConnection>scm:git:ssh://github.com:jplag/JPlag.git</developerConnection>
-        <url>http://github.com/jplag/JPlag/tree/master</url>
+        <url>http://github.com/jplag/JPlag/tree/main</url>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Since most repositories (from my point of view :) ) are moving to `main` as new default branch. I've prepared a possible transition to a new default branch.