### PR TITLE
Fix bug that prevented the basecode fallback when the subdirectory option is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ named arguments:
 The new API makes it easy to integrate JPlag's plagiarism detection into external Java projects:
 
 ```java
-JPlagOptions options = new JPlagOptions(List.of("/path/to/rootDir"), List.of(), LanguageOption.JAVA);
-options.setBaseCodeSubmissionName("template");
+Language language = LanguageLoader.getLanguage(Language.IDENTIFIER).orElseThrow();
+JPlagOptions options = new JPlagOptions(language, List.of("/path/to/rootDir"), List.of()).withBaseCodeSubmissionPath("template");
 
 JPlag jplag = new JPlag(options);
 JPlagResult result = jplag.run();

--- a/cli/src/test/java/de/jplag/cli/BaseCodeOptionTest.java
+++ b/cli/src/test/java/de/jplag/cli/BaseCodeOptionTest.java
@@ -14,13 +14,13 @@ class BaseCodeOptionTest extends CommandLineInterfaceTest {
     @Test
     void testDefaultValue() {
         buildOptionsFromCLI(CURRENT_DIRECTORY);
-        assertNull(options.baseCodeSubmissionName());
+        assertNull(options.baseCodeSubmissionPath());
     }
 
     @Test
     void testCustomName() {
         String argument = buildArgument(CommandLineArgument.BASE_CODE, NAME);
         buildOptionsFromCLI(argument, CURRENT_DIRECTORY);
-        assertEquals(NAME, options.baseCodeSubmissionName());
+        assertEquals(NAME, options.baseCodeSubmissionPath());
     }
 }

--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -114,13 +114,13 @@ public class SubmissionSet {
      */
     private void parseBaseCodeSubmission(Submission baseCode) throws BasecodeException {
         long startTime = System.currentTimeMillis();
-        logger.info("----- Parsing basecode submission: " + baseCode.getName());
+        logger.trace("----- Parsing basecode submission: " + baseCode.getName());
         if (!baseCode.parse(options.debugParser())) {
             throw new BasecodeException("Could not successfully parse basecode submission!");
         } else if (baseCode.getNumberOfTokens() < options.minimumTokenMatch()) {
             throw new BasecodeException("Basecode submission contains fewer tokens than minimum match length allows!");
         }
-        logger.info("Basecode submission parsed!");
+        logger.trace("Basecode submission parsed!");
         long duration = System.currentTimeMillis() - startTime;
         logger.trace("Time for parsing Basecode: " + TimeUtil.formatDuration(duration));
 

--- a/core/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/core/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -135,7 +135,7 @@ public class SubmissionSetBuilder {
             return Optional.empty();
         }
 
-        String baseCodeName = Optional.ofNullable(options.baseCodeSubmissionName()).orElseThrow();
+        String baseCodeName = Optional.ofNullable(options.baseCodeSubmissionPath()).orElseThrow();
         Submission baseCode = loadBaseCodeAsPath(baseCodeName);
         if (baseCode == null) {
             int numberOfRootDirectories = submissionDirectories.size() + oldSubmissionDirectories.size();

--- a/core/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/core/src/main/java/de/jplag/options/JPlagOptions.java
@@ -30,7 +30,7 @@ import de.jplag.strategy.ComparisonMode;
  * matching section. A smaller {@code <n>} increases the sensitivity but might lead to more false-positives.
  * @param submissionDirectories Directories with new submissions. These must be checked for plagiarism.
  * @param oldSubmissionDirectories Directories with old submissions to check against.
- * @param baseCodeSubmissionName Path name of the directory containing the base code.
+ * @param baseCodeSubmissionPath Path name of the directory containing the base code.
  * @param subdirectoryName Example: If the subdirectoryName is 'src', only the code inside submissionDir/src of each
  * submission will be used for comparison.
  * @param fileSuffixes List of file suffixes that should be included.
@@ -49,7 +49,7 @@ import de.jplag.strategy.ComparisonMode;
  * @param debugParser If true, submissions that cannot be parsed will be stored in a separate directory.
  */
 public record JPlagOptions(Language language, Integer minimumTokenMatch, List<String> submissionDirectories, List<String> oldSubmissionDirectories,
-        String baseCodeSubmissionName, String subdirectoryName, List<String> fileSuffixes, String exclusionFileName,
+        String baseCodeSubmissionPath, String subdirectoryName, List<String> fileSuffixes, String exclusionFileName,
         SimilarityMetric similarityMetric, double similarityThreshold, int maximumNumberOfComparisons, ClusteringOptions clusteringOptions,
         ComparisonMode comparisonMode, Verbosity verbosity, boolean debugParser) {
 
@@ -68,7 +68,7 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, List<St
     }
 
     public JPlagOptions(Language language, Integer minimumTokenMatch, List<String> submissionDirectories, List<String> oldSubmissionDirectories,
-            String baseCodeSubmissionName, String subdirectoryName, List<String> fileSuffixes, String exclusionFileName,
+            String baseCodeSubmissionPath, String subdirectoryName, List<String> fileSuffixes, String exclusionFileName,
             SimilarityMetric similarityMetric, double similarityThreshold, int maximumNumberOfComparisons, ClusteringOptions clusteringOptions,
             ComparisonMode comparisonMode, Verbosity verbosity, boolean debugParser) {
         this.language = language;
@@ -82,104 +82,104 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, List<St
         this.exclusionFileName = exclusionFileName;
         this.submissionDirectories = submissionDirectories == null ? null : Collections.unmodifiableList(submissionDirectories);
         this.oldSubmissionDirectories = oldSubmissionDirectories == null ? null : Collections.unmodifiableList(oldSubmissionDirectories);
-        this.baseCodeSubmissionName = (baseCodeSubmissionName == null || baseCodeSubmissionName.isBlank()) ? null : baseCodeSubmissionName;
+        this.baseCodeSubmissionPath = (baseCodeSubmissionPath == null || baseCodeSubmissionPath.isBlank()) ? null : baseCodeSubmissionPath;
         this.subdirectoryName = subdirectoryName;
         this.verbosity = verbosity;
         this.clusteringOptions = clusteringOptions;
     }
 
     public JPlagOptions withLanguageOption(Language language) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withComparisonMode(ComparisonMode comparisonMode) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withDebugParser(boolean debugParser) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withFileSuffixes(List<String> fileSuffixes) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withSimilarityThreshold(double similarityThreshold) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withMaximumNumberOfComparisons(int maximumNumberOfComparisons) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withSimilarityMetric(SimilarityMetric similarityMetric) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withMinimumTokenMatch(Integer minimumTokenMatch) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withExclusionFileName(String exclusionFileName) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withSubmissionDirectories(List<String> submissionDirectories) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withOldSubmissionDirectories(List<String> oldSubmissionDirectories) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
-    public JPlagOptions withBaseCodeSubmissionName(String baseCodeSubmissionName) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+    public JPlagOptions withBaseCodeSubmissionPath(String baseCodeSubmissionPath) {
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withSubdirectoryName(String subdirectoryName) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withVerbosity(Verbosity verbosity) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public JPlagOptions withClusteringOptions(ClusteringOptions clusteringOptions) {
-        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionName,
+        return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionPath,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
                 clusteringOptions, comparisonMode, verbosity, debugParser);
     }
 
     public boolean hasBaseCode() {
-        return baseCodeSubmissionName != null;
+        return baseCodeSubmissionPath != null;
     }
 
     public Set<String> excludedFiles() {
@@ -207,8 +207,8 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, List<St
      * conditions of the compatibility fallback listed above.
      */
     @Override
-    public String baseCodeSubmissionName() {
-        return baseCodeSubmissionName;
+    public String baseCodeSubmissionPath() {
+        return baseCodeSubmissionPath;
     }
 
     @Override

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -138,7 +138,7 @@ public class ReportObjectFactory {
         folders.addAll(result.getOptions().submissionDirectories());
         folders.addAll(result.getOptions().oldSubmissionDirectories());
 
-        String baseCodePath = result.getOptions().hasBaseCode() ? result.getOptions().baseCodeSubmissionName() : "";
+        String baseCodePath = result.getOptions().hasBaseCode() ? result.getOptions().baseCodeSubmissionPath() : "";
         ClusteringResultMapper clusteringResultMapper = new ClusteringResultMapper(submissionToIdFunction);
 
         OverviewReport overviewReport = new OverviewReport(folders, // submissionFolderPath

--- a/core/src/test/java/de/jplag/BaseCodeTest.java
+++ b/core/src/test/java/de/jplag/BaseCodeTest.java
@@ -16,24 +16,24 @@ public class BaseCodeTest extends TestBase {
 
     @Test
     void testBasecodeUserSubmissionComparison() throws ExitException {
-        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionName("base"));
+        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionPath("base"));
         verifyResults(result);
     }
 
     @Test
     void testTinyBasecode() {
-        assertThrows(BasecodeException.class, () -> runJPlag("TinyBasecode", it -> it.withBaseCodeSubmissionName("base")));
+        assertThrows(BasecodeException.class, () -> runJPlag("TinyBasecode", it -> it.withBaseCodeSubmissionPath("base")));
     }
 
     @Test
     void testEmptySubmission() throws ExitException {
-        JPlagResult result = runJPlag("emptysubmission", it -> it.withBaseCodeSubmissionName("base"));
+        JPlagResult result = runJPlag("emptysubmission", it -> it.withBaseCodeSubmissionPath("base"));
         verifyResults(result);
     }
 
     @Test
     void testAutoTrimFileSeparators() throws ExitException {
-        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionName(File.separator + "base" + File.separator));
+        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionPath(File.separator + "base" + File.separator));
         verifyResults(result);
     }
 
@@ -47,7 +47,7 @@ public class BaseCodeTest extends TestBase {
 
     @Test
     void testBasecodePathComparison() throws ExitException {
-        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionName(getBasePath("basecode-base")));
+        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionPath(getBasePath("basecode-base")));
         assertEquals(3, result.getNumberOfSubmissions()); // "basecode/base" is now a user submission.
     }
 
@@ -58,12 +58,12 @@ public class BaseCodeTest extends TestBase {
 
     @Test
     void testInvalidBasecode() {
-        assertThrows(BasecodeException.class, () -> runJPlag("basecode", it -> it.withBaseCodeSubmissionName("WrongBasecode")));
+        assertThrows(BasecodeException.class, () -> runJPlag("basecode", it -> it.withBaseCodeSubmissionPath("WrongBasecode")));
     }
 
     @Test
     void testBasecodeUserSubmissionWithDots() {
-        assertThrows(BasecodeException.class, () -> runJPlag("basecode", it -> it.withBaseCodeSubmissionName("base.ext")));
+        assertThrows(BasecodeException.class, () -> runJPlag("basecode", it -> it.withBaseCodeSubmissionPath("base.ext")));
     }
 
     /**
@@ -72,7 +72,7 @@ public class BaseCodeTest extends TestBase {
     @Test
     void testSubdirectoryGlobalBasecode() throws ExitException {
         String basecode = getBasePath("SubdirectoryBase");
-        JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionName(basecode));
+        JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionPath(basecode));
         verifySimpleDuplicate(result, 3, 3);
     }
 
@@ -81,7 +81,7 @@ public class BaseCodeTest extends TestBase {
      */
     @Test
     void testSubdirectoryLocalBasecode() throws ExitException {
-        JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionName("Base"));
+        JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionPath("Base"));
         verifySimpleDuplicate(result, 2, 1);
     }
 

--- a/core/src/test/java/de/jplag/BaseCodeTest.java
+++ b/core/src/test/java/de/jplag/BaseCodeTest.java
@@ -65,4 +65,31 @@ public class BaseCodeTest extends TestBase {
     void testBasecodeUserSubmissionWithDots() {
         assertThrows(BasecodeException.class, () -> runJPlag("basecode", it -> it.withBaseCodeSubmissionName("base.ext")));
     }
+
+    /**
+     * The simple duplicate contains obvious plagiarism.
+     */
+    @Test
+    void testSubdirectoryGlobalBasecode() throws ExitException {
+        String basecode = getBasePath("SubdirectoryBase");
+        JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionName(basecode));
+        verifySimpleDuplicate(result, 3, 3);
+    }
+
+    /**
+     * The simple duplicate contains obvious plagiarism.
+     */
+    @Test
+    void testSubdirectoryLocalBasecode() throws ExitException {
+        JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionName("Base"));
+        verifySimpleDuplicate(result, 2, 1);
+    }
+
+    private void verifySimpleDuplicate(JPlagResult result, int submissions, int comparisons) {
+        assertEquals(submissions, result.getNumberOfSubmissions());
+        assertEquals(comparisons, result.getAllComparisons().size());
+        assertEquals(1, result.getAllComparisons().get(0).matches().size());
+        assertEquals(1, result.getSimilarityDistribution()[3]);
+        assertEquals(62.07, result.getAllComparisons().get(0).similarity(), DELTA);
+    }
 }

--- a/core/src/test/java/de/jplag/BaseCodeTest.java
+++ b/core/src/test/java/de/jplag/BaseCodeTest.java
@@ -73,7 +73,7 @@ public class BaseCodeTest extends TestBase {
     void testSubdirectoryGlobalBasecode() throws ExitException {
         String basecode = getBasePath("SubdirectoryBase");
         JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionPath(basecode));
-        verifySimpleDuplicate(result, 3, 3);
+        verifySimpleSubdirectoryDuplicate(result, 3, 3);
     }
 
     /**
@@ -82,14 +82,21 @@ public class BaseCodeTest extends TestBase {
     @Test
     void testSubdirectoryLocalBasecode() throws ExitException {
         JPlagResult result = runJPlag("SubdirectoryDuplicate", it -> it.withSubdirectoryName("src").withBaseCodeSubmissionPath("Base"));
-        verifySimpleDuplicate(result, 2, 1);
+        verifySimpleSubdirectoryDuplicate(result, 2, 1);
     }
 
-    private void verifySimpleDuplicate(JPlagResult result, int submissions, int comparisons) {
+    private void verifySimpleSubdirectoryDuplicate(JPlagResult result, int submissions, int comparisons) {
+        result.getSubmissions().getSubmissions().forEach(this::hasSubdirectoryRoot);
+        hasSubdirectoryRoot(result.getSubmissions().getBaseCode());
+
         assertEquals(submissions, result.getNumberOfSubmissions());
         assertEquals(comparisons, result.getAllComparisons().size());
         assertEquals(1, result.getAllComparisons().get(0).matches().size());
         assertEquals(1, result.getSimilarityDistribution()[3]);
         assertEquals(62.07, result.getAllComparisons().get(0).similarity(), DELTA);
+    }
+
+    private void hasSubdirectoryRoot(Submission submission) {
+        assertEquals("src", submission.getRoot().getName());
     }
 }

--- a/core/src/test/java/de/jplag/NormalComparisonTest.java
+++ b/core/src/test/java/de/jplag/NormalComparisonTest.java
@@ -25,7 +25,7 @@ class NormalComparisonTest extends TestBase {
         assertEquals(1, result.getAllComparisons().size());
         assertEquals(1, result.getAllComparisons().get(0).matches().size());
         assertEquals(1, result.getSimilarityDistribution()[3]);
-        assertEquals(62.07, result.getAllComparisons().get(0).similarity(), 0.1);
+        assertEquals(62.07, result.getAllComparisons().get(0).similarity(), DELTA);
     }
 
     /**
@@ -40,7 +40,7 @@ class NormalComparisonTest extends TestBase {
         assertEquals(1, result.getAllComparisons().size());
         assertEquals(2, result.getAllComparisons().get(0).matches().size());
         assertArrayEquals(expectedDistribution, result.getSimilarityDistribution());
-        assertEquals(96.55, result.getAllComparisons().get(0).similarity(), 0.1);
+        assertEquals(96.55, result.getAllComparisons().get(0).similarity(), DELTA);
     }
 
     /**
@@ -53,7 +53,7 @@ class NormalComparisonTest extends TestBase {
         assertEquals(3, result.getNumberOfSubmissions());
         assertEquals(3, result.getAllComparisons().size());
 
-        result.getAllComparisons().forEach(comparison -> assertEquals(0, comparison.similarity(), 0.1));
+        result.getAllComparisons().forEach(comparison -> assertEquals(0, comparison.similarity(), DELTA));
     }
 
     /**
@@ -74,17 +74,17 @@ class NormalComparisonTest extends TestBase {
                 .forEach(comparison -> assertEquals(0, comparison.similarity(), DELTA));
 
         // Hard coded assertions on selected comparisons
-        assertEquals(24.6, getSelectedPercent(result, "A", "B"), 0.1);
-        assertEquals(99.7, getSelectedPercent(result, "A", "C"), 0.1);
-        assertEquals(77.9, getSelectedPercent(result, "A", "D"), 0.1);
-        assertEquals(24.6, getSelectedPercent(result, "B", "C"), 0.1);
-        assertEquals(28.3, getSelectedPercent(result, "B", "D"), 0.1);
-        assertEquals(77.9, getSelectedPercent(result, "C", "D"), 0.1);
+        assertEquals(24.6, getSelectedPercent(result, "A", "B"), DELTA);
+        assertEquals(99.7, getSelectedPercent(result, "A", "C"), DELTA);
+        assertEquals(77.9, getSelectedPercent(result, "A", "D"), DELTA);
+        assertEquals(24.6, getSelectedPercent(result, "B", "C"), DELTA);
+        assertEquals(28.3, getSelectedPercent(result, "B", "D"), DELTA);
+        assertEquals(77.9, getSelectedPercent(result, "C", "D"), DELTA);
 
         // More detailed assertions for the plagiarism in A-D
         var biggestMatch = getSelectedComparison(result, "A", "D");
-        assertEquals(96.4, biggestMatch.get().maximalSimilarity(), 0.1);
-        assertEquals(65.3, biggestMatch.get().minimalSimilarity(), 0.1);
+        assertEquals(96.4, biggestMatch.get().maximalSimilarity(), DELTA);
+        assertEquals(65.3, biggestMatch.get().minimalSimilarity(), DELTA);
         assertEquals(12, biggestMatch.get().matches().size());
 
     }

--- a/core/src/test/java/de/jplag/NormalComparisonTest.java
+++ b/core/src/test/java/de/jplag/NormalComparisonTest.java
@@ -112,7 +112,7 @@ class NormalComparisonTest extends TestBase {
     void testMultiRootDirSeparateBasecode() throws ExitException {
         String basecodePath = getBasePath("basecode-base");
         List<String> paths = List.of(getBasePath("basecode"), getBasePath("SimpleDuplicate")); // 3 + 2 submissions.
-        JPlagResult result = runJPlag(paths, it -> it.withBaseCodeSubmissionName(basecodePath));
+        JPlagResult result = runJPlag(paths, it -> it.withBaseCodeSubmissionPath(basecodePath));
         assertEquals(5, result.getNumberOfSubmissions());
     }
 
@@ -120,7 +120,7 @@ class NormalComparisonTest extends TestBase {
     public void testMultiRootDirBasecodeInSubmissionDir() throws ExitException {
         String basecodePath = getBasePath("basecode", "base");
         List<String> paths = List.of(getBasePath("basecode"), getBasePath("SimpleDuplicate")); // 2 + 2 submissions.
-        JPlagResult result = runJPlag(paths, it -> it.withBaseCodeSubmissionName(basecodePath));
+        JPlagResult result = runJPlag(paths, it -> it.withBaseCodeSubmissionPath(basecodePath));
         assertEquals(4, result.getNumberOfSubmissions());
     }
 
@@ -128,7 +128,7 @@ class NormalComparisonTest extends TestBase {
     public void testMultiRootDirBasecodeName() {
         List<String> paths = List.of(getBasePath("basecode"), getBasePath("SimpleDuplicate"));
         String basecodePath = "base"; // Should *not* find basecode/base
-        assertThrows(BasecodeException.class, () -> runJPlag(paths, it -> it.withBaseCodeSubmissionName(basecodePath)));
+        assertThrows(BasecodeException.class, () -> runJPlag(paths, it -> it.withBaseCodeSubmissionPath(basecodePath)));
     }
 
     @Test
@@ -154,7 +154,7 @@ class NormalComparisonTest extends TestBase {
         String basecodePath = getBasePath("basecode", "base");
         List<String> newDirectories = List.of(getBasePath("SimpleDuplicate")); // 2 submissions
         List<String> oldDirectories = List.of(getBasePath("basecode")); // 3 - 1 submissions
-        JPlagResult result = runJPlag(newDirectories, oldDirectories, it -> it.withBaseCodeSubmissionName(basecodePath));
+        JPlagResult result = runJPlag(newDirectories, oldDirectories, it -> it.withBaseCodeSubmissionPath(basecodePath));
         int numberOfExpectedComparison = 1 + 2 * 2;
         assertEquals(numberOfExpectedComparison, result.getAllComparisons().size());
     }

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryBase/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryBase/src/SimpleDuplicate.java
@@ -1,0 +1,7 @@
+public class SimpleDuplicate {
+
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+
+}

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/A/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/A/src/SimpleDuplicate.java
@@ -1,0 +1,11 @@
+public class SimpleDuplicate {
+
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+
+        for(int i = 0; i < 10; i++) {
+            System.out.println("Number is " + i);
+        }
+    }
+
+}

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/B/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/B/src/SimpleDuplicate.java
@@ -1,0 +1,12 @@
+public class SimpleDuplicate {
+
+    public static void main(String[] args) {
+        System.out.println("Hello Plagiarism!");
+
+        int max = 10;
+        for(int j = 0; j < max; j++) {
+            System.out.println("Number is " + j);
+        }
+    }
+
+}

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/Base/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/Base/src/SimpleDuplicate.java
@@ -1,0 +1,7 @@
+public class SimpleDuplicate {
+
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+
+}


### PR DESCRIPTION
Resolves #660:
- Adds test case that reproduces the bug
- Fix the bug
- Enforce use of the delta constant for double comparison in test cases
- Fix name of basecode option (usually it is a path not a name)