### PR TITLE
Change antlr.preprocessor.Preprocessor to ClusteringPreprocessor.

### DIFF
--- a/jplag/src/main/java/de/jplag/clustering/Preprocessing.java
+++ b/jplag/src/main/java/de/jplag/clustering/Preprocessing.java
@@ -3,14 +3,12 @@ package de.jplag.clustering;
 import java.util.Optional;
 import java.util.function.Function;
 
-import antlr.preprocessor.Preprocessor;
-
 import de.jplag.clustering.preprocessors.CumulativeDistributionFunctionPreprocessor;
 import de.jplag.clustering.preprocessors.PercentileThresholdProcessor;
 import de.jplag.clustering.preprocessors.ThresholdPreprocessor;
 
 /**
- * List of all usable {@link Preprocessor}s.
+ * List of all usable {@link ClusteringPreprocessor}s.
  */
 public enum Preprocessing {
     NONE(options -> null),


### PR DESCRIPTION
While building an executable I ran into an `antlr.preprocessor.Preprocessor` import that is only used in the comment below. Antlr is still used in a few frontends but not in the main program code anymore it seems.

I think it should be the new `ClusteringPreprocessor` class, as all processors there derive from it.
