### PR TITLE
Fix warnings of Sonarcloud

### DIFF
--- a/jplag.frontend.cpp/src/main/javacc/CPP.jj
+++ b/jplag.frontend.cpp/src/main/javacc/CPP.jj
@@ -19,10 +19,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
-import de.jplag.cpp.NewlineStream;
-
 public class CPPScanner implements CPPTokenConstants {
-    private static Scanner delegatingScanner;
+    private Scanner delegatingScanner;
 
     public static boolean scanFile(File dir, String fileName, Scanner delegatingScanner) {
         CPPScanner scanner;

--- a/jplag/src/main/java/de/jplag/JPlagComparison.java
+++ b/jplag/src/main/java/de/jplag/JPlagComparison.java
@@ -40,10 +40,9 @@ public class JPlagComparison { // FIXME TS: contains a lot of code duplication
         if (other == this) {
             return true;
         }
-        if (!(other instanceof JPlagComparison)) {
+        if (!(other instanceof JPlagComparison otherComparison)) {
             return false;
         }
-        JPlagComparison otherComparison = (JPlagComparison) other;
         return firstSubmission.equals(otherComparison.getFirstSubmission()) && secondSubmission.equals(otherComparison.getSecondSubmission())
                 && matches.equals(otherComparison.matches);
     }

--- a/jplag/src/main/java/de/jplag/JPlagComparison.java
+++ b/jplag/src/main/java/de/jplag/JPlagComparison.java
@@ -1,13 +1,13 @@
 package de.jplag;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This method represents the whole result of a comparison between two submissions.
  */
-public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME TS: contains a lot of code duplication
+public class JPlagComparison { // FIXME TS: contains a lot of code duplication
 
     private static final int ROUNDING_FACTOR = 10;
 
@@ -36,17 +36,21 @@ public class JPlagComparison implements Comparator<JPlagComparison> { // FIXME T
     }
 
     @Override
-    public int compare(JPlagComparison comparison1, JPlagComparison comparison2) {
-        return Float.compare(comparison2.similarity(), comparison1.similarity()); // comparison2 first!
-    }
-
-    // TODO DF: hashCode is not implemented!!
-    @Override
     public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
         if (!(other instanceof JPlagComparison)) {
             return false;
         }
-        return (compare(this, (JPlagComparison) other) == 0);
+        JPlagComparison otherComparison = (JPlagComparison) other;
+        return firstSubmission.equals(otherComparison.getFirstSubmission()) && secondSubmission.equals(otherComparison.getSecondSubmission())
+                && matches.equals(otherComparison.matches);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(firstSubmission, secondSubmission, matches);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -83,10 +83,11 @@ public class Submission implements Comparable<Submission> {
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;
-        } else if (!(obj instanceof Submission)) {
+        }
+        if (!(obj instanceof Submission otherSubmission)) {
             return false;
         }
-        return ((Submission) obj).getName().equals(name);
+        return otherSubmission.getName().equals(name);
     }
 
     @Override

--- a/jplag/src/main/java/de/jplag/Submission.java
+++ b/jplag/src/main/java/de/jplag/Submission.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,8 +76,22 @@ public class Submission implements Comparable<Submission> {
 
     @Override
     public int compareTo(Submission other) {
-        // TODO DF: "equals(Object obj)" should be overridden along with the "compareTo(T obj)" method
         return name.compareTo(other.name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (!(obj instanceof Submission)) {
+            return false;
+        }
+        return ((Submission) obj).getName().equals(name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -129,27 +129,27 @@ public class SubmissionSetBuilder {
 
     private Optional<Submission> loadBaseCode(Set<File> submissionDirectories, Set<File> oldSubmissionDirectories,
             Map<File, Submission> foundSubmissions) throws ExitException {
-        // Extract the basecode submission if necessary.
-        Optional<Submission> baseCodeSubmission = Optional.empty();
-        if (options.hasBaseCode()) {
-            String baseCodeName = options.getBaseCodeSubmissionName().orElseThrow();
-            Submission baseCode = loadBaseCodeAsPath(baseCodeName);
-            if (baseCode == null) {
-                int numberOfRootDirectories = submissionDirectories.size() + oldSubmissionDirectories.size();
-                if (numberOfRootDirectories > 1) {
-                    throw new BasecodeException("The base code submission needs to be specified by path instead of by name!");
-                }
+        if (!options.hasBaseCode()) {
+            return Optional.empty();
+        }
 
-                // There is one root directory, and the submissionDirectories variable has been checked to be non-empty.
-                // That set thus contains the one and only root directory.
-                File rootDirectory = submissionDirectories.iterator().next();
-
-                // Single root-directory, try the legacy way of specifying basecode.
-                baseCode = loadBaseCodeViaName(baseCodeName, rootDirectory, foundSubmissions);
+        String baseCodeName = options.getBaseCodeSubmissionName().orElseThrow();
+        Submission baseCode = loadBaseCodeAsPath(baseCodeName);
+        if (baseCode == null) {
+            int numberOfRootDirectories = submissionDirectories.size() + oldSubmissionDirectories.size();
+            if (numberOfRootDirectories > 1) {
+                throw new BasecodeException("The base code submission needs to be specified by path instead of by name!");
             }
-            // TODO DF: Here the method assumes that baseCode can be null. later, this is not assumed anymore
-            baseCodeSubmission = Optional.ofNullable(baseCode);
 
+            // There is one root directory, and the submissionDirectories variable has been checked to be non-empty.
+            // That set thus contains the one and only root directory.
+            File rootDirectory = submissionDirectories.iterator().next();
+
+            // Single root-directory, try the legacy way of specifying basecode.
+            baseCode = loadBaseCodeViaName(baseCodeName, rootDirectory, foundSubmissions);
+        }
+
+        if (baseCode != null) {
             logger.info("Basecode directory \"{}\" will be used.", baseCode.getName());
 
             // Basecode may also be registered as a user submission. If so, remove the latter.
@@ -158,7 +158,7 @@ public class SubmissionSetBuilder {
                 logger.info("Submission \"{}\" is the specified basecode, it will be skipped during comparison.", removed.getName());
             }
         }
-        return baseCodeSubmission;
+        return Optional.of(baseCode);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -158,7 +158,7 @@ public class SubmissionSetBuilder {
                 logger.info("Submission \"{}\" is the specified basecode, it will be skipped during comparison.", removed.getName());
             }
         }
-        return Optional.of(baseCode);
+        return Optional.ofNullable(baseCode);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/clustering/algorithm/BayesianOptimization.java
+++ b/jplag/src/main/java/de/jplag/clustering/algorithm/BayesianOptimization.java
@@ -45,6 +45,9 @@ public class BayesianOptimization {
      * @param lengthScale width parameter for the matern kernel
      */
     public BayesianOptimization(RealVector minima, RealVector maxima, int initPoints, int maxEvaluations, double noise, RealVector lengthScale) {
+        if (minima.getDimension() == 0) {
+            throw new IllegalArgumentException("explored parameters must at least have one dimension");
+        }
         if (minima.getDimension() != maxima.getDimension()) {
             throw new DimensionMismatchException(minima.getDimension(), maxima.getDimension());
         }
@@ -162,7 +165,6 @@ public class BayesianOptimization {
                 if (debug && logger.isDebugEnabled()) {
                     logger.debug(gpr.toString(minima, maxima, 100, 25, 0));
                 }
-                // TODO Check that best is not null here
                 coordinates = maxAcq(gpr, best.score, poiSampler, zeroAcquisitionsCounter);
                 testedCoordinates.add(coordinates);
             }
@@ -173,7 +175,6 @@ public class BayesianOptimization {
                 best = result;
             }
         }
-
         return best;
     }
 


### PR DESCRIPTION
Fixes the warnings of Sonarcloud such that the build is not marked as _failing_ anymore.
- Fixes potential NullpointerException in `SubmissionSetBuilder`
- Validate input in `BayesianOptimization` such that later on NullpointerException is not possible
- Implement `hashCode` and `equals` for `Submission` and `JPlagComparison`
  - Remove conformance to `Comparable` for `JPlagComparison` as it was not consistent with `equals` (thus resolving #233)

Additionally fixed some warnings for the generated `CPPScanner`.