### PR TITLE
Fix Report Viewer

### DIFF
--- a/jplag/src/main/java/de/jplag/reporting/reportobject/mapper/ComparisonReportMapper.java
+++ b/jplag/src/main/java/de/jplag/reporting/reportobject/mapper/ComparisonReportMapper.java
@@ -36,7 +36,7 @@ public class ComparisonReportMapper {
                 .map(match -> convertMatchToReportMatch(comparison, match, result.getOptions().getLanguage().supportsColumns())).toList();
     }
 
-    private Match convertMatchToReportMatch(JPlagComparison comparison, de.jplag.Match match, boolean usesIndex) {
+    private Match convertMatchToReportMatch(JPlagComparison comparison, de.jplag.Match match, boolean languageSupportsColumnsAndLines) {
         TokenList tokensFirst = comparison.getFirstSubmission().getTokenList();
         TokenList tokensSecond = comparison.getSecondSubmission().getTokenList();
         Token startTokenFirst = tokensFirst.getToken(match.startOfFirst());
@@ -44,13 +44,17 @@ public class ComparisonReportMapper {
         Token startTokenSecond = tokensSecond.getToken(match.startOfSecond());
         Token endTokenSecond = tokensSecond.getToken(match.startOfSecond() + match.length() - 1);
 
-        int startFirst = usesIndex ? startTokenFirst.getIndex() : startTokenFirst.getLine();
-        int endFirst = usesIndex ? endTokenFirst.getIndex() : endTokenFirst.getLine();
-        int startSecond = usesIndex ? startTokenSecond.getIndex() : startTokenSecond.getLine();
-        int endSecond = usesIndex ? endTokenSecond.getIndex() : endTokenSecond.getLine();
+        int startFirst = getPosition(languageSupportsColumnsAndLines, startTokenFirst);
+        int endFirst = getPosition(languageSupportsColumnsAndLines, endTokenFirst);
+        int startSecond = getPosition(languageSupportsColumnsAndLines, startTokenSecond);
+        int endSecond = getPosition(languageSupportsColumnsAndLines, endTokenSecond);
         int tokens = match.length();
 
         return new Match(startTokenFirst.getFile(), startTokenSecond.getFile(), startFirst, endFirst, startSecond, endSecond, tokens);
+    }
+
+    private int getPosition(boolean languageSupportsColumnsAndLines, Token token) {
+        return languageSupportsColumnsAndLines ? token.getLine() : token.getIndex();
     }
 
 }

--- a/report-viewer/src/components/CodePanel.vue
+++ b/report-viewer/src/components/CodePanel.vue
@@ -25,27 +25,32 @@
         />
       </button>
     </div>
-    <div :class="{ hidden: !collapse }" class="code-container">
-      <LineOfCode
-        v-for="(line, index) in lines"
-        :id="String(panelId).concat(title).concat(index)"
-        :key="index"
-        :color="coloringArray[index]"
-        :is-first="isFirst[index]"
-        :is-last="isLast[index]"
-        :line-number="index + 1"
-        :text="line"
-        :visible="collapse"
-        @click="
-          $emit(
-            'lineSelected',
-            $event,
-            linksArray[index].panel,
-            linksArray[index].file,
-            linksArray[index].line
-          )
-        "
-      />
+    <div :class="{ hidden: !collapse }">
+      <div v-if="!isEmpty(lines)" class="code-container">
+        <LineOfCode
+          v-for="(line, index) in lines"
+          :id="String(panelId).concat(title).concat(index)"
+          :key="index"
+          :color="coloringArray[index]"
+          :is-first="isFirst[index]"
+          :is-last="isLast[index]"
+          :line-number="index + 1"
+          :text="line"
+          :visible="collapse"
+          @click="
+            $emit(
+              'lineSelected',
+              $event,
+              linksArray[index].panel,
+              linksArray[index].file,
+              linksArray[index].line
+            )
+          "
+        />
+      </div>
+      <div v-else class="code-container">
+        <p>Empty File</p>
+      </div>
     </div>
   </div>
 </template>
@@ -112,6 +117,9 @@ export default defineComponent({
      * @type {Ref<UnwrapRef<{}>>}
      */
     const coloringArray = ref({});
+    const isEmpty = (lines) => {
+      return lines.length === 0 || lines.every((line) => !(line.trim()));
+    };
     /**
      * An object containing an object from which an id is to of the line to which this is linked is constructed.
      * Id object contains panel, file name, first line number of linked matched.
@@ -170,6 +178,7 @@ export default defineComponent({
       linksArray,
       isFirst,
       isLast,
+      isEmpty,
     };
   },
 });

--- a/report-viewer/src/components/MatchTable.vue
+++ b/report-viewer/src/components/MatchTable.vue
@@ -13,20 +13,24 @@
         <th>File 2</th>
         <th>Tokens</th>
       </tr>
-      <tr v-for="( match, index ) in matches"
-          :key="String(index).concat(match.startInFirst).concat(match.startInSecond)"
-          :style="{ background : match.color }"
-          @click="$emit('matchSelected', $event, match)">
+      <tr
+        v-for="(match, index) in matches"
+        :key="
+          String(index).concat(match.startInFirst).concat(match.startInSecond)
+        "
+        :style="{ background: match.color }"
+        @click="$emit('matchSelected', $event, match)"
+      >
         <td>
           <div class="td-content">
             <p>{{ match.firstFile }}</p>
-            <p>({{ match.startInFirst }} - {{ match.endInFirst }})</p>
+            <p>({{ match.startInFirst + 1 }} - {{ match.endInFirst + 1 }})</p>
           </div>
         </td>
         <td>
           <div class="td-content">
             <p>{{ match.secondFile }}</p>
-            <p>({{ match.startInSecond }} - {{ match.endInSecond }})</p>
+            <p>({{ match.startInSecond + 1 }} - {{ match.endInSecond + 1 }})</p>
           </div>
         </td>
         <td>{{ match.tokens }}</td>
@@ -36,7 +40,7 @@
 </template>
 
 <script>
-import {defineComponent} from "vue";
+import { defineComponent } from "vue";
 
 export default defineComponent({
   name: "MatchTable",
@@ -46,25 +50,25 @@ export default defineComponent({
      * type: Array<Match>
      */
     matches: {
-      type: Array
+      type: Array,
     },
     /**
      * ID of first submission
      */
     id1: {
-      type: String
+      type: String,
     },
     /**
      * ID of second submission
      */
     id2: {
-      type: String
-    }
+      type: String,
+    },
   },
   setup() {
-    return {}
-  }
-})
+    return {};
+  },
+});
 </script>
 
 <style scoped>
@@ -97,13 +101,11 @@ table {
 th {
   color: var(--on-primary-color);
   text-align: center;
-
 }
 
 td {
   font-size: small;
   text-align: center;
   padding: 2%;
-
 }
 </style>


### PR DESCRIPTION
Concerning issue #571 :

I falsely assumed that the submission file name would always have the same index when splitting its path, as this was always the case when I tested the viewer. The submission files in my zip always had the path `result/submissions/<submission-file>`, therefore I extracted the submission file name from splitting the path at / and accessing index 2.
The submission files in the zip you provided have the path `submission/<submission-file>` and therefore the filenames are not extracted correctly.

Consequently, I changed the file name extraction to locate the index of the submission folder and find the submission files by a accessing the the found index+1.

 Additionally,  I changed the way how empty submissions are displayed: Instead of showing one empty line, the text "Empty File" is displayed.
<img width="723" alt="Screenshot 2022-08-07 at 12 48 27" src="https://user-images.githubusercontent.com/33717535/183287828-1bf367f3-e1e6-4942-b04d-1ed4adfc6c38.png">
