### PR TITLE
Fix the -n argument for limiting the number of exported comparisons

### DIFF
--- a/jplag/src/main/java/de/jplag/reporting/JsonReport.java
+++ b/jplag/src/main/java/de/jplag/reporting/JsonReport.java
@@ -24,9 +24,9 @@ public class JsonReport implements Report {
     @Override
     public boolean saveReport(JPlagResult result, String path) {
         JPlagReport report = ReportObjectFactory.getReportObject(result);
-        File dir = new File(path);
-        if (!dir.exists()) {
-            if (!dir.mkdir()) {
+        File directory = new File(path);
+        if (!directory.exists()) {
+            if (!directory.mkdir()) {
                 logger.error("Failed to create dir.");
             }
         }

--- a/jplag/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/jplag/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -34,9 +34,11 @@ public class ReportObjectFactory {
 
     /**
      * Generates an Overview DTO of a JPlagResult.
+     * @param numberOfExportedComparisons
      */
     private static OverviewReport generateOverviewReport(JPlagResult result) {
-        List<JPlagComparison> comparisons = result.getComparisons();
+        int numberOfComparisons = result.getOptions().getMaximumNumberOfComparisons();
+        List<JPlagComparison> comparisons = result.getComparisons(numberOfComparisons);
         OverviewReport overviewReport = new OverviewReport();
 
         // TODO: Consider to treat entries that were checked differently from old entries with prior work.
@@ -65,11 +67,13 @@ public class ReportObjectFactory {
 
     /**
      * Generates detailed ComparisonReport DTO for each comparison in a JPlagResult.
+     * @param numberOfExportedComparisons
      * @return A list with ComparisonReport DTOs.
      */
     private static List<ComparisonReport> generateComparisonReports(JPlagResult result) {
         List<ComparisonReport> comparisons = new ArrayList<>();
-        result.getComparisons().forEach(comparison -> comparisons.add( //
+        int numberOfComparisons = result.getOptions().getMaximumNumberOfComparisons();
+        result.getComparisons(numberOfComparisons).forEach(comparison -> comparisons.add( //
                 new ComparisonReport(comparison.getFirstSubmission().getName(), //
                         comparison.getSecondSubmission().getName(), //
                         comparison.similarity(), //


### PR DESCRIPTION
The CLI argument `-n` for limiting the exported comparisons was not working with the new report viewer.
The argument works as follows: 

```
  -n N           The maximum number  of  comparisons  that  will be
                 shown in the generated  report,  if  set to -1 all
                 comparisons will be shown (Standard: 30)
```

This PR fixes that by enforcing the limit during the JSON generation. On the overview page, the report viewer will still show all comparisons. However, only the top N can be clicked. Currently, there is no warning message when clicking a comparison that was not exported. We should add an error message here.

@jplag/studdev @jplag/maintainer Note that from now on the default of max. 30 comparisons is enabled again.