### PR TITLE
Fix various sonar issues

### DIFF
--- a/jplag.cli/src/main/java/de/jplag/CommandLineArgument.java
+++ b/jplag.cli/src/main/java/de/jplag/CommandLineArgument.java
@@ -161,8 +161,8 @@ public enum CommandLineArgument {
                 .or(() -> argumentGroup.map(groupHelper::getArgumentGroup)).orElse(parser);
 
         Argument argument = argContainer.addArgument(flag).help(description);
-        choices.ifPresent(it -> argument.choices(it));
-        defaultValue.ifPresent(it -> argument.setDefault(it));
+        choices.ifPresent(argument::choices);
+        defaultValue.ifPresent(argument::setDefault);
         action.ifPresent(argument::action);
         metaVar.ifPresent(argument::metavar);
         argument.type(type);

--- a/jplag.frontend-utils/src/main/java/de/jplag/TokenList.java
+++ b/jplag.frontend-utils/src/main/java/de/jplag/TokenList.java
@@ -1,7 +1,5 @@
 package de.jplag;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -68,7 +66,7 @@ public class TokenList {
     @Override
     public final String toString() {
         try {
-            List<String> tokenStrings = tokens.stream().map(Token::toString).collect(toList());
+            List<String> tokenStrings = tokens.stream().map(Token::toString).toList();
             return String.join(System.lineSeparator(), tokenStrings);
         } catch (OutOfMemoryError exception) {
             return "Token list to large for output: " + tokens.size() + " Tokens";

--- a/jplag.frontend.cpp/src/main/javacc/CPP.jj
+++ b/jplag.frontend.cpp/src/main/javacc/CPP.jj
@@ -16,7 +16,7 @@ package de.jplag.cpp;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 
 public class CPPScanner implements CPPTokenConstants {
@@ -24,11 +24,10 @@ public class CPPScanner implements CPPTokenConstants {
 
     public static boolean scanFile(File dir, String fileName, Scanner delegatingScanner) {
         CPPScanner scanner;
-        try {
-            InputStream input = new NewlineStream(new FileInputStream(new File(dir, fileName)));
+        try(InputStream input = new NewlineStream(new FileInputStream(new File(dir, fileName)))) {
             scanner = new CPPScanner(input, "UTF-8");
             scanner.delegatingScanner = delegatingScanner;
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             System.out.println("C/C++ Scanner: File " + fileName + " not found.");
             return false;
         }

--- a/jplag.frontend.csharp-6/src/main/antlr4/de/jplag/csharp/grammar/CSharpLexer.g4
+++ b/jplag.frontend.csharp-6/src/main/antlr4/de/jplag/csharp/grammar/CSharpLexer.g4
@@ -140,19 +140,19 @@ REAL_LITERAL:        ([0-9] ('_'* [0-9])*)? '.' [0-9] ('_'* [0-9])* ExponentPart
 CHARACTER_LITERAL:                   '\'' (~['\\\r\n\u0085\u2028\u2029] | CommonCharacter) '\'';
 REGULAR_STRING:                      '"'  (~["\\\r\n\u0085\u2028\u2029] | CommonCharacter)* '"';
 VERBATIUM_STRING:                    '@"' (~'"' | '""')* '"';
-INTERPOLATED_REGULAR_STRING_START:   '$"' { this.OnInterpolatedRegularStringStart(); } -> pushMode(INTERPOLATION_STRING);
-INTERPOLATED_VERBATIUM_STRING_START: '$@"'  { this.OnInterpolatedVerbatiumStringStart(); }  -> pushMode(INTERPOLATION_STRING);
+INTERPOLATED_REGULAR_STRING_START:   '$"' { this.onInterpolatedRegularStringStart(); } -> pushMode(INTERPOLATION_STRING);
+INTERPOLATED_VERBATIUM_STRING_START: '$@"'  { this.onInterpolatedVerbatiumStringStart(); }  -> pushMode(INTERPOLATION_STRING);
 
 //B.1.9 Operators And Punctuators
-OPEN_BRACE:               '{' { this.OnOpenBrace(); };
-CLOSE_BRACE:              '}' { this.OnCloseBrace(); };
+OPEN_BRACE:               '{' { this.onOpenBrace(); };
+CLOSE_BRACE:              '}' { this.onCloseBrace(); };
 OPEN_BRACKET:             '[';
 CLOSE_BRACKET:            ']';
 OPEN_PARENS:              '(';
 CLOSE_PARENS:             ')';
 DOT:                      '.';
 COMMA:                    ',';
-COLON:                    ':' { this.OnColon(); };
+COLON:                    ':' { this.onColon(); };
 SEMICOLON:                ';';
 PLUS:                     '+';
 MINUS:                    '-';
@@ -196,17 +196,17 @@ OP_RANGE:                 '..';
 mode INTERPOLATION_STRING;
 
 DOUBLE_CURLY_INSIDE:           '{{';
-OPEN_BRACE_INSIDE:             '{' { this.OpenBraceInside(); } -> skip, pushMode(DEFAULT_MODE);
-REGULAR_CHAR_INSIDE:           { this.IsRegularCharInside() }? SimpleEscapeSequence;
-VERBATIUM_DOUBLE_QUOTE_INSIDE: { this.IsVerbatiumDoubleQuoteInside() }? '""';
-DOUBLE_QUOTE_INSIDE:           '"' { this.OnDoubleQuoteInside(); } -> popMode;
-REGULAR_STRING_INSIDE:         { this.IsRegularCharInside() }? ~('{' | '\\' | '"')+;
-VERBATIUM_INSIDE_STRING:       { this.IsVerbatiumDoubleQuoteInside() }? ~('{' | '"')+;
+OPEN_BRACE_INSIDE:             '{' { this.openBraceInside(); } -> skip, pushMode(DEFAULT_MODE);
+REGULAR_CHAR_INSIDE:           { this.isRegularCharInside() }? SimpleEscapeSequence;
+VERBATIUM_DOUBLE_QUOTE_INSIDE: { this.isVerbatiumDoubleQuoteInside() }? '""';
+DOUBLE_QUOTE_INSIDE:           '"' { this.onDoubleQuoteInside(); } -> popMode;
+REGULAR_STRING_INSIDE:         { this.isRegularCharInside() }? ~('{' | '\\' | '"')+;
+VERBATIUM_INSIDE_STRING:       { this.isVerbatiumDoubleQuoteInside() }? ~('{' | '"')+;
 
 mode INTERPOLATION_FORMAT;
 
 DOUBLE_CURLY_CLOSE_INSIDE:      '}}' -> type(FORMAT_STRING);
-CLOSE_BRACE_INSIDE:             '}' { this.OnCloseBraceInside(); }   -> skip, popMode;
+CLOSE_BRACE_INSIDE:             '}' { this.onCloseBraceInside(); }   -> skip, popMode;
 FORMAT_STRING:                  ~'}'+;
 
 mode DIRECTIVE_MODE;

--- a/jplag.frontend.csharp-6/src/main/antlr4/de/jplag/csharp/grammar/CSharpParser.g4
+++ b/jplag.frontend.csharp-6/src/main/antlr4/de/jplag/csharp/grammar/CSharpParser.g4
@@ -473,7 +473,7 @@ block
 	;
 
 local_variable_declaration
-	: (USING | REF | REF READONLY)? local_variable_type local_variable_declarator ( ','  local_variable_declarator { this.IsLocalVariableDeclaration() }? )*
+	: (USING | REF | REF READONLY)? local_variable_type local_variable_declarator ( ','  local_variable_declarator { this.isLocalVariableDeclaration() }? )*
 	| FIXED pointer_type fixed_pointer_declarators
 	;
 

--- a/jplag.frontend.csharp-6/src/main/antlr4/de/jplag/csharp/grammar/CSharpPreprocessorParser.g4
+++ b/jplag.frontend.csharp-6/src/main/antlr4/de/jplag/csharp/grammar/CSharpPreprocessorParser.g4
@@ -7,19 +7,19 @@ parser grammar CSharpPreprocessorParser;
 options { tokenVocab=CSharpLexer; superClass=CSharpPreprocessorParserBase; }
 
 preprocessor_directive returns [Boolean value]
-	: DEFINE CONDITIONAL_SYMBOL directive_new_line_or_sharp { this.OnPreprocessorDirectiveDefine(); }  #preprocessorDeclaration
-	| UNDEF CONDITIONAL_SYMBOL directive_new_line_or_sharp { this.OnPreprocessorDirectiveUndef(); } #preprocessorDeclaration
-	| IF expr=preprocessor_expression directive_new_line_or_sharp { this.OnPreprocessorDirectiveIf(); }	  #preprocessorConditional
-	| ELIF expr=preprocessor_expression directive_new_line_or_sharp { this.OnPreprocessorDirectiveElif(); } #preprocessorConditional
-	| ELSE directive_new_line_or_sharp { this.OnPreprocessorDirectiveElse(); }    #preprocessorConditional
-	| ENDIF directive_new_line_or_sharp { this.OnPreprocessorDirectiveEndif(); } #preprocessorConditional
-	| LINE (DIGITS STRING? | DEFAULT | DIRECTIVE_HIDDEN) directive_new_line_or_sharp { this.OnPreprocessorDirectiveLine(); } #preprocessorLine
-	| ERROR TEXT directive_new_line_or_sharp { this.OnPreprocessorDirectiveError(); }   #preprocessorDiagnostic
-	| WARNING TEXT directive_new_line_or_sharp { this.OnPreprocessorDirectiveWarning(); }   #preprocessorDiagnostic
-	| REGION TEXT? directive_new_line_or_sharp { this.OnPreprocessorDirectiveRegion(); }   #preprocessorRegion
-	| ENDREGION TEXT? directive_new_line_or_sharp { this.OnPreprocessorDirectiveEndregion(); }   #preprocessorRegion
-	| PRAGMA TEXT directive_new_line_or_sharp { this.OnPreprocessorDirectivePragma(); }   #preprocessorPragma
-	| NULLABLE TEXT directive_new_line_or_sharp { this.OnPreprocessorDirectiveNullable(); }   #preprocessorNullable
+	: DEFINE CONDITIONAL_SYMBOL directive_new_line_or_sharp { this.onPreprocessorDirectiveDefine(); }  #preprocessorDeclaration
+	| UNDEF CONDITIONAL_SYMBOL directive_new_line_or_sharp { this.onPreprocessorDirectiveUndef(); } #preprocessorDeclaration
+	| IF expr=preprocessor_expression directive_new_line_or_sharp { this.onPreprocessorDirectiveIf(); }	  #preprocessorConditional
+	| ELIF expr=preprocessor_expression directive_new_line_or_sharp { this.onPreprocessorDirectiveElif(); } #preprocessorConditional
+	| ELSE directive_new_line_or_sharp { this.onPreprocessorDirectiveElse(); }    #preprocessorConditional
+	| ENDIF directive_new_line_or_sharp { this.onPreprocessorDirectiveEndif(); } #preprocessorConditional
+	| LINE (DIGITS STRING? | DEFAULT | DIRECTIVE_HIDDEN) directive_new_line_or_sharp { this.onPreprocessorDirectiveLine(); } #preprocessorLine
+	| ERROR TEXT directive_new_line_or_sharp { this.onPreprocessorDirectiveError(); }   #preprocessorDiagnostic
+	| WARNING TEXT directive_new_line_or_sharp { this.onPreprocessorDirectiveWarning(); }   #preprocessorDiagnostic
+	| REGION TEXT? directive_new_line_or_sharp { this.onPreprocessorDirectiveRegion(); }   #preprocessorRegion
+	| ENDREGION TEXT? directive_new_line_or_sharp { this.onPreprocessorDirectiveEndregion(); }   #preprocessorRegion
+	| PRAGMA TEXT directive_new_line_or_sharp { this.onPreprocessorDirectivePragma(); }   #preprocessorPragma
+	| NULLABLE TEXT directive_new_line_or_sharp { this.onPreprocessorDirectiveNullable(); }   #preprocessorNullable
 	;
 
 directive_new_line_or_sharp
@@ -28,13 +28,13 @@ directive_new_line_or_sharp
     ;
 
 preprocessor_expression returns [String value]
-	: TRUE { this.OnPreprocessorExpressionTrue(); }
-	| FALSE { this.OnPreprocessorExpressionFalse(); }
-	| CONDITIONAL_SYMBOL { this.OnPreprocessorExpressionConditionalSymbol(); }
-	| OPEN_PARENS expr=preprocessor_expression CLOSE_PARENS { this.OnPreprocessorExpressionConditionalOpenParens(); }
-	| BANG expr=preprocessor_expression { this.OnPreprocessorExpressionConditionalBang(); }
-	| expr1=preprocessor_expression OP_EQ expr2=preprocessor_expression { this.OnPreprocessorExpressionConditionalEq(); }
-	| expr1=preprocessor_expression OP_NE expr2=preprocessor_expression { this.OnPreprocessorExpressionConditionalNe(); }
-	| expr1=preprocessor_expression OP_AND expr2=preprocessor_expression { this.OnPreprocessorExpressionConditionalAnd(); }
-	| expr1=preprocessor_expression OP_OR expr2=preprocessor_expression { this.OnPreprocessorExpressionConditionalOr(); }
+	: TRUE { this.onPreprocessorExpressionTrue(); }
+	| FALSE { this.onPreprocessorExpressionFalse(); }
+	| CONDITIONAL_SYMBOL { this.onPreprocessorExpressionConditionalSymbol(); }
+	| OPEN_PARENS expr=preprocessor_expression CLOSE_PARENS { this.onPreprocessorExpressionConditionalOpenParens(); }
+	| BANG expr=preprocessor_expression { this.onPreprocessorExpressionConditionalBang(); }
+	| expr1=preprocessor_expression OP_EQ expr2=preprocessor_expression { this.onPreprocessorExpressionConditionalEq(); }
+	| expr1=preprocessor_expression OP_NE expr2=preprocessor_expression { this.onPreprocessorExpressionConditionalNe(); }
+	| expr1=preprocessor_expression OP_AND expr2=preprocessor_expression { this.onPreprocessorExpressionConditionalAnd(); }
+	| expr1=preprocessor_expression OP_OR expr2=preprocessor_expression { this.onPreprocessorExpressionConditionalOr(); }
 	;

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpLexerBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpLexerBase.java
@@ -2,7 +2,8 @@ package de.jplag.csharp.grammar;
 
 import java.util.Stack;
 
-import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Lexer;
 
 /**
  * This class was taken from <a href="https://github.com/antlr/grammars-v4/tree/master/csharp">antlr/grammars-v4</a>. It
@@ -18,25 +19,25 @@ abstract class CSharpLexerBase extends Lexer {
     protected Stack<Integer> curlyLevels = new Stack<>();
     protected boolean verbatium;
 
-    protected void OnInterpolatedRegularStringStart() {
+    protected void onInterpolatedRegularStringStart() {
         interpolatedStringLevel++;
         interpolatedVerbatiums.push(false);
         verbatium = false;
     }
 
-    protected void OnInterpolatedVerbatiumStringStart() {
+    protected void onInterpolatedVerbatiumStringStart() {
         interpolatedStringLevel++;
         interpolatedVerbatiums.push(true);
         verbatium = true;
     }
 
-    protected void OnOpenBrace() {
+    protected void onOpenBrace() {
         if (interpolatedStringLevel > 0) {
             curlyLevels.push(curlyLevels.pop() + 1);
         }
     }
 
-    protected void OnCloseBrace() {
+    protected void onCloseBrace() {
 
         if (interpolatedStringLevel > 0) {
             curlyLevels.push(curlyLevels.pop() - 1);
@@ -48,7 +49,7 @@ abstract class CSharpLexerBase extends Lexer {
         }
     }
 
-    protected void OnColon() {
+    protected void onColon() {
         if (interpolatedStringLevel > 0) {
             int ind = 1;
             boolean switchToFormatString = true;
@@ -65,25 +66,25 @@ abstract class CSharpLexerBase extends Lexer {
         }
     }
 
-    protected void OpenBraceInside() {
+    protected void openBraceInside() {
         curlyLevels.push(1);
     }
 
-    protected void OnDoubleQuoteInside() {
+    protected void onDoubleQuoteInside() {
         interpolatedStringLevel--;
         interpolatedVerbatiums.pop();
         verbatium = (interpolatedVerbatiums.size() > 0 ? interpolatedVerbatiums.peek() : false);
     }
 
-    protected void OnCloseBraceInside() {
+    protected void onCloseBraceInside() {
         curlyLevels.pop();
     }
 
-    protected boolean IsRegularCharInside() {
+    protected boolean isRegularCharInside() {
         return !verbatium;
     }
 
-    protected boolean IsVerbatiumDoubleQuoteInside() {
+    protected boolean isVerbatiumDoubleQuoteInside() {
         return verbatium;
     }
 }

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpLexerBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpLexerBase.java
@@ -14,8 +14,8 @@ abstract class CSharpLexerBase extends Lexer {
     }
 
     protected int interpolatedStringLevel;
-    protected Stack<Boolean> interpolatedVerbatiums = new Stack<Boolean>();
-    protected Stack<Integer> curlyLevels = new Stack<Integer>();
+    protected Stack<Boolean> interpolatedVerbatiums = new Stack<>();
+    protected Stack<Integer> curlyLevels = new Stack<>();
     protected boolean verbatium;
 
     protected void OnInterpolatedRegularStringStart() {

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpLexerBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpLexerBase.java
@@ -49,7 +49,6 @@ abstract class CSharpLexerBase extends Lexer {
     }
 
     protected void OnColon() {
-
         if (interpolatedStringLevel > 0) {
             int ind = 1;
             boolean switchToFormatString = true;

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpParserBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpParserBase.java
@@ -17,13 +17,13 @@ public abstract class CSharpParserBase extends Parser {
 
     protected boolean isLocalVariableDeclaration() {
         Local_variable_declarationContext localVariable = (Local_variable_declarationContext) this._ctx;
-        if (localVariable == null)
+        if (localVariable == null) {
             return true;
+        }
         Local_variable_typeContext localVariableType = localVariable.local_variable_type();
-        if (localVariableType == null)
+        if (localVariableType == null) {
             return true;
-        if (localVariableType.getText().equals("var"))
-            return false;
-        return true;
+        }
+        return !localVariableType.getText().equals("var");
     }
 }

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpParserBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpParserBase.java
@@ -3,6 +3,9 @@ package de.jplag.csharp.grammar;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.TokenStream;
 
+import de.jplag.csharp.grammar.CSharpParser.Local_variable_declarationContext;
+import de.jplag.csharp.grammar.CSharpParser.Local_variable_typeContext;
+
 /**
  * This class was taken from <a href="https://github.com/antlr/grammars-v4/tree/master/csharp">antlr/grammars-v4</a>. It
  * was originally written by Ken Domino. Note that this class is licensed under Eclipse Public License - v 1.0.
@@ -13,13 +16,13 @@ public abstract class CSharpParserBase extends Parser {
     }
 
     protected boolean IsLocalVariableDeclaration() {
-        CSharpParser.Local_variable_declarationContext local_var_decl = (CSharpParser.Local_variable_declarationContext) this._ctx;
-        if (local_var_decl == null)
+        Local_variable_declarationContext localVariable = (Local_variable_declarationContext) this._ctx;
+        if (localVariable == null)
             return true;
-        CSharpParser.Local_variable_typeContext local_variable_type = local_var_decl.local_variable_type();
-        if (local_variable_type == null)
+        Local_variable_typeContext localVariableType = localVariable.local_variable_type();
+        if (localVariableType == null)
             return true;
-        if (local_variable_type.getText().equals("var"))
+        if (localVariableType.getText().equals("var"))
             return false;
         return true;
     }

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpParserBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpParserBase.java
@@ -15,7 +15,7 @@ public abstract class CSharpParserBase extends Parser {
         super(input);
     }
 
-    protected boolean IsLocalVariableDeclaration() {
+    protected boolean isLocalVariableDeclaration() {
         Local_variable_declarationContext localVariable = (Local_variable_declarationContext) this._ctx;
         if (localVariable == null)
             return true;

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpPreprocessorParserBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpPreprocessorParserBase.java
@@ -26,162 +26,162 @@ abstract class CSharpPreprocessorParserBase extends Parser {
     private static final String TRUE = Boolean.toString(true);
     private static final String DEBUG = "DEBUG";
 
-    private Stack<Boolean> conditions = new Stack<>();
-    private HashSet<String> ConditionalSymbols = new HashSet<>();
+    private final Stack<Boolean> conditions = new Stack<>();
+    private final HashSet<String> conditionalSymbols = new HashSet<>();
 
     protected CSharpPreprocessorParserBase(TokenStream input) {
         super(input);
         conditions.push(true);
-        ConditionalSymbols.add(DEBUG);
+        conditionalSymbols.add(DEBUG);
     }
 
-    protected Boolean AllConditions() {
+    protected Boolean allConditions() {
         return conditions.stream().allMatch(it -> it);
     }
 
-    protected void OnPreprocessorDirectiveDefine() {
+    protected void onPreprocessorDirectiveDefine() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorDeclarationContext context = (PreprocessorDeclarationContext) ruleContext;
-        ConditionalSymbols.add(context.CONDITIONAL_SYMBOL().getText());
-        context.value = AllConditions();
+        conditionalSymbols.add(context.CONDITIONAL_SYMBOL().getText());
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectiveUndef() {
+    protected void onPreprocessorDirectiveUndef() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorDeclarationContext context = (PreprocessorDeclarationContext) ruleContext;
-        ConditionalSymbols.remove(context.CONDITIONAL_SYMBOL().getText());
-        context.value = AllConditions();
+        conditionalSymbols.remove(context.CONDITIONAL_SYMBOL().getText());
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectiveIf() {
+    protected void onPreprocessorDirectiveIf() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
-        context.value = context.expr.value.equals(TRUE) && AllConditions();
+        context.value = context.expr.value.equals(TRUE) && allConditions();
         conditions.push(context.expr.value.equals(TRUE));
     }
 
-    protected void OnPreprocessorDirectiveElif() {
+    protected void onPreprocessorDirectiveElif() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
         if (Boolean.FALSE.equals(conditions.peek())) {
             conditions.pop();
-            context.value = context.expr.value.equals(TRUE) && AllConditions();
+            context.value = context.expr.value.equals(TRUE) && allConditions();
             conditions.push(context.expr.value.equals(TRUE));
         } else {
             context.value = false;
         }
     }
 
-    protected void OnPreprocessorDirectiveElse() {
+    protected void onPreprocessorDirectiveElse() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
         if (Boolean.FALSE.equals(conditions.peek())) {
             conditions.pop();
-            context.value = AllConditions();
+            context.value = allConditions();
             conditions.push(true);
         } else {
             context.value = false;
         }
     }
 
-    protected void OnPreprocessorDirectiveEndif() {
+    protected void onPreprocessorDirectiveEndif() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
         conditions.pop();
         context.value = conditions.peek();
     }
 
-    protected void OnPreprocessorDirectiveLine() {
+    protected void onPreprocessorDirectiveLine() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorLineContext context = (PreprocessorLineContext) ruleContext;
-        context.value = AllConditions();
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectiveError() {
+    protected void onPreprocessorDirectiveError() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorDiagnosticContext context = (PreprocessorDiagnosticContext) ruleContext;
-        context.value = AllConditions();
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectiveWarning() {
+    protected void onPreprocessorDirectiveWarning() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorDiagnosticContext context = (PreprocessorDiagnosticContext) ruleContext;
-        context.value = AllConditions();
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectiveRegion() {
+    protected void onPreprocessorDirectiveRegion() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorRegionContext context = (PreprocessorRegionContext) ruleContext;
-        context.value = AllConditions();
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectiveEndregion() {
+    protected void onPreprocessorDirectiveEndregion() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorRegionContext context = (PreprocessorRegionContext) ruleContext;
-        context.value = AllConditions();
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectivePragma() {
+    protected void onPreprocessorDirectivePragma() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorPragmaContext context = (PreprocessorPragmaContext) ruleContext;
-        context.value = AllConditions();
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorDirectiveNullable() {
+    protected void onPreprocessorDirectiveNullable() {
         ParserRuleContext ruleContext = this._ctx;
         PreprocessorNullableContext context = (PreprocessorNullableContext) ruleContext;
-        context.value = AllConditions();
+        context.value = allConditions();
     }
 
-    protected void OnPreprocessorExpressionTrue() {
+    protected void onPreprocessorExpressionTrue() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = TRUE;
     }
 
-    protected void OnPreprocessorExpressionFalse() {
+    protected void onPreprocessorExpressionFalse() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = FALSE;
     }
 
-    protected void OnPreprocessorExpressionConditionalSymbol() {
+    protected void onPreprocessorExpressionConditionalSymbol() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
-        context.value = ConditionalSymbols.contains(context.CONDITIONAL_SYMBOL().getText()) ? TRUE : FALSE;
+        context.value = conditionalSymbols.contains(context.CONDITIONAL_SYMBOL().getText()) ? TRUE : FALSE;
     }
 
-    protected void OnPreprocessorExpressionConditionalOpenParens() {
+    protected void onPreprocessorExpressionConditionalOpenParens() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = context.expr.value;
     }
 
-    protected void OnPreprocessorExpressionConditionalBang() {
+    protected void onPreprocessorExpressionConditionalBang() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = context.expr.value.equals(TRUE) ? FALSE : TRUE;
     }
 
-    protected void OnPreprocessorExpressionConditionalEq() {
+    protected void onPreprocessorExpressionConditionalEq() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = (Objects.equals(context.expr1.value, context.expr2.value) ? TRUE : FALSE);
     }
 
-    protected void OnPreprocessorExpressionConditionalNe() {
+    protected void onPreprocessorExpressionConditionalNe() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = (!Objects.equals(context.expr1.value, context.expr2.value) ? TRUE : FALSE);
     }
 
-    protected void OnPreprocessorExpressionConditionalAnd() {
+    protected void onPreprocessorExpressionConditionalAnd() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = (context.expr1.value.equals(TRUE) && context.expr2.value.equals(TRUE) ? TRUE : FALSE);
     }
 
-    protected void OnPreprocessorExpressionConditionalOr() {
+    protected void onPreprocessorExpressionConditionalOr() {
         ParserRuleContext ruleContext = this._ctx;
         Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
         context.value = (context.expr1.value.equals(TRUE) || context.expr2.value.equals(TRUE) ? TRUE : FALSE);

--- a/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpPreprocessorParserBase.java
+++ b/jplag.frontend.csharp-6/src/main/java/de/jplag/csharp/grammar/CSharpPreprocessorParserBase.java
@@ -8,174 +8,182 @@ import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.TokenStream;
 
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.PreprocessorConditionalContext;
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.PreprocessorDeclarationContext;
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.PreprocessorDiagnosticContext;
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.PreprocessorLineContext;
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.PreprocessorNullableContext;
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.PreprocessorPragmaContext;
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.PreprocessorRegionContext;
+import de.jplag.csharp.grammar.CSharpPreprocessorParser.Preprocessor_expressionContext;
+
 /**
  * This class was taken from <a href="https://github.com/antlr/grammars-v4/tree/master/csharp">antlr/grammars-v4</a>. It
  * was originally written by Ken Domino. Note that this class is licensed under Eclipse Public License - v 1.0.
  */
-@SuppressWarnings("java:S100")
 abstract class CSharpPreprocessorParserBase extends Parser {
+    private static final String FALSE = Boolean.toString(false);
+    private static final String TRUE = Boolean.toString(true);
+    private static final String DEBUG = "DEBUG";
+
+    private Stack<Boolean> conditions = new Stack<>();
+    private HashSet<String> ConditionalSymbols = new HashSet<>();
+
     protected CSharpPreprocessorParserBase(TokenStream input) {
         super(input);
         conditions.push(true);
-        ConditionalSymbols.add("DEBUG");
+        ConditionalSymbols.add(DEBUG);
     }
 
-    Stack<Boolean> conditions = new Stack<>();
-    public HashSet<String> ConditionalSymbols = new HashSet<String>();
-
     protected Boolean AllConditions() {
-        for (Boolean condition : conditions) {
-            if (!condition)
-                return false;
-        }
-        return true;
+        return conditions.stream().allMatch(it -> it);
     }
 
     protected void OnPreprocessorDirectiveDefine() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorDeclarationContext d = (CSharpPreprocessorParser.PreprocessorDeclarationContext) c;
-        ConditionalSymbols.add(d.CONDITIONAL_SYMBOL().getText());
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorDeclarationContext context = (PreprocessorDeclarationContext) ruleContext;
+        ConditionalSymbols.add(context.CONDITIONAL_SYMBOL().getText());
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectiveUndef() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorDeclarationContext d = (CSharpPreprocessorParser.PreprocessorDeclarationContext) c;
-        ConditionalSymbols.remove(d.CONDITIONAL_SYMBOL().getText());
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorDeclarationContext context = (PreprocessorDeclarationContext) ruleContext;
+        ConditionalSymbols.remove(context.CONDITIONAL_SYMBOL().getText());
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectiveIf() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorConditionalContext d = (CSharpPreprocessorParser.PreprocessorConditionalContext) c;
-        d.value = d.expr.value.equals("true") && AllConditions();
-        conditions.push(d.expr.value.equals("true"));
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
+        context.value = context.expr.value.equals(TRUE) && AllConditions();
+        conditions.push(context.expr.value.equals(TRUE));
     }
 
     protected void OnPreprocessorDirectiveElif() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorConditionalContext d = (CSharpPreprocessorParser.PreprocessorConditionalContext) c;
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
         if (Boolean.FALSE.equals(conditions.peek())) {
             conditions.pop();
-            d.value = d.expr.value.equals("true") && AllConditions();
-            conditions.push(d.expr.value.equals("true"));
+            context.value = context.expr.value.equals(TRUE) && AllConditions();
+            conditions.push(context.expr.value.equals(TRUE));
         } else {
-            d.value = false;
+            context.value = false;
         }
     }
 
     protected void OnPreprocessorDirectiveElse() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorConditionalContext d = (CSharpPreprocessorParser.PreprocessorConditionalContext) c;
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
         if (Boolean.FALSE.equals(conditions.peek())) {
             conditions.pop();
-            d.value = AllConditions();
+            context.value = AllConditions();
             conditions.push(true);
         } else {
-            d.value = false;
+            context.value = false;
         }
     }
 
     protected void OnPreprocessorDirectiveEndif() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorConditionalContext d = (CSharpPreprocessorParser.PreprocessorConditionalContext) c;
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorConditionalContext context = (PreprocessorConditionalContext) ruleContext;
         conditions.pop();
-        d.value = conditions.peek();
+        context.value = conditions.peek();
     }
 
     protected void OnPreprocessorDirectiveLine() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorLineContext d = (CSharpPreprocessorParser.PreprocessorLineContext) c;
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorLineContext context = (PreprocessorLineContext) ruleContext;
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectiveError() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorDiagnosticContext d = (CSharpPreprocessorParser.PreprocessorDiagnosticContext) c;
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorDiagnosticContext context = (PreprocessorDiagnosticContext) ruleContext;
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectiveWarning() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorDiagnosticContext d = (CSharpPreprocessorParser.PreprocessorDiagnosticContext) c;
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorDiagnosticContext context = (PreprocessorDiagnosticContext) ruleContext;
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectiveRegion() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorRegionContext d = (CSharpPreprocessorParser.PreprocessorRegionContext) c;
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorRegionContext context = (PreprocessorRegionContext) ruleContext;
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectiveEndregion() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorRegionContext d = (CSharpPreprocessorParser.PreprocessorRegionContext) c;
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorRegionContext context = (PreprocessorRegionContext) ruleContext;
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectivePragma() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorPragmaContext d = (CSharpPreprocessorParser.PreprocessorPragmaContext) c;
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorPragmaContext context = (PreprocessorPragmaContext) ruleContext;
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorDirectiveNullable() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.PreprocessorNullableContext d = (CSharpPreprocessorParser.PreprocessorNullableContext) c;
-        d.value = AllConditions();
+        ParserRuleContext ruleContext = this._ctx;
+        PreprocessorNullableContext context = (PreprocessorNullableContext) ruleContext;
+        context.value = AllConditions();
     }
 
     protected void OnPreprocessorExpressionTrue() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = "true";
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = TRUE;
     }
 
     protected void OnPreprocessorExpressionFalse() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = "false";
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = FALSE;
     }
 
     protected void OnPreprocessorExpressionConditionalSymbol() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = ConditionalSymbols.contains(d.CONDITIONAL_SYMBOL().getText()) ? "true" : "false";
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = ConditionalSymbols.contains(context.CONDITIONAL_SYMBOL().getText()) ? TRUE : FALSE;
     }
 
     protected void OnPreprocessorExpressionConditionalOpenParens() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = d.expr.value;
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = context.expr.value;
     }
 
     protected void OnPreprocessorExpressionConditionalBang() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = d.expr.value.equals("true") ? "false" : "true";
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = context.expr.value.equals(TRUE) ? FALSE : TRUE;
     }
 
     protected void OnPreprocessorExpressionConditionalEq() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = (Objects.equals(d.expr1.value, d.expr2.value) ? "true" : "false");
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = (Objects.equals(context.expr1.value, context.expr2.value) ? TRUE : FALSE);
     }
 
     protected void OnPreprocessorExpressionConditionalNe() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = (!Objects.equals(d.expr1.value, d.expr2.value) ? "true" : "false");
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = (!Objects.equals(context.expr1.value, context.expr2.value) ? TRUE : FALSE);
     }
 
     protected void OnPreprocessorExpressionConditionalAnd() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = (d.expr1.value.equals("true") && d.expr2.value.equals("true") ? "true" : "false");
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = (context.expr1.value.equals(TRUE) && context.expr2.value.equals(TRUE) ? TRUE : FALSE);
     }
 
     protected void OnPreprocessorExpressionConditionalOr() {
-        ParserRuleContext c = this._ctx;
-        CSharpPreprocessorParser.Preprocessor_expressionContext d = (CSharpPreprocessorParser.Preprocessor_expressionContext) c;
-        d.value = (d.expr1.value.equals("true") || d.expr2.value.equals("true") ? "true" : "false");
+        ParserRuleContext ruleContext = this._ctx;
+        Preprocessor_expressionContext context = (Preprocessor_expressionContext) ruleContext;
+        context.value = (context.expr1.value.equals(TRUE) || context.expr2.value.equals(TRUE) ? TRUE : FALSE);
     }
 }

--- a/jplag.frontend.scala/pom.xml
+++ b/jplag.frontend.scala/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>frontend-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.scalameta/scalameta -->

--- a/jplag/src/main/java/de/jplag/SubmissionSet.java
+++ b/jplag/src/main/java/de/jplag/SubmissionSet.java
@@ -178,7 +178,7 @@ public class SubmissionSet {
         }
 
         long duration = System.currentTimeMillis() - startTime;
-        String timePerSubmission = submissions.size() > 0 ? Long.toString(duration / submissions.size()) : "n/a";
+        String timePerSubmission = submissions.isEmpty() ? "n/a" : Long.toString(duration / submissions.size());
         logger.trace("Total time for parsing: " + TimeUtil.formatDuration(duration));
         logger.trace("Time per parsed submission: " + timePerSubmission + " msec");
     }

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringAdapter.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringAdapter.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import org.apache.commons.math3.linear.Array2DRowRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
@@ -59,9 +58,9 @@ public class ClusteringAdapter {
         Collection<Collection<Integer>> intResult = algorithm.cluster(similarityMatrix);
         ClusteringResult<Integer> modularityClusterResult = ClusteringResult.fromIntegerCollections(new ArrayList<>(intResult), similarityMatrix);
         List<Cluster<Submission>> mappedClusters = modularityClusterResult.getClusters().stream()
-                .map(unmappedCluster -> new Cluster<>(unmappedCluster.getMembers().stream().map(mapping::unmap).collect(Collectors.toList()),
+                .map(unmappedCluster -> new Cluster<>(unmappedCluster.getMembers().stream().map(mapping::unmap).toList(),
                         unmappedCluster.getCommunityStrength(), unmappedCluster.getAverageSimilarity()))
-                .collect(Collectors.toList());
+                .toList();
         return new ClusteringResult<>(mappedClusters, modularityClusterResult.getCommunityStrength());
     }
 

--- a/jplag/src/main/java/de/jplag/clustering/IntegerMapping.java
+++ b/jplag/src/main/java/de/jplag/clustering/IntegerMapping.java
@@ -20,18 +20,15 @@ public class IntegerMapping<T> {
     }
 
     /**
-     * @param value is added to the mapping (if not already present)
+     * @param key is added to the mapping (if not already present)
      * @return the associated integer
      */
-    public int map(T value) {
-        Integer result = mapping.get(value);
-        if (result == null) {
-            int newIndex = size++;
-            mapping.put(value, newIndex);
-            backMapping.add(value);
-            return newIndex;
-        }
-        return result;
+    public int map(T key) {
+        mapping.computeIfAbsent(key, it -> {
+            backMapping.add(it);
+            return size++;
+        });
+        return mapping.get(key);
     }
 
     /**

--- a/jplag/src/main/java/de/jplag/options/LanguageOption.java
+++ b/jplag/src/main/java/de/jplag/options/LanguageOption.java
@@ -1,7 +1,5 @@
 package de.jplag.options;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -45,7 +43,7 @@ public enum LanguageOption {
     }
 
     public static Collection<String> getAllDisplayNames() {
-        return Arrays.stream(LanguageOption.values()).map(languageOption -> languageOption.displayName).collect(toList());
+        return Arrays.stream(LanguageOption.values()).map(languageOption -> languageOption.displayName).toList();
     }
 
     public static LanguageOption getDefault() {


### PR DESCRIPTION
To get rid of a few critical issues:

- Fix misnamed methods in the C# grammar
- Prevent overriding of frontend-utils dependency version
- Ensure input stream is closed when reading C++ files
- Replace usage of `Stream.collect(Collectors.toList())` with `Stream.toList()`
- Improve code quality of problematic classes
- Improve readability via static imports