### PR TITLE
Revert "Skip sonar scan if build skipped (#546)"

### DIFF
--- a/.github/workflows/sonarcloud-pr.yml
+++ b/.github/workflows/sonarcloud-pr.yml
@@ -27,8 +27,6 @@ jobs:
       pullRequestLabels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
       targetBranch: ${{ steps.source-run-info.outputs.targetBranch }}
       sourceEvent: ${{ steps.source-run-info.outputs.sourceEvent }}
-      # Get the information about the build job of the maven.yml workflow
-      buildResult: ${{ fromJson(steps.get_jobs_of_parent.outputs.data).jobs[1].conclusion }}
     steps:
       - name: "Get information about the origin 'CI' run"
         uses: potiuk/get-workflow-origin@v1_3
@@ -36,18 +34,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
-      - name: Get Workflow Run
-        uses: octokit/request-action@v2.1.0
-        id: get_jobs_of_parent
-        with:
-          route: GET /repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   sonar:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
-    if: ${{ needs.get-info.outputs.sourceEvent == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' && needs.get-info.outputs.buildResult == 'success' }}
+    if: ${{ needs.get-info.outputs.sourceEvent == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
     needs: get-info
 
     steps:


### PR DESCRIPTION
This reverts commit 67fc4ed05ac2656c8a184ec91272392c4c5e0c88.

Not needed due to pull_request check in .github/workflows/sonarcloud-pr.yml `needs.get-info.outputs.sourceEvent == 'pull_request'`