### PR TITLE
Fixes to the TokenPrinter

### DIFF
--- a/jplag.frontend-utils/src/main/java/de/jplag/TokenPrinter.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/TokenPrinter.java
@@ -86,14 +86,14 @@ public final class TokenPrinter {
                     currentLine = currentLine.replace(TAB, TAB_REPLACEMENT);
                 }
                 appendCodeLinePrefix(builder, lineIndex).append(currentLine);
-                appendTokenLinePrefix(builder);
+                appendTokenLinePrefix(builder, lineIndex);
             }
 
             assert currentLine != null;
 
             // New line if already past token index:
             if (columnIndex > token.getColumn()) {
-                appendTokenLinePrefix(builder);
+                appendTokenLinePrefix(builder, lineIndex);
                 columnIndex = 1;
             }
             // Move to token index:
@@ -123,11 +123,14 @@ public final class TokenPrinter {
     }
 
     private static StringBuilder appendCodeLinePrefix(StringBuilder builder, int index) {
-        return builder.append(System.lineSeparator()).append(index).append(TAB);
+        String padding = index >= 1000 ? SPACE : TAB;
+        return builder.append(System.lineSeparator()).append(index).append(padding);
     }
 
-    private static StringBuilder appendTokenLinePrefix(StringBuilder builder) {
-        return builder.append(System.lineSeparator()).append(TAB);
+    private static StringBuilder appendTokenLinePrefix(StringBuilder builder, int index) {
+        int paddingLength = Math.max(("" + index).length() + 1, 4);
+        String padding = TAB.repeat(paddingLength / 4) + SPACE.repeat(paddingLength % 4);
+        return builder.append(System.lineSeparator()).append(padding);
     }
 
     /**


### PR DESCRIPTION
I would like to suggest some changes to the `TokenPrinter` to make it even more useful for testing frontends.
Specifically, these changes are intended to fix the alignment of Token labels to the code lines.

- Account for tab characters in code (which is not the same as activating the REPLACE_TABS option)
- Account for line numbers that are longer than one tab character

Tested in a console with various settings of tab lengths and REPLACE_TABS to ensure that the correct alignment is independent from the actual console tab length _and_ the constant `TAB_LENGTH`.

Assuming that these changes leave no faults, any remaining misalignment would indicate that the position saved in the Token is wrong, which could then be fixed in the respective frontend.

Also, personally, I am confused by the lower case token labels for "tiny tokens". Can someone explain why that setting could be useful? Otherwise, I suggest setting `INDICATE_TINY_TOKENS` to `false` by default.