### PR TITLE
Fix language file suffix bug

### DIFF
--- a/jplag.cli/src/test/java/de/jplag/cli/LanguageTest.java
+++ b/jplag.cli/src/test/java/de/jplag/cli/LanguageTest.java
@@ -3,6 +3,8 @@ package de.jplag.cli;
 import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +39,7 @@ class LanguageTest extends CommandLineInterfaceTest {
             String argument = buildArgument(CommandLineArgument.LANGUAGE, language.getIdentifier());
             buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
             assertEquals(language.getIdentifier(), options.language().getIdentifier());
+            assertEquals(Arrays.asList(language.suffixes()), options.fileSuffixes());
         }
     }
 

--- a/jplag.cli/src/test/java/de/jplag/cli/LanguageTest.java
+++ b/jplag.cli/src/test/java/de/jplag/cli/LanguageTest.java
@@ -4,6 +4,7 @@ import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,14 @@ class LanguageTest extends CommandLineInterfaceTest {
             assertEquals(language.getIdentifier(), options.language().getIdentifier());
             assertEquals(Arrays.asList(language.suffixes()), options.fileSuffixes());
         }
+    }
+
+    @Test
+    void testCustomSuffixes() {
+        List<String> suffixes = List.of("x", "y", "z");
+        String argument = buildArgument(CommandLineArgument.SUFFIXES, String.join(",", suffixes));
+        buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
+        assertEquals(suffixes, options.fileSuffixes());
     }
 
 }

--- a/jplag/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/jplag/src/main/java/de/jplag/options/JPlagOptions.java
@@ -71,7 +71,7 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, List<St
         this.language = language;
         this.comparisonMode = comparisonMode;
         this.debugParser = debugParser;
-        this.fileSuffixes = fileSuffixes == null ? null : Collections.unmodifiableList(fileSuffixes);
+        this.fileSuffixes = fileSuffixes == null || fileSuffixes.isEmpty() ? null : Collections.unmodifiableList(fileSuffixes);
         this.similarityThreshold = normalizeSimilarityThreshold(similarityThreshold);
         this.maximumNumberOfComparisons = normalizeMaximumNumberOfComparisons(maximumNumberOfComparisons);
         this.similarityMetric = similarityMetric;


### PR DESCRIPTION
- Extend CLI language test case to include default file suffixes
- Add CLI test case for custom file suffixes
- Fix bug where language suffixes were not used due to an empty array being interpreted as custom suffixes