### PR TITLE
Lightweight frontend tests and frontend-testutils (+ JUnit 5 for every test)

### DIFF
--- a/jplag.frontend-testutils/pom.xml
+++ b/jplag.frontend-testutils/pom.xml
@@ -14,10 +14,5 @@
             <groupId>de.jplag</groupId>
             <artifactId>frontend-utils</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
     </dependencies>
-
 </project>

--- a/jplag.frontend-testutils/pom.xml
+++ b/jplag.frontend-testutils/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>de.jplag</groupId>
+        <artifactId>aggregator</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>frontend-testutils</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>frontend-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jplag.frontend-testutils/src/test/java/de/jplag/testutils/TestErrorConsumer.java
+++ b/jplag.frontend-testutils/src/test/java/de/jplag/testutils/TestErrorConsumer.java
@@ -1,0 +1,24 @@
+package de.jplag.testutils;
+
+import static org.junit.Assert.fail;
+
+import de.jplag.ErrorConsumer;
+
+/**
+ * Mock error consumer that fails the test case on error occurence.
+ * @author Timur Saglam
+ */
+public class TestErrorConsumer implements ErrorConsumer {
+
+    @Override
+    public void addError(String errorMessage) {
+        System.err.println(errorMessage);
+        fail(errorMessage);
+    }
+
+    @Override
+    public void print(String message, String longMessage) {
+        System.out.println(message);
+    }
+
+}

--- a/jplag.frontend-testutils/src/test/java/de/jplag/testutils/TestErrorConsumer.java
+++ b/jplag.frontend-testutils/src/test/java/de/jplag/testutils/TestErrorConsumer.java
@@ -1,11 +1,11 @@
 package de.jplag.testutils;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import de.jplag.ErrorConsumer;
 
 /**
- * Mock error consumer that fails the test case on error occurence.
+ * Mock error consumer that fails the test case on error occurrence.
  * @author Timur Saglam
  */
 public class TestErrorConsumer implements ErrorConsumer {

--- a/jplag.frontend-utils/pom.xml
+++ b/jplag.frontend-utils/pom.xml
@@ -8,5 +8,4 @@
         <version>${revision}</version>
     </parent>
     <artifactId>frontend-utils</artifactId>
-
 </project>

--- a/jplag.frontend-utils/src/main/java/de/jplag/Token.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/Token.java
@@ -80,6 +80,13 @@ public abstract class Token {
     }
 
     /**
+     * @return the type identifier of the token.
+     */
+    public int getType() {
+        return type;
+    }
+
+    /**
      * Sets the character index which denotes where the code sections represented by this token starts in the line.
      * @param column is the index in characters to set.
      */

--- a/jplag.frontend.csharp-6/pom.xml
+++ b/jplag.frontend.csharp-6/pom.xml
@@ -21,10 +21,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>

--- a/jplag.frontend.csharp-6/pom.xml
+++ b/jplag.frontend.csharp-6/pom.xml
@@ -14,6 +14,17 @@
             <artifactId>frontend-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>frontend-testutils</artifactId>
+            <version>${revision}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>

--- a/jplag.frontend.csharp-6/src/test/java/de/jplag/csharp/MinimalCSharpFrontendTest.java
+++ b/jplag.frontend.csharp-6/src/test/java/de/jplag/csharp/MinimalCSharpFrontendTest.java
@@ -1,20 +1,9 @@
 package de.jplag.csharp;
 
-import static de.jplag.csharp.CSharpTokenConstants.ASSIGNMENT;
-import static de.jplag.csharp.CSharpTokenConstants.CLASS;
-import static de.jplag.csharp.CSharpTokenConstants.CLASS_BEGIN;
-import static de.jplag.csharp.CSharpTokenConstants.CLASS_END;
-import static de.jplag.csharp.CSharpTokenConstants.CONSTRUCTOR;
-import static de.jplag.csharp.CSharpTokenConstants.DECLARE_VAR;
-import static de.jplag.csharp.CSharpTokenConstants.INVOCATION;
-import static de.jplag.csharp.CSharpTokenConstants.METHOD;
-import static de.jplag.csharp.CSharpTokenConstants.METHOD_BEGIN;
-import static de.jplag.csharp.CSharpTokenConstants.METHOD_END;
-import static de.jplag.csharp.CSharpTokenConstants.PROPERTY;
-import static de.jplag.csharp.CSharpTokenConstants.RETURN;
+import static de.jplag.csharp.CSharpTokenConstants.*;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -22,15 +11,16 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import de.jplag.Token;
 import de.jplag.TokenConstants;
 import de.jplag.TokenList;
 import de.jplag.TokenPrinter;
 import de.jplag.testutils.TestErrorConsumer;
 
-public class MinimalCSharpFrontendTest {
+class MinimalCSharpFrontendTest {
     private static final int EXPEXTED_NUMBER_OF_TOKENS = 15;
     private static final Path BASE_PATH = Path.of("src", "test", "resources", "de", "jplag", "csharp");
     private static final String TEST_SUBJECT = "TestClass.cs";
@@ -38,16 +28,16 @@ public class MinimalCSharpFrontendTest {
     private de.jplag.Language frontend;
     private File baseDirectory;
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeEach
+    public void setUp() {
         TestErrorConsumer consumer = new TestErrorConsumer();
         frontend = new Language(consumer);
         baseDirectory = BASE_PATH.toFile();
-        assertTrue("Could not find base directory!", baseDirectory.exists());
+        assertTrue(baseDirectory.exists(), "Could not find base directory!");
     }
 
     @Test
-    public void testParsingTestClass() {
+    void testParsingTestClass() {
         List<Integer> expectedToken = List.of(CLASS, CLASS_BEGIN, DECLARE_VAR, CONSTRUCTOR, METHOD, METHOD_BEGIN, INVOCATION, METHOD_END, PROPERTY,
                 DECLARE_VAR, PROPERTY, RETURN, ASSIGNMENT, CLASS_END, TokenConstants.FILE_END);
 
@@ -58,7 +48,7 @@ public class MinimalCSharpFrontendTest {
 
         // Compare parsed tokens:
         assertEquals(EXPEXTED_NUMBER_OF_TOKENS, result.size());
-        List<Integer> actualToken = StreamSupport.stream(result.allTokens().spliterator(), false).map(it -> it.getType()).collect(toList());
+        List<Integer> actualToken = StreamSupport.stream(result.allTokens().spliterator(), false).map(Token::getType).collect(toList());
         assertEquals(expectedToken, actualToken);
     }
 

--- a/jplag.frontend.csharp-6/src/test/java/de/jplag/csharp/MinimalCSharpFrontendTest.java
+++ b/jplag.frontend.csharp-6/src/test/java/de/jplag/csharp/MinimalCSharpFrontendTest.java
@@ -1,0 +1,65 @@
+package de.jplag.csharp;
+
+import static de.jplag.csharp.CSharpTokenConstants.ASSIGNMENT;
+import static de.jplag.csharp.CSharpTokenConstants.CLASS;
+import static de.jplag.csharp.CSharpTokenConstants.CLASS_BEGIN;
+import static de.jplag.csharp.CSharpTokenConstants.CLASS_END;
+import static de.jplag.csharp.CSharpTokenConstants.CONSTRUCTOR;
+import static de.jplag.csharp.CSharpTokenConstants.DECLARE_VAR;
+import static de.jplag.csharp.CSharpTokenConstants.INVOCATION;
+import static de.jplag.csharp.CSharpTokenConstants.METHOD;
+import static de.jplag.csharp.CSharpTokenConstants.METHOD_BEGIN;
+import static de.jplag.csharp.CSharpTokenConstants.METHOD_END;
+import static de.jplag.csharp.CSharpTokenConstants.PROPERTY;
+import static de.jplag.csharp.CSharpTokenConstants.RETURN;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.jplag.TokenConstants;
+import de.jplag.TokenList;
+import de.jplag.TokenPrinter;
+import de.jplag.testutils.TestErrorConsumer;
+
+public class MinimalCSharpFrontendTest {
+    private static final int EXPEXTED_NUMBER_OF_TOKENS = 15;
+    private static final Path BASE_PATH = Path.of("src", "test", "resources", "de", "jplag", "csharp");
+    private static final String TEST_SUBJECT = "TestClass.cs";
+
+    private de.jplag.Language frontend;
+    private File baseDirectory;
+
+    @Before
+    public void setUp() throws Exception {
+        TestErrorConsumer consumer = new TestErrorConsumer();
+        frontend = new Language(consumer);
+        baseDirectory = BASE_PATH.toFile();
+        assertTrue("Could not find base directory!", baseDirectory.exists());
+    }
+
+    @Test
+    public void testParsingTestClass() {
+        List<Integer> expectedToken = List.of(CLASS, CLASS_BEGIN, DECLARE_VAR, CONSTRUCTOR, METHOD, METHOD_BEGIN, INVOCATION, METHOD_END, PROPERTY,
+                DECLARE_VAR, PROPERTY, RETURN, ASSIGNMENT, CLASS_END, TokenConstants.FILE_END);
+
+        // Parse test input
+        String[] input = new String[] {TEST_SUBJECT};
+        TokenList result = frontend.parse(baseDirectory, input);
+        System.out.println(TokenPrinter.printTokens(result, baseDirectory, Arrays.asList(input)));
+
+        // Compare parsed tokens:
+        assertEquals(EXPEXTED_NUMBER_OF_TOKENS, result.size());
+        List<Integer> actualToken = StreamSupport.stream(result.allTokens().spliterator(), false).map(it -> it.getType()).collect(toList());
+        assertEquals(expectedToken, actualToken);
+    }
+
+}

--- a/jplag.frontend.csharp-6/src/test/resources/de/jplag/csharp/TestClass.cs
+++ b/jplag.frontend.csharp-6/src/test/resources/de/jplag/csharp/TestClass.cs
@@ -1,0 +1,27 @@
+/**
+ * Class for testing the C# language frontend.
+ */
+public class MyClass
+{
+    public string  myField = string.Empty;
+
+    public MyClass()
+    {
+    }
+
+    public void MyMethod(int parameter1, string parameter2)
+    {
+        Console.WriteLine("First Parameter {0}, second parameter {1}", 
+                                                    parameter1, parameter2);
+    }
+
+    public int MyAutoImplementedProperty { get; set; }
+
+    private int myPropertyVar;
+    
+    public int MyProperty
+    {
+        get { return myPropertyVar; }
+        set { myPropertyVar = value; }
+    } 
+}

--- a/jplag/pom.xml
+++ b/jplag/pom.xml
@@ -16,11 +16,6 @@
             <artifactId>argparse4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.13.2.2</version>
@@ -30,13 +25,6 @@
             <artifactId>commons-math3</artifactId>
             <version>3.6.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>4.5.1</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>frontend-utils</artifactId>

--- a/jplag/src/test/java/de/jplag/BaseCodeTest.java
+++ b/jplag/src/test/java/de/jplag/BaseCodeTest.java
@@ -1,11 +1,12 @@
 package de.jplag;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.exceptions.BasecodeException;
 import de.jplag.exceptions.ExitException;
@@ -14,24 +15,24 @@ import de.jplag.exceptions.RootDirectoryException;
 public class BaseCodeTest extends TestBase {
 
     @Test
-    public void testBasecodeUserSubmissionComparison() throws ExitException {
+    void testBasecodeUserSubmissionComparison() throws ExitException {
         JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName("base"));
         verifyResults(result);
     }
 
-    @Test(expected = BasecodeException.class)
-    public void testTinyBasecode() throws ExitException {
-        runJPlag("TinyBasecode", it -> it.setBaseCodeSubmissionName("base"));
+    @Test
+    void testTinyBasecode() {
+        assertThrows(BasecodeException.class, () -> runJPlag("TinyBasecode", it -> it.setBaseCodeSubmissionName("base")));
     }
 
     @Test
-    public void testEmptySubmission() throws ExitException {
+    void testEmptySubmission() throws ExitException {
         JPlagResult result = runJPlag("emptysubmission", it -> it.setBaseCodeSubmissionName("base"));
         verifyResults(result);
     }
 
     @Test
-    public void testAutoTrimFileSeparators() throws ExitException {
+    void testAutoTrimFileSeparators() throws ExitException {
         JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName(File.separator + "base" + File.separator));
         verifyResults(result);
     }
@@ -45,23 +46,23 @@ public class BaseCodeTest extends TestBase {
     }
 
     @Test
-    public void testBasecodePathComparison() throws ExitException {
+    void testBasecodePathComparison() throws ExitException {
         JPlagResult result = runJPlag("basecode", it -> it.setBaseCodeSubmissionName(getBasePath("basecode-base")));
         assertEquals(3, result.getNumberOfSubmissions()); // "basecode/base" is now a user submission.
     }
 
-    @Test(expected = RootDirectoryException.class)
-    public void testInvalidRoot() throws ExitException {
-        runJPlag("basecode", it -> it.setSubmissionDirectories(List.of("WrongRoot")));
+    @Test
+    void testInvalidRoot() throws ExitException {
+        assertThrows(RootDirectoryException.class, () -> runJPlag("basecode", it -> it.setSubmissionDirectories(List.of("WrongRoot"))));
     }
 
-    @Test(expected = BasecodeException.class)
-    public void testInvalidBasecode() throws ExitException {
-        runJPlag("basecode", it -> it.setBaseCodeSubmissionName("WrongBasecode"));
+    @Test
+    void testInvalidBasecode() {
+        assertThrows(BasecodeException.class, () -> runJPlag("basecode", it -> it.setBaseCodeSubmissionName("WrongBasecode")));
     }
 
-    @Test(expected = BasecodeException.class)
-    public void testBasecodeUserSubmissionWithDots() throws ExitException {
-        runJPlag("basecode", it -> it.setBaseCodeSubmissionName("base.ext"));
+    @Test
+    void testBasecodeUserSubmissionWithDots() {
+        assertThrows(BasecodeException.class, () -> runJPlag("basecode", it -> it.setBaseCodeSubmissionName("base.ext")));
     }
 }

--- a/jplag/src/test/java/de/jplag/InvalidSubmissionTest.java
+++ b/jplag/src/test/java/de/jplag/InvalidSubmissionTest.java
@@ -1,19 +1,17 @@
 package de.jplag;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.exceptions.ExitException;
 import de.jplag.exceptions.SubmissionException;
 
-public class InvalidSubmissionTest extends TestBase {
+class InvalidSubmissionTest extends TestBase {
 
     private static final String SAMPLE_NAME = "InvalidSubmissions";
 
@@ -22,7 +20,7 @@ public class InvalidSubmissionTest extends TestBase {
      * invalid submissions being stored.
      */
     @Test
-    public void testInvalidSubmissionsWithDebug() throws ExitException {
+    void testInvalidSubmissionsWithDebug() throws ExitException {
         try {
             runJPlag(SAMPLE_NAME, it -> it.setDebugParser(true));
             fail("No submission exception was thrown!");

--- a/jplag/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/jplag/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -1,8 +1,8 @@
 package de.jplag;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.exceptions.ExitException;
 
@@ -19,11 +19,11 @@ public class NewJavaFeaturesTest extends TestBase {
         JPlagResult result = runJPlagWithExclusionFile(ROOT_DIRECTORY, EXCLUSION_FILE_NAME);
 
         // Ensure test input did not change:
-        assertEquals(String.format(CHANGE_MESSAGE, "Submissions"), 2, result.getNumberOfSubmissions());
+        assertEquals(2, result.getNumberOfSubmissions(), String.format(CHANGE_MESSAGE, "Submissions"));
         for (Submission submission : result.getSubmissions().getSubmissions()) {
-            assertEquals(String.format(CHANGE_MESSAGE, "Files"), 6, submission.getFiles().size());
+            assertEquals(6, submission.getFiles().size(), String.format(CHANGE_MESSAGE, "Files"));
         }
-        assertEquals(String.format(CHANGE_MESSAGE, "Comparisons"), 1, result.getComparisons().size());
+        assertEquals(1, result.getComparisons().size(), String.format(CHANGE_MESSAGE, "Comparisons"));
 
         // Check similarity and number of matches:
         var comparison = result.getComparisons().get(0);

--- a/jplag/src/test/java/de/jplag/NormalComparisonTest.java
+++ b/jplag/src/test/java/de/jplag/NormalComparisonTest.java
@@ -1,23 +1,23 @@
 package de.jplag;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.exceptions.BasecodeException;
 import de.jplag.exceptions.ExitException;
 
-public class NormalComparisonTest extends TestBase {
+class NormalComparisonTest extends TestBase {
 
     /**
      * The simple duplicate contains obvious plagiarism.
      */
     @Test
-    public void testSimpleDuplicate() throws ExitException {
+    void testSimpleDuplicate() throws ExitException {
         JPlagResult result = runJPlagWithDefaultOptions("SimpleDuplicate");
 
         assertEquals(2, result.getNumberOfSubmissions());
@@ -31,7 +31,7 @@ public class NormalComparisonTest extends TestBase {
      * The classes in no duplicate have nearly nothing in common.
      */
     @Test
-    public void testNoDuplicate() throws ExitException {
+    void testNoDuplicate() throws ExitException {
         JPlagResult result = runJPlagWithDefaultOptions("NoDuplicate");
 
         assertEquals(3, result.getNumberOfSubmissions());
@@ -48,7 +48,7 @@ public class NormalComparisonTest extends TestBase {
      * e.g., changed variable names, additional unneeded code, ... E is just a Hello World Java errorConsumer
      */
     @Test
-    public void testPartialPlagiarism() throws ExitException {
+    void testPartialPlagiarism() throws ExitException {
         JPlagResult result = runJPlagWithDefaultOptions("PartialPlagiarism");
 
         assertEquals(5, result.getNumberOfSubmissions());
@@ -88,7 +88,7 @@ public class NormalComparisonTest extends TestBase {
     }
 
     @Test
-    public void testMultiRootDirNoBasecode() throws ExitException {
+    void testMultiRootDirNoBasecode() throws ExitException {
         List<String> paths = List.of(getBasePath("basecode"), getBasePath("SimpleDuplicate")); // 3 + 2 submissions.
         JPlagResult result = runJPlag(paths, options -> {
         });
@@ -96,7 +96,7 @@ public class NormalComparisonTest extends TestBase {
     }
 
     @Test
-    public void testMultiRootDirSeparateBasecode() throws ExitException {
+    void testMultiRootDirSeparateBasecode() throws ExitException {
         String basecodePath = getBasePath("basecode-base");
         List<String> paths = List.of(getBasePath("basecode"), getBasePath("SimpleDuplicate")); // 3 + 2 submissions.
         JPlagResult result = runJPlag(paths, it -> it.setBaseCodeSubmissionName(basecodePath));
@@ -111,12 +111,11 @@ public class NormalComparisonTest extends TestBase {
         assertEquals(4, result.getNumberOfSubmissions());
     }
 
-    @Test(expected = BasecodeException.class)
+    @Test
     public void testMultiRootDirBasecodeName() throws ExitException {
         List<String> paths = List.of(getBasePath("basecode"), getBasePath("SimpleDuplicate"));
         String basecodePath = "base"; // Should *not* find basecode/base
-        runJPlag(paths, it -> it.setBaseCodeSubmissionName(basecodePath));
-        fail("No basecode exception was thrown!");
+        assertThrows(BasecodeException.class, () -> runJPlag(paths, it -> it.setBaseCodeSubmissionName(basecodePath)));
     }
 
     @Test
@@ -130,7 +129,7 @@ public class NormalComparisonTest extends TestBase {
     }
 
     @Test
-    public void testOverlappingNewAndOldDirectoriesOverlap() throws ExitException {
+    void testOverlappingNewAndOldDirectoriesOverlap() throws ExitException {
         List<String> newDirectories = List.of(getBasePath("SimpleDuplicate")); // 2 submissions
         List<String> oldDirectories = List.of(getBasePath("SimpleDuplicate"));
         JPlagResult result = runJPlag(newDirectories, oldDirectories, it -> {
@@ -140,7 +139,7 @@ public class NormalComparisonTest extends TestBase {
     }
 
     @Test
-    public void testBasecodeInOldDirectory() throws ExitException {
+    void testBasecodeInOldDirectory() throws ExitException {
         String basecodePath = getBasePath("basecode", "base");
         List<String> newDirectories = List.of(getBasePath("SimpleDuplicate")); // 2 submissions
         List<String> oldDirectories = List.of(getBasePath("basecode")); // 3 - 1 submissions

--- a/jplag/src/test/java/de/jplag/ParallelComparisonTest.java
+++ b/jplag/src/test/java/de/jplag/ParallelComparisonTest.java
@@ -1,11 +1,11 @@
 package de.jplag;
 
 import static de.jplag.strategy.ComparisonMode.PARALLEL;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.exceptions.ExitException;
 import de.jplag.strategy.ParallelComparisonStrategy;

--- a/jplag/src/test/java/de/jplag/cli/BaseCodeOptionTest.java
+++ b/jplag/src/test/java/de/jplag/cli/BaseCodeOptionTest.java
@@ -1,25 +1,25 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.CommandLineArgument;
 
-public class BaseCodeOptionTest extends CommandLineInterfaceTest {
+class BaseCodeOptionTest extends CommandLineInterfaceTest {
 
     private static final String NAME = "BaseCodeName";
 
     @Test
-    public void testDefaultValue() {
+    void testDefaultValue() {
         buildOptionsFromCLI(CURRENT_DIRECTORY);
         assertEquals(Optional.empty(), options.getBaseCodeSubmissionName());
     }
 
     @Test
-    public void testCustomName() {
+    void testCustomName() {
         String argument = buildArgument(CommandLineArgument.BASE_CODE, NAME);
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
         assertEquals(NAME, options.getBaseCodeSubmissionName().get());

--- a/jplag/src/test/java/de/jplag/cli/ClusteringTest.java
+++ b/jplag/src/test/java/de/jplag/cli/ClusteringTest.java
@@ -1,33 +1,33 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.CommandLineArgument;
 import de.jplag.clustering.Preprocessing;
 
-public class ClusteringTest extends CommandLineInterfaceTest {
+class ClusteringTest extends CommandLineInterfaceTest {
 
     private static final double EPSILON = 0.000001;
 
     @Test
-    public void parsePercentilePreProcessor() {
-        String argument = CommandLineArgument.CLUSTER_PREPROCESSING_PERCENTILE.flag() + "=" + Float.toString(0.5f);
+    void parsePercentilePreProcessor() {
+        String argument = CommandLineArgument.CLUSTER_PREPROCESSING_PERCENTILE.flag() + "=" + 0.5f;
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
         assertEquals(Preprocessing.PERCENTILE, options.getClusteringOptions().getPreprocessor());
         assertEquals(0.5, options.getClusteringOptions().getPreprocessorPercentile(), EPSILON);
     }
 
     @Test
-    public void parseCdfPreProcessor() {
+    void parseCdfPreProcessor() {
         String argument = CommandLineArgument.CLUSTER_PREPROCESSING_CDF.flag();
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
         assertEquals(Preprocessing.CUMULATIVE_DISTRIBUTION_FUNCTION, options.getClusteringOptions().getPreprocessor());
     }
 
     @Test
-    public void parseNoPreProcessor() {
+    void parseNoPreProcessor() {
         String argument = CommandLineArgument.CLUSTER_PREPROCESSING_NONE.flag();
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
         assertEquals(Preprocessing.NONE, options.getClusteringOptions().getPreprocessor());

--- a/jplag/src/test/java/de/jplag/cli/ComparisonModeTest.java
+++ b/jplag/src/test/java/de/jplag/cli/ComparisonModeTest.java
@@ -1,35 +1,31 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.CommandLineArgument;
 import de.jplag.options.JPlagOptions;
 import de.jplag.strategy.ComparisonMode;
 
-public class ComparisonModeTest extends CommandLineInterfaceTest {
-
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
+class ComparisonModeTest extends CommandLineInterfaceTest {
 
     @Test
-    public void testDefaultMode() {
+    void testDefaultMode() {
         buildOptionsFromCLI(CURRENT_DIRECTORY);
         assertEquals(JPlagOptions.DEFAULT_COMPARISON_MODE, options.getComparisonMode());
     }
 
     @Test
-    public void testInvalidMode() {
-        exit.expectSystemExitWithStatus(1);
+    void testInvalidMode() throws Exception {
         String argument = buildArgument(CommandLineArgument.COMPARISON_MODE, "Test'); DROP TABLE STUDENTS; --");
-        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        int statusCode = catchSystemExit(() -> buildOptionsFromCLI(argument, CURRENT_DIRECTORY));
+        assertEquals(1, statusCode);
     }
 
     @Test
-    public void testNormalMode() {
+    void testNormalMode() {
         ComparisonMode mode = ComparisonMode.NORMAL;
         String argument = buildArgument(CommandLineArgument.COMPARISON_MODE, mode.getName());
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
@@ -37,7 +33,7 @@ public class ComparisonModeTest extends CommandLineInterfaceTest {
     }
 
     @Test
-    public void testParallelMode() {
+    void testParallelMode() {
         ComparisonMode mode = ComparisonMode.PARALLEL;
         String argument = buildArgument(CommandLineArgument.COMPARISON_MODE, mode.getName());
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);

--- a/jplag/src/test/java/de/jplag/cli/LanguageOptionTest.java
+++ b/jplag/src/test/java/de/jplag/cli/LanguageOptionTest.java
@@ -1,18 +1,14 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.CommandLineArgument;
 import de.jplag.options.LanguageOption;
 
 public class LanguageOptionTest extends CommandLineInterfaceTest {
-
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void testDefaultLanguage() {
@@ -21,10 +17,10 @@ public class LanguageOptionTest extends CommandLineInterfaceTest {
     }
 
     @Test
-    public void testInvalidLanguage() {
-        exit.expectSystemExitWithStatus(1);
+    public void testInvalidLanguage() throws Exception {
         String argument = buildArgument(CommandLineArgument.LANGUAGE, "Piet");
-        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        int statusCode = catchSystemExit(() -> buildOptionsFromCLI(argument, CURRENT_DIRECTORY));
+        assertEquals(1, statusCode);
     }
 
     @Test

--- a/jplag/src/test/java/de/jplag/cli/MinTokenMatchTest.java
+++ b/jplag/src/test/java/de/jplag/cli/MinTokenMatchTest.java
@@ -1,20 +1,14 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.CommandLineArgument;
 import de.jplag.JPlag;
 
 public class MinTokenMatchTest extends CommandLineInterfaceTest {
-
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void testLanguageDefault() {
@@ -32,17 +26,17 @@ public class MinTokenMatchTest extends CommandLineInterfaceTest {
     }
 
     @Test
-    public void testInvalidInput() {
-        exit.expectSystemExitWithStatus(1);
+    public void testInvalidInput() throws Exception {
         String argument = buildArgument(CommandLineArgument.MIN_TOKEN_MATCH, "Not an integer...");
-        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        int statusCode = catchSystemExit(() -> buildOptionsFromCLI(argument, CURRENT_DIRECTORY));
+        assertEquals(1, statusCode);
     }
 
     @Test
-    public void testUpperBound() {
-        exit.expectSystemExitWithStatus(1);
+    public void testUpperBound() throws Exception {
         String argument = buildArgument(CommandLineArgument.MIN_TOKEN_MATCH, "2147483648"); // max value plus one
-        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        int statusCode = catchSystemExit(() -> buildOptionsFromCLI(argument, CURRENT_DIRECTORY));
+        assertEquals(1, statusCode);
     }
 
     @Test

--- a/jplag/src/test/java/de/jplag/cli/OldNewRootDirectoriesArgumentTest.java
+++ b/jplag/src/test/java/de/jplag/cli/OldNewRootDirectoriesArgumentTest.java
@@ -1,8 +1,8 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OldNewRootDirectoriesArgumentTest extends CommandLineInterfaceTest {
     @Test

--- a/jplag/src/test/java/de/jplag/cli/SimiliarityThresholdTest.java
+++ b/jplag/src/test/java/de/jplag/cli/SimiliarityThresholdTest.java
@@ -1,18 +1,14 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.CommandLineArgument;
 import de.jplag.options.JPlagOptions;
 
 public class SimiliarityThresholdTest extends CommandLineInterfaceTest {
-
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void testDefaultThreshold() {
@@ -21,10 +17,10 @@ public class SimiliarityThresholdTest extends CommandLineInterfaceTest {
     }
 
     @Test
-    public void testInvalidThreshold() {
-        exit.expectSystemExitWithStatus(1);
+    public void testInvalidThreshold() throws Exception {
         String argument = buildArgument(CommandLineArgument.SIMILARITY_THRESHOLD, "Not a float...");
-        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        int statusCode = catchSystemExit(() -> buildOptionsFromCLI(argument, CURRENT_DIRECTORY));
+        assertEquals(1, statusCode);
     }
 
     @Test

--- a/jplag/src/test/java/de/jplag/cli/StoredMatchesTest.java
+++ b/jplag/src/test/java/de/jplag/cli/StoredMatchesTest.java
@@ -1,18 +1,14 @@
 package de.jplag.cli;
 
-import static org.junit.Assert.assertEquals;
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.CommandLineArgument;
 import de.jplag.options.JPlagOptions;
 
 public class StoredMatchesTest extends CommandLineInterfaceTest {
-
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
 
     @Test
     public void testDefault() {
@@ -44,9 +40,9 @@ public class StoredMatchesTest extends CommandLineInterfaceTest {
     }
 
     @Test
-    public void testInvalidThreshold() {
-        exit.expectSystemExitWithStatus(1);
+    public void testInvalidThreshold() throws Exception {
         String argument = buildArgument(CommandLineArgument.SHOWN_COMPARISONS, "Not an integer...");
-        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        int statusCode = catchSystemExit(() -> buildOptionsFromCLI(argument, CURRENT_DIRECTORY));
+        assertEquals(1, statusCode);
     }
 }

--- a/jplag/src/test/java/de/jplag/clustering/ClusterTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/ClusterTest.java
@@ -1,12 +1,12 @@
 package de.jplag.clustering;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClusterTest {
 

--- a/jplag/src/test/java/de/jplag/clustering/ClusteringAdapterTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/ClusteringAdapterTest.java
@@ -1,6 +1,6 @@
 package de.jplag.clustering;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.commons.math3.linear.RealMatrix;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 
 import de.jplag.JPlagComparison;

--- a/jplag/src/test/java/de/jplag/clustering/ClusteringRealDataTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/ClusteringRealDataTest.java
@@ -1,28 +1,18 @@
 package de.jplag.clustering;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.clustering.algorithm.GenericClusteringAlgorithm;
 import de.jplag.clustering.algorithm.SpectralClustering;
@@ -64,7 +54,7 @@ public class ClusteringRealDataTest {
     private URL loadFromClasspath(String file) throws FileNotFoundException {
         URL url = getClass().getClassLoader().getResource(file);
         if (url == null) {
-            assumeTrue(file + " not found. 'de/jpag/PseudonymizedReports' must contain the data from the PseudonymizedReports repository.", false);
+            assumeTrue(false, file + " not found. 'de/jpag/PseudonymizedReports' must contain the data from the PseudonymizedReports repository.");
         }
         return url;
     }

--- a/jplag/src/test/java/de/jplag/clustering/ClusteringResultTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/ClusteringResultTest.java
@@ -1,17 +1,17 @@
 package de.jplag.clustering;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ClusteringResultTest {
+class ClusteringResultTest {
 
     @Test
-    public void perfectClustering() {
+    void perfectClustering() {
         RealMatrix similarity = new Array2DRowRealMatrix(4, 4);
 
         // These are similar
@@ -27,7 +27,7 @@ public class ClusteringResultTest {
     }
 
     @Test
-    public void uniformClustering() {
+    void uniformClustering() {
         RealMatrix similarity = new Array2DRowRealMatrix(4, 4);
 
         // We'd obtain such weights by pre-selecting the clusters,

--- a/jplag/src/test/java/de/jplag/clustering/algorithm/AgglomerativeClusteringTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/algorithm/AgglomerativeClusteringTest.java
@@ -2,7 +2,7 @@ package de.jplag.clustering.algorithm;
 
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AgglomerativeClusteringTest {
 

--- a/jplag/src/test/java/de/jplag/clustering/algorithm/BayesianOptimizationTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/algorithm/BayesianOptimizationTest.java
@@ -1,10 +1,10 @@
 package de.jplag.clustering.algorithm;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.RealVector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BayesianOptimizationTest {
 

--- a/jplag/src/test/java/de/jplag/clustering/algorithm/ClusteringData.java
+++ b/jplag/src/test/java/de/jplag/clustering/algorithm/ClusteringData.java
@@ -1,6 +1,6 @@
 package de.jplag.clustering.algorithm;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -58,7 +58,7 @@ public enum ClusteringData {
     }
 
     public void assertValid(Collection<? extends Collection<Integer>> actual) {
-        assertEquals(this.name() + " not clustered correctly", expected, makeSets(actual));
+        assertEquals(expected, makeSets(actual), this.name() + " not clustered correctly");
     }
 
     private static void setEntries(RealMatrix matrix, int i, int j, double value) {

--- a/jplag/src/test/java/de/jplag/clustering/algorithm/GaussianProcessTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/algorithm/GaussianProcessTest.java
@@ -1,13 +1,13 @@
 package de.jplag.clustering.algorithm;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.RealVector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GaussianProcessTest {
 
@@ -30,8 +30,8 @@ public class GaussianProcessTest {
             double x = i / 2.0;
             vx.setEntry(0, x);
             double[] prediction = gp.predict(vx);
-            assertTrue("The prediction error can't very high", Math.abs(prediction[0] - x) < 1);
-            assertTrue("The standard deviation must be greater than 0", prediction[1] > 0);
+            assertTrue(Math.abs(prediction[0] - x) < 1, "The prediction error can't very high");
+            assertTrue(prediction[1] > 0, "The standard deviation must be greater than 0");
         }
     }
 }

--- a/jplag/src/test/java/de/jplag/clustering/algorithm/SpectralClusteringTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/algorithm/SpectralClusteringTest.java
@@ -2,7 +2,7 @@ package de.jplag.clustering.algorithm;
 
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SpectralClusteringTest {
 

--- a/jplag/src/test/java/de/jplag/clustering/preprocessors/CumulativeDistributionFunctionPreprocessorTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/preprocessors/CumulativeDistributionFunctionPreprocessorTest.java
@@ -1,10 +1,10 @@
 package de.jplag.clustering.preprocessors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CumulativeDistributionFunctionPreprocessorTest extends PreprocessingTestBase {
 
@@ -12,7 +12,7 @@ public class CumulativeDistributionFunctionPreprocessorTest extends Preprocessin
 
     CumulativeDistributionFunctionPreprocessor preprocessor;
 
-    @Before
+    @BeforeEach
     public void init() {
         preprocessor = new CumulativeDistributionFunctionPreprocessor();
     }

--- a/jplag/src/test/java/de/jplag/clustering/preprocessors/PercentilePreprocessorTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/preprocessors/PercentilePreprocessorTest.java
@@ -1,11 +1,11 @@
 package de.jplag.clustering.preprocessors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PercentilePreprocessorTest extends PreprocessingTestBase {
 
@@ -13,7 +13,7 @@ public class PercentilePreprocessorTest extends PreprocessingTestBase {
 
     PercentileThresholdProcessor preprocessor;
 
-    @Before
+    @BeforeEach
     public void init() {
         preprocessor = new PercentileThresholdProcessor(0.5f);
     }

--- a/jplag/src/test/java/de/jplag/clustering/preprocessors/PreprocessingTestBase.java
+++ b/jplag/src/test/java/de/jplag/clustering/preprocessors/PreprocessingTestBase.java
@@ -1,13 +1,9 @@
 package de.jplag.clustering.preprocessors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.Collectors;
@@ -46,19 +42,19 @@ public class PreprocessingTestBase {
     public void validPreprocessing(double[][] originalArray, double[][] resultArray, IntUnaryOperator originalIndex) {
         RealMatrix result = new Array2DRowRealMatrix(resultArray, false);
         RealMatrix original = new Array2DRowRealMatrix(originalArray, false);
-        assertEquals("not a square matrix", result.getColumnDimension(), result.getRowDimension());
+        assertEquals(result.getColumnDimension(), result.getRowDimension(), "not a square matrix");
 
         List<Integer> usedOriginalIndices = IntStream.range(0, result.getColumnDimension()).map(originalIndex).boxed().collect(Collectors.toList());
 
-        assertEquals("original indices not unique", usedOriginalIndices.size(), new HashSet<>(usedOriginalIndices).size());
+        assertEquals(usedOriginalIndices.size(), new HashSet<>(usedOriginalIndices).size(), "original indices not unique");
 
-        assertTrue("original indices valid", usedOriginalIndices.stream().allMatch(index -> index >= 0 && index < original.getColumnDimension()));
+        assertTrue(usedOriginalIndices.stream().allMatch(index -> index >= 0 && index < original.getColumnDimension()), "original indices valid");
 
         double[] columnNorms = IntStream.range(0, result.getColumnDimension()).mapToObj(index -> result.getColumn(index))
                 .mapToDouble(array -> new ArrayRealVector(array, false).getNorm()).toArray();
 
         for (int i = 0; i < columnNorms.length; i++) {
-            assertTrue("produced zero column in column " + i, columnNorms[i] > EPSILON);
+            assertTrue(columnNorms[i] > EPSILON, "produced zero column in column " + i);
         }
     }
 

--- a/jplag/src/test/java/de/jplag/clustering/preprocessors/ThresholdPreprocessorTest.java
+++ b/jplag/src/test/java/de/jplag/clustering/preprocessors/ThresholdPreprocessorTest.java
@@ -1,11 +1,11 @@
 package de.jplag.clustering.preprocessors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ThresholdPreprocessorTest extends PreprocessingTestBase {
 
@@ -13,7 +13,7 @@ public class ThresholdPreprocessorTest extends PreprocessingTestBase {
 
     ThresholdPreprocessor preprocessor;
 
-    @Before
+    @BeforeEach
     public void init() {
         preprocessor = new ThresholdPreprocessor(0.2);
     }

--- a/jplag/src/test/java/de/jplag/special/TokenPrinterTest.java
+++ b/jplag/src/test/java/de/jplag/special/TokenPrinterTest.java
@@ -1,11 +1,11 @@
 package de.jplag.special;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.function.Consumer;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.JPlagResult;
 import de.jplag.Submission;
@@ -26,7 +26,7 @@ public class TokenPrinterTest extends TestBase {
     private static final int MIN_TOKEN_MATCH = 5;
     private static final String PRINTER_FOLDER = "PRINTER"; // in the folder 'jplag/src/test/resources/samples'
 
-    @Ignore
+    @Disabled
     @Test
     public void printCPPFiles() {
         printSubmissions(options -> {
@@ -35,7 +35,7 @@ public class TokenPrinterTest extends TestBase {
         });
     }
 
-    @Ignore
+    @Disabled
     @Test
     public void printJavaFiles() {
         printSubmissions(options -> {

--- a/jplag/src/test/java/de/jplag/special/VolumeTest.java
+++ b/jplag/src/test/java/de/jplag/special/VolumeTest.java
@@ -1,7 +1,7 @@
 package de.jplag.special;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,8 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import de.jplag.TestBase;
 import de.jplag.exceptions.ExitException;
@@ -39,7 +39,7 @@ public class VolumeTest extends TestBase {
      * Accepts a derivation of 0.1% in the matching percentage
      */
     @Test
-    @Ignore
+    @Disabled
     public void volumeComparisonTest() throws ExitException, IOException {
 
         // Always succeed if not executed in an appropriate environment

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 
     <modules>
         <module>jplag.frontend-utils</module>
+        <module>jplag.frontend-testutils</module>
         <module>jplag.frontend.chars</module>
         <module>jplag.frontend.cpp</module>
         <module>jplag.frontend.csharp-6</module>
@@ -175,18 +176,16 @@
             </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
+                <artifactId>frontend-testutils</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
                 <artifactId>jplag</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <!-- The Revision of JPlag -->
         <revision>4.0.0-SNAPSHOT</revision>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <!-- ANTLR -->
@@ -119,18 +120,6 @@
                 <groupId>net.sourceforge.argparse4j</groupId>
                 <artifactId>argparse4j</artifactId>
                 <version>0.9.0</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-rules</artifactId>
-                <version>1.19.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- JPLAG -->
@@ -186,6 +175,27 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>
@@ -304,6 +314,11 @@
                 <artifactId>flatten-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M6</version>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <executions>
@@ -358,6 +373,7 @@
                         <phase>verify</phase>
                         <configuration>
                             <keyname>0xC6E9DAC2</keyname>
+                            <!--suppress UnresolvedMavenProperty -->
                             <passphrase>${env.GPG_PASSPHRASE}</passphrase>
                         </configuration>
                     </execution>
@@ -381,6 +397,7 @@
                 <configuration>
                     <java>
                         <eclipse>
+                            <!--suppress UnresolvedMavenProperty -->
                             <file>${maven.multiModuleProjectDirectory}/formatter.xml</file>
                         </eclipse>
 


### PR DESCRIPTION
Adds a utility project for `frontend-testutils`, thus allowing for lightweight test cases without depending on the core project.
Note that these test cases are only on the token level, as only the `frontend-utils` data structures are available.
Adds a very simple and thus initial test case for the new C# frontend, which is currently largely untested,

```mermaid
graph BT;
    java("Java Frontend")-->utils("Frontend Utilities");
    jplag("Frontend Testutils")-->utils;
    cpp("C# Frontend")-->utils;
    java-->jplag;
    cpp-->jplag;
```

Additionally, this PR updates all test cases to **JUnit 5**, which is now our preferred version for ALL test cases to come.