### PR TITLE
Avoid star imports for IntelliJ users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ result
 hs_err_pid*
 
 # intelliJ
-.idea/
+.idea/*
+!.idea/codeStyles
 *.iml
 .flattened-pom.xml
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,8 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="100" />
+    </JavaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>


### PR DESCRIPTION
- Enforces explicit import declarations by adding some IntelliJ-specific configuration.
- TODO make all imports explicit via auto-formatting

@jplag/maintainer what do you think?