### PR TITLE
Create action to npm build PRs

### DIFF
--- a/.github/workflows/report-viewer-test.yml
+++ b/.github/workflows/report-viewer-test.yml
@@ -1,0 +1,23 @@
+name: Report Viewer Build Workflow # Copy of report viewer deployment, but without deployment for PRs :)
+
+on:
+ workflow_dispatch:
+ pull_request:
+    types: [opened, synchronize, reopened]
+      
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+      
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          
+      - name: Install and Build 🔧
+        working-directory: report-viewer
+        run: |
+          npm install
+          npm run build


### PR DESCRIPTION
This action should be triggered on PRs (especially those dependabot PRs) and try to build the report viewer with the updated dependencies.