### PR TITLE
Fix CLI behavior for enabling/disabling clustering calculation

### DIFF
--- a/jplag.cli/src/main/java/de/jplag/CLI.java
+++ b/jplag.cli/src/main/java/de/jplag/CLI.java
@@ -141,7 +141,7 @@ public final class CLI {
                 () -> logger.warn("Unknown comparison mode, using default mode!"));
 
         ClusteringOptions.Builder clusteringBuilder = new ClusteringOptions.Builder();
-        Optional.ofNullable((Boolean) CLUSTER_ENABLE.getFrom(namespace)).ifPresent(clusteringBuilder::enabled);
+        Optional.ofNullable(!(Boolean) CLUSTER_DISABLE.getFrom(namespace)).ifPresent(clusteringBuilder::enabled);
         Optional.ofNullable((ClusteringAlgorithm) CLUSTER_ALGORITHM.getFrom(namespace)).ifPresent(clusteringBuilder::algorithm);
         Optional.ofNullable((SimilarityMetric) CLUSTER_METRIC.getFrom(namespace)).ifPresent(clusteringBuilder::similarityMetric);
         Optional.ofNullable((Float) CLUSTER_SPECTRAL_BANDWIDTH.getFrom(namespace)).ifPresent(clusteringBuilder::spectralKernelBandwidth);

--- a/jplag.cli/src/main/java/de/jplag/CommandLineArgument.java
+++ b/jplag.cli/src/main/java/de/jplag/CommandLineArgument.java
@@ -47,7 +47,7 @@ public enum CommandLineArgument {
     SHOWN_COMPARISONS(new Builder("-n", Integer.class).defaultsTo(DEFAULT_SHOWN_COMPARISONS)),
     RESULT_FOLDER(new Builder("-r", String.class).defaultsTo("result")),
     COMPARISON_MODE(new Builder("-c", String.class).defaultsTo(DEFAULT_COMPARISON_MODE.getName()).choices(ComparisonMode.allNames())),
-    CLUSTER_ENABLE(new Builder("--cluster-skip", Boolean.class).argumentGroup(CLUSTERING_GROUP_NAME).action(Arguments.storeTrue())),
+    CLUSTER_DISABLE(new Builder("--cluster-skip", Boolean.class).argumentGroup(CLUSTERING_GROUP_NAME).action(Arguments.storeTrue())),
     CLUSTER_ALGORITHM(
             new Builder("--cluster-alg", ClusteringAlgorithm.class).argumentGroup(CLUSTERING_GROUP_NAME)
                     .defaultsTo(ClusteringOptions.DEFAULTS.getAlgorithm())),

--- a/jplag.cli/src/test/java/de/jplag/cli/ClusteringTest.java
+++ b/jplag.cli/src/test/java/de/jplag/cli/ClusteringTest.java
@@ -12,8 +12,21 @@ class ClusteringTest extends CommandLineInterfaceTest {
     private static final double EPSILON = 0.000001;
 
     @Test
+    void parseSkipClustering() {
+        String argument = CommandLineArgument.CLUSTER_DISABLE.flag();
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(false, options.getClusteringOptions().isEnabled());
+    }
+
+    @Test
+    void parseDefaultClustering() {
+        buildOptionsFromCLI(CURRENT_DIRECTORY);
+        assertEquals(true, options.getClusteringOptions().isEnabled());
+    }
+
+    @Test
     void parsePercentilePreProcessor() {
-        String argument = CommandLineArgument.CLUSTER_PREPROCESSING_PERCENTILE.flag() + "=" + 0.5f;
+        String argument = buildArgument(CommandLineArgument.CLUSTER_PREPROCESSING_PERCENTILE, Float.toString(0.5f));
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
         assertEquals(Preprocessing.PERCENTILE, options.getClusteringOptions().getPreprocessor());
         assertEquals(0.5, options.getClusteringOptions().getPreprocessorPercentile(), EPSILON);

--- a/jplag.cli/src/test/java/de/jplag/cli/CommandLineInterfaceTest.java
+++ b/jplag.cli/src/test/java/de/jplag/cli/CommandLineInterfaceTest.java
@@ -26,7 +26,7 @@ public abstract class CommandLineInterfaceTest {
     protected JPlagOptions options;
 
     /**
-     * Creates a string for all arguments and their values that have been succesfully parsed.F
+     * Creates a string for all arguments and their values that have been succesfully parsed.
      */
     private String parsedKeys(String... arguments) {
         var keys = namespace.getAttrs().keySet().stream()

--- a/jplag/src/main/java/de/jplag/clustering/Cluster.java
+++ b/jplag/src/main/java/de/jplag/clustering/Cluster.java
@@ -9,7 +9,7 @@ import java.util.function.BiFunction;
  * Cluster part of a {@link ClusteringResult}.
  * @param <T> type of the clusters members
  */
-public class Cluster<T> implements Comparable<Cluster<T>> {
+public class Cluster<T> {
 
     private final float communityStrength;
     private final Collection<T> members;
@@ -121,11 +121,6 @@ public class Cluster<T> implements Comparable<Cluster<T>> {
      */
     public boolean isBadCluster() {
         return getMembers().size() < 2 || getCommunityStrength() < 0;
-    }
-
-    @Override
-    public int compareTo(Cluster<T> other) {
-        return Float.compare(other.getCommunityStrength(), getCommunityStrength());
     }
 
 }

--- a/jplag/src/main/java/de/jplag/clustering/Cluster.java
+++ b/jplag/src/main/java/de/jplag/clustering/Cluster.java
@@ -27,11 +27,16 @@ public class Cluster<T> {
         this.averageSimilarity = averageSimilarity;
     }
 
+    /**
+     * @return a view on the members of this cluster.
+     */
     public Collection<T> getMembers() {
-        // TODO Check why access to local attribute.
-        return members;
+        return new ArrayList<>(members);
     }
 
+    /**
+     * @return average similarity between all tuple comparisons of the members in this cluster.
+     */
     public float getAverageSimilarity() {
         return averageSimilarity;
     }
@@ -57,7 +62,7 @@ public class Cluster<T> {
      * @return How much each member of this cluster contributes to the {@link ClusteringResult#getCommunityStrength}.
      */
     public float getCommunityStrengthPerConnection() {
-        int size = getMembers().size();
+        int size = members.size();
         if (size < 2)
             return 0;
         return getCommunityStrength() / connections();
@@ -84,7 +89,7 @@ public class Cluster<T> {
      */
     public double getWorth(BiFunction<T, T, Float> similarity) {
         double communityStrength = getCommunityStrength();
-        if (getMembers().size() > 1) {
+        if (members.size() > 1) {
             communityStrength /= connections();
         }
         double averageSimilarity = averageSimilarity(similarity);
@@ -97,7 +102,7 @@ public class Cluster<T> {
      * @return average similarity
      */
     private float averageSimilarity(BiFunction<T, T, Float> similarity) {
-        List<T> members = new ArrayList<>(getMembers());
+        List<T> members = new ArrayList<>(this.members);
         if (members.size() < 2) {
             return 1;
         }
@@ -111,7 +116,7 @@ public class Cluster<T> {
     }
 
     private int connections() {
-        int size = getMembers().size();
+        int size = members.size();
         return ((size - 1) * size) / 2;
     }
 
@@ -120,7 +125,7 @@ public class Cluster<T> {
      * @return is bad
      */
     public boolean isBadCluster() {
-        return getMembers().size() < 2 || getCommunityStrength() < 0;
+        return members.size() < 2 || getCommunityStrength() < 0;
     }
 
 }

--- a/jplag/src/main/java/de/jplag/clustering/Cluster.java
+++ b/jplag/src/main/java/de/jplag/clustering/Cluster.java
@@ -9,7 +9,7 @@ import java.util.function.BiFunction;
  * Cluster part of a {@link ClusteringResult}.
  * @param <T> type of the clusters members
  */
-public class Cluster<T> {
+public class Cluster<T> implements Comparable<Cluster<T>> {
 
     private final float communityStrength;
     private final Collection<T> members;
@@ -122,4 +122,10 @@ public class Cluster<T> {
     public boolean isBadCluster() {
         return getMembers().size() < 2 || getCommunityStrength() < 0;
     }
+
+    @Override
+    public int compareTo(Cluster<T> other) {
+        return Float.compare(other.getCommunityStrength(), getCommunityStrength());
+    }
+
 }

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringAlgorithm.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringAlgorithm.java
@@ -39,4 +39,9 @@ public enum ClusteringAlgorithm {
     public interface ClusteringAlgorithmSupplier {
         GenericClusteringAlgorithm create(ClusteringOptions options);
     }
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase();
+    }
 }

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
@@ -16,16 +16,17 @@ import de.jplag.clustering.algorithm.GenericClusteringAlgorithm;
  * Runs the clustering according to an options object.
  */
 public class ClusteringFactory {
-    private static final String CLUSTER_INFORMATION = "Calculating clusters via {} clustering with {} pre-processing...";
-    private static final String NO_CLUSTERS = "Cluster calculation disabled (as requested)!";
+    private static final String CLUSTERING_RESULT = "{} clusters were found!";
+    private static final String CLUSTERING_PARAMETERS = "Calculating clusters via {} clustering with {} pre-processing...";
+    private static final String CLUSTERING_DISABLED = "Cluster calculation disabled (as requested)!";
     private static final Logger logger = LoggerFactory.getLogger(ClusteringFactory.class);
 
     public static List<ClusteringResult<Submission>> getClusterings(Collection<JPlagComparison> comparisons, ClusteringOptions options) {
         if (!options.isEnabled()) {
-            logger.warn(NO_CLUSTERS);
+            logger.warn(CLUSTERING_DISABLED);
             return Collections.emptyList();
         } else {
-            logger.info(CLUSTER_INFORMATION, options.getAlgorithm(), options.getPreprocessor());
+            logger.info(CLUSTERING_PARAMETERS, options.getAlgorithm(), options.getPreprocessor());
         }
 
         // init algorithm
@@ -47,6 +48,7 @@ public class ClusteringFactory {
 
         // remove bad clusters
         result = removeBadClusters(result);
+        logger.info(CLUSTERING_RESULT, result.getClusters().size());
 
         return List.of(result);
     }

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
@@ -1,5 +1,6 @@
 package de.jplag.clustering;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -49,10 +50,7 @@ public class ClusteringFactory {
 
         // remove bad clusters
         result = removeBadClusters(result);
-        logger.info(CLUSTERING_RESULT, result.getClusters().size());
-        for (Cluster<Submission> cluster : result.getClusters()) {
-            logger.info(CLUSTER_PATTERN, cluster.getMembers(), cluster.getCommunityStrength());
-        }
+        logClusters(result);
 
         return List.of(result);
     }
@@ -60,5 +58,14 @@ public class ClusteringFactory {
     private static ClusteringResult<Submission> removeBadClusters(final ClusteringResult<Submission> clustering) {
         List<Cluster<Submission>> filtered = clustering.getClusters().stream().filter(cluster -> !cluster.isBadCluster()).toList();
         return new ClusteringResult<>(filtered, clustering.getCommunityStrength());
+    }
+
+    private static void logClusters(ClusteringResult<Submission> result) {
+        logger.info(CLUSTERING_RESULT, result.getClusters().size());
+        var clusters = new ArrayList<>(result.getClusters());
+        Collections.sort(clusters);
+        for (Cluster<Submission> cluster : clusters) {
+            logger.info(CLUSTER_PATTERN, cluster.getMembers(), cluster.getCommunityStrength());
+        }
     }
 }

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
@@ -5,6 +5,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import de.jplag.JPlagComparison;
 import de.jplag.Submission;
 import de.jplag.clustering.algorithm.GenericClusteringAlgorithm;
@@ -13,9 +16,17 @@ import de.jplag.clustering.algorithm.GenericClusteringAlgorithm;
  * Runs the clustering according to an options object.
  */
 public class ClusteringFactory {
+    private static final String CLUSTER_INFORMATION = "Calculating clusters via {} clustering with {} pre-processing...";
+    private static final String NO_CLUSTERS = "Cluster calculation disabled (as requested)!";
+    private static final Logger logger = LoggerFactory.getLogger(ClusteringFactory.class);
+
     public static List<ClusteringResult<Submission>> getClusterings(Collection<JPlagComparison> comparisons, ClusteringOptions options) {
-        if (!options.isEnabled())
+        if (!options.isEnabled()) {
+            logger.warn(NO_CLUSTERS);
             return Collections.emptyList();
+        } else {
+            logger.info(CLUSTER_INFORMATION, options.getAlgorithm(), options.getPreprocessor());
+        }
 
         // init algorithm
         GenericClusteringAlgorithm clusteringAlgorithm = options.getAlgorithm().create(options);

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
@@ -16,6 +16,7 @@ import de.jplag.clustering.algorithm.GenericClusteringAlgorithm;
  * Runs the clustering according to an options object.
  */
 public class ClusteringFactory {
+    private static final String CLUSTER_PATTERN = "    {}: {}";
     private static final String CLUSTERING_RESULT = "{} clusters were found!";
     private static final String CLUSTERING_PARAMETERS = "Calculating clusters via {} clustering with {} pre-processing...";
     private static final String CLUSTERING_DISABLED = "Cluster calculation disabled (as requested)!";
@@ -49,6 +50,9 @@ public class ClusteringFactory {
         // remove bad clusters
         result = removeBadClusters(result);
         logger.info(CLUSTERING_RESULT, result.getClusters().size());
+        for (Cluster<Submission> cluster : result.getClusters()) {
+            logger.info(CLUSTER_PATTERN, cluster.getMembers(), cluster.getCommunityStrength());
+        }
 
         return List.of(result);
     }

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
@@ -17,8 +17,8 @@ import de.jplag.clustering.algorithm.GenericClusteringAlgorithm;
  * Runs the clustering according to an options object.
  */
 public class ClusteringFactory {
-    private static final String CLUSTER_PATTERN = "    {}: {}";
-    private static final String CLUSTERING_RESULT = "{} clusters were found!";
+    private static final String CLUSTER_PATTERN = " cluster strength: {}, avg similarity: {}%, members: {}";
+    private static final String CLUSTERING_RESULT = "{} clusters were found:";
     private static final String CLUSTERING_PARAMETERS = "Calculating clusters via {} clustering with {} pre-processing...";
     private static final String CLUSTERING_DISABLED = "Cluster calculation disabled (as requested)!";
     private static final Logger logger = LoggerFactory.getLogger(ClusteringFactory.class);
@@ -64,6 +64,6 @@ public class ClusteringFactory {
         var clusters = new ArrayList<>(result.getClusters());
         Collections.sort(clusters, (first, second) -> Float.compare(second.getCommunityStrength(), first.getCommunityStrength()));
         logger.info(CLUSTERING_RESULT, clusters.size());
-        clusters.forEach(it -> logger.info(CLUSTER_PATTERN, it.getMembers(), it.getCommunityStrength()));
+        clusters.forEach(it -> logger.info(CLUSTER_PATTERN, it.getCommunityStrength(), it.getAverageSimilarity(), it.getMembers()));
     }
 }

--- a/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
+++ b/jplag/src/main/java/de/jplag/clustering/ClusteringFactory.java
@@ -61,11 +61,9 @@ public class ClusteringFactory {
     }
 
     private static void logClusters(ClusteringResult<Submission> result) {
-        logger.info(CLUSTERING_RESULT, result.getClusters().size());
         var clusters = new ArrayList<>(result.getClusters());
-        Collections.sort(clusters);
-        for (Cluster<Submission> cluster : clusters) {
-            logger.info(CLUSTER_PATTERN, cluster.getMembers(), cluster.getCommunityStrength());
-        }
+        Collections.sort(clusters, (first, second) -> Float.compare(second.getCommunityStrength(), first.getCommunityStrength()));
+        logger.info(CLUSTERING_RESULT, clusters.size());
+        clusters.forEach(it -> logger.info(CLUSTER_PATTERN, it.getMembers(), it.getCommunityStrength()));
     }
 }

--- a/jplag/src/main/java/de/jplag/clustering/Preprocessing.java
+++ b/jplag/src/main/java/de/jplag/clustering/Preprocessing.java
@@ -28,4 +28,9 @@ public enum Preprocessing {
     public Optional<ClusteringPreprocessor> constructPreprocessor(ClusteringOptions options) {
         return Optional.ofNullable(constructor.apply(options));
     }
+
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase().replace('_', ' ');
+    }
 }


### PR DESCRIPTION
Relates to #609:
- Fixes a bug in the Clustering CLI: When --cluster-skip is not present enabled is set to false and clustering is skipped.
- Adds test cases for expected behavior
- Log if clustering is run, with which parameters and how many clusters are found
- Log for each cluster the inter-cluster strength, the average similarity and the members
- Fixes encapsulation of the cluster members