### PR TITLE
Language Overview in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ In the following, a list of all supported languages with their supported languag
 | [R](https://www.r-project.org/) | 3.5.0 | rlang |
 | [Scala](https://www.scala-lang.org) | 2.13.8 | scala |
 | [Scheme](http://www.scheme-reports.org) | ? | scheme |
-| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) (static) | 2.25.0 | emf-metamodel |
+| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) | 2.25.0 | emf-metamodel |
 | [EMF Metamodel](https://www.eclipse.org/modeling/emf/) (dynamic) | 2.25.0 | emf-metamodel-dynamic |
-| Char | - | char |
 | Text (naive) | - | text |
 
 ## Download and Installation

--- a/README.md
+++ b/README.md
@@ -9,7 +9,27 @@
 [![License](https://img.shields.io/github/license/jplag/jplag.svg)](https://github.com/jplag/jplag/blob/master/LICENSE)
 [![Lines of code](https://img.shields.io/tokei/lines/github/jplag/jplag)](https://github.com/jplag/jplag/graphs/contributors)
 
-JPlag is a system that finds similarities among multiple sets of source code files. This way it can detect software plagiarism and collusion in software development. JPlag currently supports Java, C#, C, C++, Python 3, Scheme, and natural language text.
+JPlag is a system that finds similarities among multiple sets of source code files. This way it can detect software plagiarism and collusion in software development. JPlag currently supports various programming languages, EMF metamodels, and natural language text.
+
+## Supported Languages
+
+In the following, a list of all supported languages with their supported language version is provided. A language can be selected from the command line using the `-l <cli argument name>` argument.
+
+| Language | Version | CLI Argument Name
+| --- | ---: | --- |
+| [C++](https://isocpp.org) | ? | cpp |
+| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/) | 6 | csharp |
+| [Go](https://go.dev) | 1.17 | golang |
+| [Java](https://www.java.com) | 17 | java
+| [Kotlin](https://kotlinlang.org) | 1.3 | kotlin |
+| [Python](https://www.python.org) | 3 | python3 |
+| [R](https://www.r-project.org/) | 3.5.0 | rlang |
+| [Scala](https://www.scala-lang.org) | 2.13.8 | scala |
+| [Scheme](http://www.scheme-reports.org) | ? | scheme |
+| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) (static) | 2.25.0 | emf-metamodel |
+| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) (dynamic) | 2.25.0 | emf-metamodel-dynamic |
+| Char | - | char |
+| Text (naive) | - | text |
 
 ## Download and Installation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In the following, a list of all supported languages with their supported languag
 | [Go](https://go.dev) | 1.17 | golang |
 | [Java](https://www.java.com) | 17 | java
 | [Kotlin](https://kotlinlang.org) | 1.3 | kotlin |
-| [Python](https://www.python.org) | 3 | python3 |
+| [Python](https://www.python.org) | 3.6 | python3 |
 | [R](https://www.r-project.org/) | 3.5.0 | rlang |
 | [Scala](https://www.scala-lang.org) | 2.13.8 | scala |
 | [Scheme](http://www.scheme-reports.org) | ? | scheme |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In the following, a list of all supported languages with their supported languag
 | Language | Version | CLI Argument Name | [state](https://github.com/jplag/JPlag/wiki/3.-Language-Modules) | parser
 | --- | ---: | --- | :---: | :---: |
 | [Java](https://www.java.com) | 17 | java | mature | JavaC |
-| [C++](https://isocpp.org) | ? | cpp | legacy | JavaCC |
+| [C++](https://isocpp.org) | 11 | cpp | legacy | JavaCC |
 | [C#](https://docs.microsoft.com/en-us/dotnet/csharp/) | 8 | csharp | beta | ANTLR 4 |
 | [Go](https://go.dev) | 1.17 | golang | beta | ANTLR 4 |
 | [Kotlin](https://kotlinlang.org) | 1.3 | kotlin | beta | ANTLR 4 |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In the following, a list of all supported languages with their supported languag
 | --- | ---: | --- | :---: | :---: |
 | [Java](https://www.java.com) | 17 | java | mature | JavaC |
 | [C++](https://isocpp.org) | ? | cpp | legacy | JavaCC |
-| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/) | 6 | csharp | beta | ANTLR 4 |
+| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/) | 8 | csharp | beta | ANTLR 4 |
 | [Go](https://go.dev) | 1.17 | golang | beta | ANTLR 4 |
 | [Kotlin](https://kotlinlang.org) | 1.3 | kotlin | beta | ANTLR 4 |
 | [Python](https://www.python.org) | 3.6 | python3 | legacy | ANTLR 4 |

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ JPlag is a system that finds similarities among multiple sets of source code fil
 
 In the following, a list of all supported languages with their supported language version is provided. A language can be selected from the command line using the `-l <cli argument name>` argument.
 
-| Language | Version | CLI Argument Name
-| --- | ---: | --- |
-| [C++](https://isocpp.org) | ? | cpp |
-| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/) | 6 | csharp |
-| [Go](https://go.dev) | 1.17 | golang |
-| [Java](https://www.java.com) | 17 | java
-| [Kotlin](https://kotlinlang.org) | 1.3 | kotlin |
-| [Python](https://www.python.org) | 3.6 | python3 |
-| [R](https://www.r-project.org/) | 3.5.0 | rlang |
-| [Scala](https://www.scala-lang.org) | 2.13.8 | scala |
-| [Scheme](http://www.scheme-reports.org) | ? | scheme |
-| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) | 2.25.0 | emf-metamodel |
-| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) (dynamic) | 2.25.0 | emf-metamodel-dynamic |
-| Text (naive) | - | text |
+| Language | Version | CLI Argument Name | [state](https://github.com/jplag/JPlag/wiki/3.-Language-Modules) | parser
+| --- | ---: | --- | :---: | :---: |
+| [Java](https://www.java.com) | 17 | java | mature | JavaC |
+| [C++](https://isocpp.org) | ? | cpp | legacy | JavaCC |
+| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/) | 6 | csharp | beta | ANTLR 4 |
+| [Go](https://go.dev) | 1.17 | golang | beta | ANTLR 4 |
+| [Kotlin](https://kotlinlang.org) | 1.3 | kotlin | beta | ANTLR 4 |
+| [Python](https://www.python.org) | 3.6 | python3 | legacy | ANTLR 4 |
+| [R](https://www.r-project.org/) | 3.5.0 | rlang | beta | ANTLR 4 |
+| [Scala](https://www.scala-lang.org) | 2.13.8 | scala | beta | Scalameta |
+| [Scheme](http://www.scheme-reports.org) | ? | scheme | unknown | JavaCC |
+| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) | 2.25.0 | emf-metamodel | alpha | EMF |
+| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) (dynamic) | 2.25.0 | emf-metamodel-dynamic | alpha | EMF |
+| Text (naive) | - | text | legacy | ANTLR |
 
 ## Download and Installation
 


### PR DESCRIPTION
This PR adds an overview of the supported programming languages, meta models, and text (I did not find a proper generic term, thus using language) with their supported versions and the CLI argument name. Additionally, the used parser and the state of the language module are listed.