### PR TITLE
Make comparison report generation faster

### DIFF
--- a/jplag/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/jplag/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -1,11 +1,15 @@
 package de.jplag.reporting.jsonfactory;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import de.jplag.*;
+import de.jplag.JPlagComparison;
+import de.jplag.JPlagResult;
+import de.jplag.Submission;
+import de.jplag.Token;
+import de.jplag.TokenList;
 import de.jplag.reporting.reportobject.model.ComparisonReport;
 import de.jplag.reporting.reportobject.model.Match;
 
@@ -17,7 +21,7 @@ public class ComparisonReportWriter {
 
     private final FileWriter fileWriter;
     private final Function<Submission, String> submissionToIdFunction;
-    private final Map<String, Map<String, String>> submissionIdToComparisonFileName = new HashMap<>();
+    private final Map<String, Map<String, String>> submissionIdToComparisonFileName = new ConcurrentHashMap<>();
 
     public ComparisonReportWriter(Function<Submission, String> submissionToIdFunction, FileWriter fileWriter) {
         this.submissionToIdFunction = submissionToIdFunction;
@@ -42,7 +46,7 @@ public class ComparisonReportWriter {
     }
 
     private void writeComparisons(String path, List<JPlagComparison> comparisons) {
-        for (JPlagComparison comparison : comparisons) {
+        comparisons.parallelStream().forEach(comparison -> {
             String firstSubmissionId = submissionToIdFunction.apply(comparison.getFirstSubmission());
             String secondSubmissionId = submissionToIdFunction.apply(comparison.getSecondSubmission());
             String fileName = generateComparisonName(firstSubmissionId, secondSubmissionId);
@@ -50,7 +54,7 @@ public class ComparisonReportWriter {
             var comparisonReport = new ComparisonReport(firstSubmissionId, secondSubmissionId, comparison.similarity(),
                     convertMatchesToReportMatches(comparison));
             fileWriter.saveAsJSON(comparisonReport, path, fileName);
-        }
+        });
     }
 
     private void addToLookUp(String firstSubmissionId, String secondSubmissionId, String fileName) {
@@ -59,7 +63,7 @@ public class ComparisonReportWriter {
     }
 
     private void writeToMap(String id1, String id2, String comparisonFileName) {
-        submissionIdToComparisonFileName.putIfAbsent(id1, new HashMap<>());
+        submissionIdToComparisonFileName.putIfAbsent(id1, new ConcurrentHashMap<>());
         submissionIdToComparisonFileName.get(id1).put(id2, comparisonFileName);
     }
 


### PR DESCRIPTION
Modify comparison report writer to handle comparisons in parallel, thus increasing performance. While the writing of the comparisons is I/O heavy, some calculations need to be done. Doing this in parallel increases performance even though the I/O is still the main bottleneck. As an example, for a large data set and `-n 2500` (write 2500 comparisons), this optimization reduces the time for writing the comparisons from ~70 to ~25 seconds on my system.

In the future, we should take a look at the zipping, as it also takes some time for large data sets.