### PR TITLE
Language API cleanup

### DIFF
--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -3,9 +3,9 @@ package de.jplag;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -232,23 +232,6 @@ public class Submission implements Comparable<Submission> {
         return subdirectory;
     }
 
-    /**
-     * Map all files of this submission to their path relative to the submission directory.
-     * <p>
-     * This method is required to stay compatible with `language.parse(...)` as it requires the given file paths to be
-     * relative to the submission directory.
-     * <p>
-     * In a future update, `language.parse(...)` should probably just take a list of files.
-     * @param baseFile - File to base all relative file paths on.
-     * @param files - List of files to map.
-     * @return an array of file paths relative to the submission directory.
-     */
-    private String[] getRelativeFilePaths(File baseFile, Collection<File> files) {
-        Path baseFilePath = baseFile.toPath();
-
-        return files.stream().map(File::toPath).map(baseFilePath::relativize).map(Path::toString).toArray(String[]::new);
-    }
-
     /* package-private */ void markAsErroneous() {
         hasErrors = true;
     }
@@ -265,9 +248,7 @@ public class Submission implements Comparable<Submission> {
             return false;
         }
 
-        String[] relativeFilePaths = getRelativeFilePaths(submissionRootFile, files);
-
-        tokenList = language.parse(submissionRootFile, relativeFilePaths);
+        tokenList = language.parse(new HashSet<>(files));
         if (!language.hasErrors()) {
             if (tokenList.size() < 3) {
                 logger.error("Submission \"{}\" is too short!", name);

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -248,22 +248,24 @@ public class Submission implements Comparable<Submission> {
             return false;
         }
 
-        tokenList = language.parse(new HashSet<>(files));
-        if (!language.hasErrors()) {
-            if (tokenList.size() < 3) {
-                logger.error("Submission \"{}\" is too short!", name);
-                tokenList = null;
-                hasErrors = true; // invalidate submission
-                return false;
+        try {
+            tokenList = language.parse(new HashSet<>(files));
+        } catch (ParsingException e) {
+            logger.warn("Failed to parse submission {} with error {}", this, e);
+            tokenList = null;
+            hasErrors = true;
+            if (debugParser) {
+                copySubmission();
             }
-            return true;
+            return false;
         }
 
-        tokenList = null;
-        hasErrors = true; // invalidate submission
-        if (debugParser) {
-            copySubmission();
+        if (tokenList.size() < 3) {
+            logger.error("Submission \"{}\" is too short!", name);
+            tokenList = null;
+            hasErrors = true; // invalidate submission
+            return false;
         }
-        return false;
+        return true;
     }
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -1,5 +1,6 @@
 package de.jplag.reporting.jsonfactory;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -97,8 +98,13 @@ public class ComparisonReportWriter {
         Token startOfSecond = tokensSecond.get(match.startOfSecond());
         Token endOfSecond = tokensSecond.get(match.startOfSecond() + match.length() - 1);
 
-        return new Match(startOfFirst.getFile(), startOfSecond.getFile(), startOfFirst.getLine(), endOfFirst.getLine(), startOfSecond.getLine(),
-                endOfSecond.getLine(), match.length());
+        return new Match(relativizedFilePath(startOfFirst.getFile(), comparison.firstSubmission()),
+                relativizedFilePath(startOfSecond.getFile(), comparison.secondSubmission()), startOfFirst.getLine(), endOfFirst.getLine(),
+                startOfSecond.getLine(), endOfSecond.getLine(), match.length());
+    }
+
+    private String relativizedFilePath(File file, Submission submission) {
+        return submission.getRoot().toPath().relativize(file.toPath()).toString();
     }
 
 }

--- a/language-api/src/main/java/de/jplag/AbstractParser.java
+++ b/language-api/src/main/java/de/jplag/AbstractParser.java
@@ -8,17 +8,9 @@ import org.slf4j.LoggerFactory;
  * @author Emeric Kwemou
  */
 public abstract class AbstractParser {
-    protected int errors = 0;
     public final Logger logger;
 
     protected AbstractParser() {
         this.logger = LoggerFactory.getLogger(this.getClass());
-    }
-
-    /**
-     * @return true if the last parse call (which could be still ongoing) lead to one or more errors.
-     */
-    public boolean hasErrors() {
-        return errors != 0;
     }
 }

--- a/language-api/src/main/java/de/jplag/Language.java
+++ b/language-api/src/main/java/de/jplag/Language.java
@@ -2,6 +2,7 @@ package de.jplag;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Common interface for all languages. Each language-front end must provide a concrete language implementation.
@@ -29,12 +30,11 @@ public interface Language {
     int minimumTokenMatch();
 
     /**
-     * Parses a set files in a directory.
-     * @param directory is the directory where the files are located.
-     * @param files are the names of the files to parse.
+     * Parses a set of files.
+     * @param files are the files to parse.
      * @return the list of parsed JPlag tokens.
      */
-    List<Token> parse(File directory, String[] files);
+    List<Token> parse(Set<File> files);
 
     /**
      * Whether errors were found during the last {@link #parse}.
@@ -62,5 +62,4 @@ public interface Language {
     default String viewFileSuffix() {
         return "";
     }
-
 }

--- a/language-api/src/main/java/de/jplag/Language.java
+++ b/language-api/src/main/java/de/jplag/Language.java
@@ -33,13 +33,9 @@ public interface Language {
      * Parses a set of files.
      * @param files are the files to parse.
      * @return the list of parsed JPlag tokens.
+     * @throws ParsingException if an error during parsing the files occurred.
      */
-    List<Token> parse(Set<File> files);
-
-    /**
-     * Whether errors were found during the last {@link #parse}.
-     */
-    boolean hasErrors();
+    List<Token> parse(Set<File> files) throws ParsingException;
 
     /**
      * Determines whether a fixed-width font should be used to display that language.

--- a/language-api/src/main/java/de/jplag/ParsingException.java
+++ b/language-api/src/main/java/de/jplag/ParsingException.java
@@ -1,0 +1,61 @@
+package de.jplag;
+
+import java.io.File;
+import java.io.Serial;
+
+/**
+ * An exception to throw if any error occurred while parsing files in a language frontend.
+ */
+public class ParsingException extends Exception {
+    @Serial
+    private static final long serialVersionUID = 4385949762027596330L; // generated
+
+    /**
+     * Constructs a new exception indicating a parsing exception in the given file without a specific reason.
+     * @param file the file in which a parsing error occurred. (A null value is permitted, and indicates that the file is
+     * nonexistent or unknown.)
+     */
+    public ParsingException(File file) {
+        this(file, (String) null);
+    }
+
+    /**
+     * Constructs a new exception indicating a parsing exception in the given file with the given reason.
+     * @param file the file in which a parsing error occurred. (A null value is permitted, and indicates that the file is
+     * nonexistent or unknown.)
+     * @param reason the reason the parsing failed. A null value is permitted.)
+     */
+    public ParsingException(File file, String reason) {
+        super(constructMessage(file, reason));
+    }
+
+    /**
+     * Constructs a new exception indicating a parsing exception in the given file with the given cause.
+     * @param file the file in which a parsing error occurred. (A null value is permitted, and indicates that the file is
+     * nonexistent or unknown.)
+     * @param cause the cause. (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
+     */
+    public ParsingException(File file, Throwable cause) {
+        this(file, null, cause);
+    }
+
+    /**
+     * Constructs a new exception indicating a parsing exception in the given file with the given reason and cause.
+     * @param file the file in which a parsing error occurred. (A null value is permitted, and indicates that the file is
+     * nonexistent or unknown.)
+     * @param reason the reason the parsing failed. A null value is permitted.)
+     * @param cause the cause. (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
+     */
+    public ParsingException(File file, String reason, Throwable cause) {
+        super(constructMessage(file, reason), cause);
+    }
+
+    private static String constructMessage(File file, String reason) {
+        StringBuilder messageBuilder = new StringBuilder();
+        messageBuilder.append("failed to parse '%s'".formatted(file));
+        if (!reason.isEmpty() && !reason.isBlank()) {
+            messageBuilder.append(" with reason: %s".formatted(reason));
+        }
+        return messageBuilder.toString();
+    }
+}

--- a/language-api/src/main/java/de/jplag/ParsingException.java
+++ b/language-api/src/main/java/de/jplag/ParsingException.java
@@ -2,6 +2,8 @@ package de.jplag;
 
 import java.io.File;
 import java.io.Serial;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 /**
  * An exception to throw if any error occurred while parsing files in a language frontend.
@@ -48,6 +50,30 @@ public class ParsingException extends Exception {
      */
     public ParsingException(File file, String reason, Throwable cause) {
         super(constructMessage(file, reason), cause);
+    }
+
+    /**
+     * Creates a new parsing exception which wraps the provided exceptions. If no exception to wrap is provided, null is
+     * returned. If only one exception is provided, it is returned.
+     * @param exceptions the collection of exceptions to wrap.
+     * @return a new parsing exception wrapping the provided exceptions, <code>null</code> if no exceptions are provided, or
+     * the provided exception if only one was provided.
+     */
+    public static ParsingException wrappingExceptions(Collection<ParsingException> exceptions) {
+        switch (exceptions.size()) {
+            case 0:
+                return null;
+            case 1:
+                return exceptions.iterator().next();
+            default: {
+                String message = exceptions.stream().map(ParsingException::getMessage).collect(Collectors.joining("\n"));
+                return new ParsingException(message);
+            }
+        }
+    }
+
+    private ParsingException(String message) {
+        super(message);
     }
 
     private static String constructMessage(File file, String reason) {

--- a/language-api/src/main/java/de/jplag/Token.java
+++ b/language-api/src/main/java/de/jplag/Token.java
@@ -1,5 +1,7 @@
 package de.jplag;
 
+import java.io.File;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,14 +18,14 @@ public class Token {
     private int line;
     private int column;
     private int length;
-    private String file;
+    private File file;
     private TokenType type;
 
     /**
      * Creates a token of type {@link SharedTokenType#FILE_END FILE_END} without information about line, column, and length.
      * @param file is the name of the source code file.
      */
-    public static Token fileEnd(String file) {
+    public static Token fileEnd(File file) {
         return new Token(SharedTokenType.FILE_END, file, NO_VALUE, NO_VALUE, NO_VALUE);
     }
 
@@ -35,7 +37,7 @@ public class Token {
      * @param column is the column index, meaning where the token starts in the line. Index is 1-based.
      * @param length is the length of the token in the source code.
      */
-    public Token(TokenType type, String file, int line, int column, int length) {
+    public Token(TokenType type, File file, int line, int column, int length) {
         if (line == 0) {
             logger.warn("Creating a token with line index 0 while index is 1-based");
         }
@@ -60,7 +62,7 @@ public class Token {
     /**
      * @return the name of the file where the source code that the token represents is located in.
      */
-    public String getFile() {
+    public File getFile() {
         return file;
     }
 

--- a/language-api/src/main/java/de/jplag/TokenPrinter.java
+++ b/language-api/src/main/java/de/jplag/TokenPrinter.java
@@ -65,10 +65,10 @@ public final class TokenPrinter {
      */
     public static String printTokens(List<Token> tokenList, File rootDirectory, Optional<String> suffix) {
         PrinterOutputBuilder builder = new PrinterOutputBuilder();
-        Map<String, List<Token>> fileToTokens = groupTokensByFile(tokenList);
+        Map<File, List<Token>> fileToTokens = groupTokensByFile(tokenList);
 
-        fileToTokens.forEach((String fileName, List<Token> fileTokens) -> {
-            builder.append(fileName);
+        fileToTokens.forEach((File file, List<Token> fileTokens) -> {
+            builder.append(rootDirectory.toPath().relativize(file.toPath()).toString());
 
             List<LineData> lineDatas = getLineData(fileTokens, rootDirectory, suffix);
             lineDatas.forEach(lineData -> {
@@ -115,10 +115,7 @@ public final class TokenPrinter {
 
     private static List<LineData> getLineData(List<Token> fileTokens, File root, Optional<String> suffix) {
         // We expect that all fileTokens share the same Token.file!
-
-        String fileName = fileTokens.get(0).getFile();
-        // handle 'files as submissions' mode
-        File file = fileName.isEmpty() ? root : new File(root, fileName);
+        File file = fileTokens.get(0).getFile();
         if (suffix.isPresent()) {
             file = new File(file.getPath() + suffix.get());
         }
@@ -144,7 +141,7 @@ public final class TokenPrinter {
                 .toList();
     }
 
-    private static Map<String, List<Token>> groupTokensByFile(List<Token> tokens) {
+    private static Map<File, List<Token>> groupTokensByFile(List<Token> tokens) {
         return tokens.stream().collect(Collectors.groupingBy(Token::getFile));
     }
 

--- a/language-api/src/main/java/de/jplag/TokenPrinter.java
+++ b/language-api/src/main/java/de/jplag/TokenPrinter.java
@@ -70,7 +70,7 @@ public final class TokenPrinter {
         fileToTokens.forEach((File file, List<Token> fileTokens) -> {
             builder.append(rootDirectory.toPath().relativize(file.toPath()).toString());
 
-            List<LineData> lineDatas = getLineData(fileTokens, rootDirectory, suffix);
+            List<LineData> lineDatas = getLineData(fileTokens, suffix);
             lineDatas.forEach(lineData -> {
                 builder.setLine(lineData.lineNumber());
 
@@ -113,7 +113,7 @@ public final class TokenPrinter {
         return builder.toString();
     }
 
-    private static List<LineData> getLineData(List<Token> fileTokens, File root, Optional<String> suffix) {
+    private static List<LineData> getLineData(List<Token> fileTokens, Optional<String> suffix) {
         // We expect that all fileTokens share the same Token.file!
         File file = fileTokens.get(0).getFile();
         if (suffix.isPresent()) {

--- a/language-api/src/test/java/de/jplag/TokenPrinterTest.java
+++ b/language-api/src/test/java/de/jplag/TokenPrinterTest.java
@@ -1,9 +1,9 @@
 package de.jplag;
 
-import static de.jplag.SharedTokenType.FILE_END;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,37 +28,38 @@ class TokenPrinterTest {
 
         // See TokenPrinterTest.txt for the intended behaviour
         List<Token> tokens = new ArrayList<>();
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 1, 1, "STRING".length()));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 2, 1, "STRING".length() + 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 3, 1, "STRING".length() + 2));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 4, 1, "STRING".length() + 10));
+        File testFile = new File(TEST_FILE_LOCATION.toFile(), TEST_FILE_NAME);
+        tokens.add(new Token(TestTokenType.STRING, testFile, 1, 1, "STRING".length()));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 2, 1, "STRING".length() + 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 3, 1, "STRING".length() + 2));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 4, 1, "STRING".length() + 10));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 6, 3, 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 7, 9, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 6, 3, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 7, 9, 1));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 9, 1, 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 9, 10, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 9, 1, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 9, 10, 1));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 10, 1, 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 10, 5, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 10, 1, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 10, 5, 1));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 12, 1, 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 12, 5, 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 12, 10, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 12, 1, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 12, 5, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 12, 10, 1));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 14, 10, 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 14, 5, 1));
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 14, 1, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 14, 10, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 14, 5, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 14, 1, 1));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 16, -5, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 16, -5, 1));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 19, 100, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 19, 100, 1));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 22, 1, 100));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 22, 1, 100));
 
-        tokens.add(new Token(FILE_END, TEST_FILE_NAME, Token.NO_VALUE, Token.NO_VALUE, Token.NO_VALUE));
+        tokens.add(Token.fileEnd(testFile));
 
-        tokens.add(new Token(TestTokenType.STRING, TEST_FILE_NAME, 100, 1, 1));
+        tokens.add(new Token(TestTokenType.STRING, testFile, 100, 1, 1));
 
         String output = TokenPrinter.printTokens(tokens, TEST_FILE_LOCATION.toFile());
         logger.info(output); // no additional newline required

--- a/language-testutils/src/test/java/de/jplag/testutils/TokenUtils.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/TokenUtils.java
@@ -1,5 +1,6 @@
 package de.jplag.testutils;
 
+import java.io.File;
 import java.util.List;
 
 import de.jplag.Token;
@@ -14,21 +15,21 @@ public final class TokenUtils {
     /**
      * Returns the type of all tokens that belong to a certain file.
      * @param tokens is the list of {@link Token Tokens}.
-     * @param name is the name of the target file.
+     * @param file is the target file.
      * @return the immutable list of token types.
      */
-    public static List<TokenType> tokenTypesByFile(List<Token> tokens, String name) {
-        return tokensByFile(tokens, name).stream().map(Token::getType).toList();
+    public static List<TokenType> tokenTypesByFile(List<Token> tokens, File file) {
+        return tokensByFile(tokens, file).stream().map(Token::getType).toList();
     }
 
     /**
      * Returns the tokens that belong to a certain file.
      * @param tokens is the list of {@link Token Tokens}.
-     * @param name is the name of the target file.
+     * @param file is the target file.
      * @return the immutable list of tokens.
      */
-    public static List<Token> tokensByFile(List<Token> tokens, String name) {
-        return tokens.stream().filter(it -> it.getFile().startsWith(name)).toList();
+    public static List<Token> tokensByFile(List<Token> tokens, File file) {
+        return tokens.stream().filter(it -> it.getFile().equals(file)).toList();
     }
 
 }

--- a/languages/cpp/src/main/java/de/jplag/cpp/Language.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/Language.java
@@ -2,6 +2,7 @@ package de.jplag.cpp;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -38,8 +39,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File dir, String[] files) {
-        return this.scanner.scan(dir, files);
+    public List<Token> parse(Set<File> files) {
+        return this.scanner.scan(files);
     }
 
     @Override

--- a/languages/cpp/src/main/java/de/jplag/cpp/Language.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 @MetaInfServices(de.jplag.Language.class)
@@ -39,12 +40,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return this.scanner.scan(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return this.scanner.hasErrors();
     }
 }

--- a/languages/cpp/src/main/java/de/jplag/cpp/Scanner.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/Scanner.java
@@ -9,7 +9,7 @@ import de.jplag.AbstractParser;
 import de.jplag.Token;
 
 public class Scanner extends AbstractParser {
-    private String currentFile;
+    private File currentFile;
 
     private List<Token> tokens;
 
@@ -24,7 +24,7 @@ public class Scanner extends AbstractParser {
         tokens = new ArrayList<>();
         errors = 0;
         for (File file : files) {
-            this.currentFile = file.getName();
+            this.currentFile = file;
             logger.trace("Scanning file {}", currentFile);
             if (!CPPScanner.scanFile(file, this)) {
                 errors++;

--- a/languages/cpp/src/main/java/de/jplag/cpp/Scanner.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/Scanner.java
@@ -3,6 +3,7 @@ package de.jplag.cpp;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import de.jplag.AbstractParser;
 import de.jplag.Token;
@@ -19,13 +20,13 @@ public class Scanner extends AbstractParser {
         super();
     }
 
-    public List<Token> scan(File directory, String[] files) {
+    public List<Token> scan(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        for (String currentFile : files) {
-            this.currentFile = currentFile;
+        for (File file : files) {
+            this.currentFile = file.getName();
             logger.trace("Scanning file {}", currentFile);
-            if (!CPPScanner.scanFile(directory, currentFile, this)) {
+            if (!CPPScanner.scanFile(file, this)) {
                 errors++;
             }
             tokens.add(Token.fileEnd(currentFile));

--- a/languages/cpp/src/main/java/de/jplag/cpp/Scanner.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/Scanner.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 public class Scanner extends AbstractParser {
@@ -20,15 +21,12 @@ public class Scanner extends AbstractParser {
         super();
     }
 
-    public List<Token> scan(Set<File> files) {
+    public List<Token> scan(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
-        errors = 0;
         for (File file : files) {
             this.currentFile = file;
             logger.trace("Scanning file {}", currentFile);
-            if (!CPPScanner.scanFile(file, this)) {
-                errors++;
-            }
+            CPPScanner.scanFile(file, this);
             tokens.add(Token.fileEnd(currentFile));
         }
         return tokens;

--- a/languages/cpp/src/main/javacc/CPP.jj
+++ b/languages/cpp/src/main/javacc/CPP.jj
@@ -24,22 +24,22 @@ import static de.jplag.cpp.CPPTokenType.*;
 public class CPPScanner {
     private Scanner delegatingScanner;
 
-    public static boolean scanFile(File dir, String fileName, Scanner delegatingScanner) {
+    public static boolean scanFile(File file, Scanner delegatingScanner) {
         CPPScanner scanner;
-        try(InputStream input = new NewlineStream(new FileInputStream(new File(dir, fileName)))) {
+        try(InputStream input = new NewlineStream(new FileInputStream(file))) {
             scanner = new CPPScanner(input, "UTF-8");
             scanner.delegatingScanner = delegatingScanner;
         } catch (IOException e) {
-            System.out.println("C/C++ Scanner: File " + fileName + " not found.");
+            System.out.println("C/C++ Scanner: File " + file.getName() + " not found.");
             return false;
         }
         try {
             scanner.scan();
         } catch (ParseException e) {
-            delegatingScanner.logger.error("Parsing Error in '" + fileName + "': " + e.getMessage());
+            delegatingScanner.logger.error("Parsing Error in '" + file.getName() + "': " + e.getMessage());
             return false;
         } catch (TokenMgrException e) {
-            delegatingScanner.logger.error("Scanning Error in '" + fileName + "': " + e.getMessage());
+            delegatingScanner.logger.error("Scanning Error in '" + file.getName() + "': " + e.getMessage());
             return false;
         }
         return true;

--- a/languages/cpp/src/main/javacc/CPP.jj
+++ b/languages/cpp/src/main/javacc/CPP.jj
@@ -19,30 +19,31 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import de.jplag.ParsingException;
+
 import static de.jplag.cpp.CPPTokenType.*;
 
 public class CPPScanner {
     private Scanner delegatingScanner;
 
-    public static boolean scanFile(File file, Scanner delegatingScanner) {
+    public static void scanFile(File file, Scanner delegatingScanner) throws ParsingException {
         CPPScanner scanner;
         try(InputStream input = new NewlineStream(new FileInputStream(file))) {
             scanner = new CPPScanner(input, "UTF-8");
             scanner.delegatingScanner = delegatingScanner;
         } catch (IOException e) {
             System.out.println("C/C++ Scanner: File " + file.getName() + " not found.");
-            return false;
+            throw new ParsingException(file, e.getMessage(), e);
         }
         try {
             scanner.scan();
         } catch (ParseException e) {
             delegatingScanner.logger.error("Parsing Error in '" + file.getName() + "': " + e.getMessage());
-            return false;
+            throw new ParsingException(file, e.getMessage(), e);
         } catch (TokenMgrException e) {
             delegatingScanner.logger.error("Scanning Error in '" + file.getName() + "': " + e.getMessage());
-            return false;
+            throw new ParsingException(file, e.getMessage(), e);
         }
-        return true;
     }
 }
 PARSER_END(CPPScanner)

--- a/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
@@ -69,7 +69,6 @@ public class CSharpParserAdapter extends AbstractParser {
                 treeWalker.walk(new CSharpListener(this), parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '" + file.getName() + "':" + File.separator + exception, exception);
             throw new ParsingException(file, exception.getMessage(), exception);
         }
     }

--- a/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
@@ -14,6 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenType;
 import de.jplag.csharp.grammar.CSharpLexer;
@@ -40,19 +41,16 @@ public class CSharpParserAdapter extends AbstractParser {
      * @param files is the set of files.
      * @return the list of parsed tokens.
      */
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
-        errors = 0;
         for (File file : files) {
-            if (!parseFile(file)) {
-                errors++;
-            }
+            parseFile(file);
             tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
-    private boolean parseFile(File file) {
+    private void parseFile(File file) throws ParsingException {
         try (FileInputStream inputStream = new FileInputStream(file)) {
             currentFile = file;
 
@@ -72,9 +70,8 @@ public class CSharpParserAdapter extends AbstractParser {
             }
         } catch (IOException exception) {
             logger.error("Parsing Error in '" + file.getName() + "':" + File.separator + exception, exception);
-            return false;
+            throw new ParsingException(file, exception.getMessage(), exception);
         }
-        return true;
     }
 
     /* package-private */ void addToken(TokenType type, int line, int column, int length) {

--- a/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -35,27 +36,25 @@ public class CSharpParserAdapter extends AbstractParser {
     }
 
     /**
-     * Parses all tokens form a list of files.
-     * @param directory is the base directory.
-     * @param fileNames is the list of file names.
+     * Parses all tokens from a set of files.
+     * @param files is the set of files.
      * @return the list of parsed tokens.
      */
-    public List<Token> parse(File directory, List<String> fileNames) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        for (String fileName : fileNames) {
-            if (!parseFile(directory, fileName)) {
+        for (File file : files) {
+            if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(fileName));
+            tokens.add(Token.fileEnd(file.getName()));
         }
         return tokens;
     }
 
-    private boolean parseFile(File directory, String fileName) {
-        File file = new File(directory, fileName);
+    private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = fileName;
+            currentFile = file.getName();
 
             // create a lexer, a parser and a buffer between them.
             CSharpLexer lexer = new CSharpLexer(CharStreams.fromStream(inputStream));
@@ -72,7 +71,7 @@ public class CSharpParserAdapter extends AbstractParser {
                 treeWalker.walk(new CSharpListener(this), parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '" + fileName + "':" + File.separator + exception, exception);
+            logger.error("Parsing Error in '" + file.getName() + "':" + File.separator + exception, exception);
             return false;
         }
         return true;

--- a/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/CSharpParserAdapter.java
@@ -26,7 +26,7 @@ import de.jplag.csharp.grammar.CSharpParser;
  */
 public class CSharpParserAdapter extends AbstractParser {
     private List<Token> tokens;
-    private String currentFile;
+    private File currentFile;
 
     /**
      * Creates the parser adapter.
@@ -47,14 +47,14 @@ public class CSharpParserAdapter extends AbstractParser {
             if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file.getName()));
+            tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
     private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = file.getName();
+            currentFile = file;
 
             // create a lexer, a parser and a buffer between them.
             CSharpLexer lexer = new CSharpLexer(CharStreams.fromStream(inputStream));

--- a/languages/csharp/src/main/java/de/jplag/csharp/Language.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 /**
@@ -46,12 +47,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return parser.parse(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return parser.hasErrors();
     }
 }

--- a/languages/csharp/src/main/java/de/jplag/csharp/Language.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/Language.java
@@ -1,8 +1,8 @@
 package de.jplag.csharp;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -46,8 +46,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File dir, String[] files) {
-        return parser.parse(dir, Arrays.asList(files));
+    public List<Token> parse(Set<File> files) {
+        return parser.parse(files);
     }
 
     @Override

--- a/languages/csharp/src/test/java/de/jplag/csharp/MinimalCSharpTest.java
+++ b/languages/csharp/src/test/java/de/jplag/csharp/MinimalCSharpTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.SharedTokenType;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
@@ -55,7 +56,7 @@ class MinimalCSharpTest {
     }
 
     @Test
-    void testParsingTestClass() {
+    void testParsingTestClass() throws ParsingException {
         List<TokenType> expectedToken = List.of(CLASS, CLASS_BEGIN, FIELD, CONSTRUCTOR, LOCAL_VARIABLE, METHOD, METHOD_BEGIN, IF, IF_BEGIN,
                 INVOCATION, IF_END, IF_BEGIN, INVOCATION, IF_END, METHOD_END, PROPERTY, ACCESSORS_BEGIN, ACCESSOR_BEGIN, ACCESSOR_END, ACCESSOR_BEGIN,
                 ACCESSOR_END, ACCESSORS_END, FIELD, PROPERTY, ACCESSORS_BEGIN, ACCESSOR_BEGIN, RETURN, ACCESSOR_END, ACCESSOR_BEGIN, ASSIGNMENT,

--- a/languages/csharp/src/test/java/de/jplag/csharp/MinimalCSharpTest.java
+++ b/languages/csharp/src/test/java/de/jplag/csharp/MinimalCSharpTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,8 +62,7 @@ class MinimalCSharpTest {
                 ACCESSOR_END, ACCESSORS_END, CLASS_END, SharedTokenType.FILE_END);
 
         // Parse test input
-        String[] input = new String[] {TEST_SUBJECT};
-        List<Token> result = language.parse(baseDirectory, input);
+        List<Token> result = language.parse(Set.of(new File(baseDirectory, TEST_SUBJECT)));
         logger.info(TokenPrinter.printTokens(result, baseDirectory));
 
         // Compare parsed tokens:

--- a/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/DynamicMetamodelToken.java
+++ b/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/DynamicMetamodelToken.java
@@ -1,5 +1,6 @@
 package de.jplag.emf.dynamic;
 
+import java.io.File;
 import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
@@ -13,11 +14,11 @@ import de.jplag.emf.MetamodelToken;
  */
 public class DynamicMetamodelToken extends MetamodelToken {
 
-    public DynamicMetamodelToken(TokenType type, String file, EObject eObject) {
+    public DynamicMetamodelToken(TokenType type, File file, EObject eObject) {
         super(type, file, NO_VALUE, NO_VALUE, NO_VALUE, Optional.of(eObject));
     }
 
-    public DynamicMetamodelToken(TokenType type, String file) {
+    public DynamicMetamodelToken(TokenType type, File file) {
         super(type, file);
     }
 }

--- a/languages/emf-metamodel-dynamic/src/test/java/de/jplag/emf/dynamic/MinimalDynamicMetamodelTest.java
+++ b/languages/emf-metamodel-dynamic/src/test/java/de/jplag/emf/dynamic/MinimalDynamicMetamodelTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
 import de.jplag.TokenType;
@@ -40,7 +41,7 @@ class MinimalDynamicMetamodelTest {
     }
 
     @Test
-    void testBookstoreMetamodels() {
+    void testBookstoreMetamodels() throws ParsingException {
         List<File> testFiles = Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).toList();
         List<Token> result = language.parse(new HashSet<>(testFiles));
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();

--- a/languages/emf-metamodel-dynamic/src/test/java/de/jplag/emf/dynamic/MinimalDynamicMetamodelTest.java
+++ b/languages/emf-metamodel-dynamic/src/test/java/de/jplag/emf/dynamic/MinimalDynamicMetamodelTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,16 +41,17 @@ class MinimalDynamicMetamodelTest {
 
     @Test
     void testBookstoreMetamodels() {
-        List<Token> result = language.parse(Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).collect(Collectors.toSet()));
+        List<File> testFiles = Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).toList();
+        List<Token> result = language.parse(new HashSet<>(testFiles));
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();
         logger.debug(TokenPrinter.printTokens(result, baseDirectory, Optional.of(Language.VIEW_FILE_SUFFIX)));
         logger.info("parsed token types: " + tokenTypes.stream().map(TokenType::getDescription).toList().toString());
         assertEquals(64, tokenTypes.size());
         assertEquals(7, new HashSet<>(tokenTypes.stream().filter(DynamicMetamodelTokenType.class::isInstance).toList()).size());
 
-        var bookstoreTokens = TokenUtils.tokenTypesByFile(result, TEST_SUBJECTS[0]);
-        var bookstoreRenamedTokens = TokenUtils.tokenTypesByFile(result, TEST_SUBJECTS[2]);
-        var bookstoreExtendedTokens = TokenUtils.tokenTypesByFile(result, TEST_SUBJECTS[1]);
+        var bookstoreTokens = TokenUtils.tokenTypesByFile(result, testFiles.get(0));
+        var bookstoreRenamedTokens = TokenUtils.tokenTypesByFile(result, testFiles.get(2));
+        var bookstoreExtendedTokens = TokenUtils.tokenTypesByFile(result, testFiles.get(1));
         assertTrue(bookstoreTokens.size() < bookstoreExtendedTokens.size());
         assertIterableEquals(bookstoreTokens, bookstoreRenamedTokens);
     }

--- a/languages/emf-metamodel-dynamic/src/test/java/de/jplag/emf/dynamic/MinimalDynamicMetamodelTest.java
+++ b/languages/emf-metamodel-dynamic/src/test/java/de/jplag/emf/dynamic/MinimalDynamicMetamodelTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +42,7 @@ class MinimalDynamicMetamodelTest {
 
     @Test
     void testBookstoreMetamodels() {
-        List<Token> result = language.parse(baseDirectory, TEST_SUBJECTS);
+        List<Token> result = language.parse(Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).collect(Collectors.toSet()));
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();
         logger.debug(TokenPrinter.printTokens(result, baseDirectory, Optional.of(Language.VIEW_FILE_SUFFIX)));
         logger.info("parsed token types: " + tokenTypes.stream().map(TokenType::getDescription).toList().toString());

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/Language.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/Language.java
@@ -1,8 +1,8 @@
 package de.jplag.emf;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.emf.ecore.EcorePackage;
 import org.kohsuke.MetaInfServices;
@@ -54,8 +54,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File dir, String[] files) {
-        return parser.parse(dir, Arrays.asList(files));
+    public List<Token> parse(Set<File> files) {
+        return parser.parse(files);
     }
 
     @Override

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/Language.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/Language.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.emf.parser.EcoreParser;
 
@@ -54,13 +55,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return parser.parse(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return parser.hasErrors();
     }
 
     @Override

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/MetamodelToken.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/MetamodelToken.java
@@ -1,5 +1,6 @@
 package de.jplag.emf;
 
+import java.io.File;
 import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
@@ -18,32 +19,32 @@ public class MetamodelToken extends Token {
     /**
      * Creates an Ecore metamodel token that corresponds to an EObject.
      * @param type is the type of the token.
-     * @param file is the name of the source model file.
+     * @param file is the source model file.
      * @param eObject is the corresponding eObject in the model from which this token was extracted.
      */
-    public MetamodelToken(MetamodelTokenType type, String file, EObject eObject) {
+    public MetamodelToken(MetamodelTokenType type, File file, EObject eObject) {
         this(type, file, NO_VALUE, NO_VALUE, NO_VALUE, Optional.of(eObject));
     }
 
     /**
      * Creates an Ecore metamodel token.
      * @param type is the type of the token.
-     * @param file is the name of the source model file.
+     * @param file is the source model file.
      */
-    public MetamodelToken(TokenType type, String file) {
+    public MetamodelToken(TokenType type, File file) {
         this(type, file, NO_VALUE, NO_VALUE, NO_VALUE, Optional.empty());
     }
 
     /**
      * Creates a token with column and length information.
      * @param type is the token type.
-     * @param file is the name of the source code file.
+     * @param file is the source code file.
      * @param line is the line index in the source code where the token resides. Cannot be smaller than 1.
      * @param column is the column index, meaning where the token starts in the line.
      * @param length is the length of the token in the source code.
      * @param eObject is the corresponding eObject in the model from which this token was extracted
      */
-    public MetamodelToken(TokenType type, String file, int line, int column, int length, Optional<EObject> eObject) {
+    public MetamodelToken(TokenType type, File file, int line, int column, int length, Optional<EObject> eObject) {
         super(type, file, line, column, length);
         this.eObject = eObject;
     }

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
@@ -3,6 +3,7 @@ package de.jplag.emf.parser;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.eclipse.emf.ecore.EObject;
 
@@ -33,29 +34,27 @@ public class EcoreParser extends AbstractParser {
     }
 
     /**
-     * Parses all tokens form a list of files.
-     * @param directory is the base directory.
-     * @param fileNames is the list of file names.
+     * Parses all tokens from a set of files.
+     * @param files is the set of files.
      * @return the list of parsed tokens.
      */
-    public List<Token> parse(File directory, List<String> fileNames) {
+    public List<Token> parse(Set<File> files) {
         errors = 0;
         tokens = new ArrayList<>();
-        for (String fileName : fileNames) {
-            currentFile = fileName;
-            String filePath = fileName.isEmpty() ? directory.toString() : directory.toString() + File.separator + fileName;
-            parseModelFile(filePath);
+        for (File file : files) {
+            currentFile = file.getName();
+            parseModelFile(file);
         }
         return tokens;
     }
 
     /**
      * Loads a metamodel from a file and parses it.
-     * @param filePath is the path to the metamodel file.
+     * @param file is the metamodel file.
      */
-    protected void parseModelFile(String filePath) {
-        treeView = new MetamodelTreeView(filePath);
-        List<EObject> model = EMFUtil.loadModel(filePath);
+    protected void parseModelFile(File file) {
+        treeView = new MetamodelTreeView(file);
+        List<EObject> model = EMFUtil.loadModel(file);
         if (model == null) {
             errors++;
         } else {

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.eclipse.emf.ecore.EObject;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.emf.Language;
 import de.jplag.emf.MetamodelToken;
@@ -38,11 +39,9 @@ public class EcoreParser extends AbstractParser {
      * @param files is the set of files.
      * @return the list of parsed tokens.
      */
-    public List<Token> parse(Set<File> files) {
-        errors = 0;
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
-            currentFile = file;
             parseModelFile(file);
         }
         return tokens;
@@ -52,11 +51,12 @@ public class EcoreParser extends AbstractParser {
      * Loads a metamodel from a file and parses it.
      * @param file is the metamodel file.
      */
-    protected void parseModelFile(File file) {
+    protected void parseModelFile(File file) throws ParsingException {
+        currentFile = file;
         treeView = new MetamodelTreeView(file);
         List<EObject> model = EMFUtil.loadModel(file);
         if (model == null) {
-            errors++;
+            throw new ParsingException(file, "failed to load model");
         } else {
             for (EObject root : model) {
                 visitor = createMetamodelVisitor();

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
@@ -22,7 +22,7 @@ import de.jplag.emf.util.MetamodelTreeView;
  */
 public class EcoreParser extends AbstractParser {
     protected List<Token> tokens;
-    protected String currentFile;
+    protected File currentFile;
     protected MetamodelTreeView treeView;
     protected AbstractMetamodelVisitor visitor;
 
@@ -42,7 +42,7 @@ public class EcoreParser extends AbstractParser {
         errors = 0;
         tokens = new ArrayList<>();
         for (File file : files) {
-            currentFile = file.getName();
+            currentFile = file;
             parseModelFile(file);
         }
         return tokens;

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EMFUtil.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EMFUtil.java
@@ -66,7 +66,7 @@ public final class EMFUtil {
             final Resource resource = resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
             return resource.getContents();
         } catch (WrappedException exception) {
-            logger.error("Could not load " + file.getName() + ": " + exception.getCause().getMessage());
+            logger.error("Could not load {}: {}", file, exception.getCause().getMessage());
         }
         return null;
     }

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EMFUtil.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EMFUtil.java
@@ -57,17 +57,16 @@ public final class EMFUtil {
 
     /**
      * Loads a model or metamodel from a absolute file path.
-     * @param filePath is the absolute path to the (meta)model.
+     * @param file is file to the (meta)model.
      * @return the content of the loaded (meta)model resource or null if it could not be loaded.
      */
-    public static List<EObject> loadModel(String filePath) {
+    public static List<EObject> loadModel(File file) {
         final ResourceSet resourceSet = new ResourceSetImpl();
         try {
-            final Resource resource = resourceSet.getResource(URI.createFileURI(filePath), true);
+            final Resource resource = resourceSet.getResource(URI.createFileURI(file.getAbsolutePath()), true);
             return resource.getContents();
         } catch (WrappedException exception) {
-            String name = new File(filePath).getName();
-            logger.error("Could not load " + name + ": " + exception.getCause().getMessage());
+            logger.error("Could not load " + file.getName() + ": " + exception.getCause().getMessage());
         }
         return null;
     }

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/util/MetamodelTreeView.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/util/MetamodelTreeView.java
@@ -19,7 +19,7 @@ import de.jplag.emf.MetamodelToken;
  * @author Timur Saglam
  */
 public class MetamodelTreeView {
-    private final String filePath;
+    private final File file;
     private int lineIndex;
     private int columnIndex;
     private final StringBuilder viewBuilder;
@@ -28,10 +28,10 @@ public class MetamodelTreeView {
 
     /**
      * Creates a tree view for a metamodel.
-     * @param filePath is the path to the file where the metamodel is persisted.
+     * @param file is the file where the metamodel is persisted.
      */
-    public MetamodelTreeView(String filePath) {
-        this.filePath = filePath;
+    public MetamodelTreeView(File file) {
+        this.file = file;
         logger = LoggerFactory.getLogger(this.getClass());
         viewBuilder = new StringBuilder();
     }
@@ -85,7 +85,7 @@ public class MetamodelTreeView {
      * @param suffix is the suffix of the file to be written.
      */
     public void writeToFile(String suffix) {
-        File treeViewFile = new File(filePath + suffix);
+        File treeViewFile = new File(file, suffix);
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(treeViewFile));) {
             if (!treeViewFile.createNewFile()) {
                 logger.warn("Overwriting tree view file: {}", treeViewFile);

--- a/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
+++ b/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
 import de.jplag.TokenType;
@@ -40,7 +41,7 @@ class MinimalMetamodelTest {
     }
 
     @Test
-    void testBookstoreMetamodels() {
+    void testBookstoreMetamodels() throws ParsingException {
         List<File> testFiles = Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).toList();
         List<Token> result = language.parse(new HashSet<>(testFiles));
 

--- a/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
+++ b/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
@@ -6,9 +6,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +42,7 @@ class MinimalMetamodelTest {
 
     @Test
     void testBookstoreMetamodels() {
-        List<Token> result = language.parse(baseDirectory, TEST_SUBJECTS);
+        List<Token> result = language.parse(Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).collect(Collectors.toSet()));
 
         logger.debug(TokenPrinter.printTokens(result, baseDirectory, Optional.of(Language.VIEW_FILE_SUFFIX)));
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();

--- a/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
+++ b/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,8 @@ class MinimalMetamodelTest {
 
     @Test
     void testBookstoreMetamodels() {
-        List<Token> result = language.parse(Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).collect(Collectors.toSet()));
+        List<File> testFiles = Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).toList();
+        List<Token> result = language.parse(new HashSet<>(testFiles));
 
         logger.debug(TokenPrinter.printTokens(result, baseDirectory, Optional.of(Language.VIEW_FILE_SUFFIX)));
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();
@@ -50,9 +50,9 @@ class MinimalMetamodelTest {
         assertEquals(43, tokenTypes.size());
         assertEquals(10, new HashSet<>(tokenTypes).size());
 
-        var bookstoreTokens = TokenUtils.tokenTypesByFile(result, TEST_SUBJECTS[0]);
-        var bookstoreRenamedTokens = TokenUtils.tokenTypesByFile(result, TEST_SUBJECTS[2]);
-        var bookstoreExtendedTokens = TokenUtils.tokenTypesByFile(result, TEST_SUBJECTS[1]);
+        var bookstoreTokens = TokenUtils.tokenTypesByFile(result, testFiles.get(0));
+        var bookstoreRenamedTokens = TokenUtils.tokenTypesByFile(result, testFiles.get(2));
+        var bookstoreExtendedTokens = TokenUtils.tokenTypesByFile(result, testFiles.get(1));
         assertTrue(bookstoreTokens.size() < bookstoreExtendedTokens.size());
         assertIterableEquals(bookstoreTokens, bookstoreRenamedTokens);
     }

--- a/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
+++ b/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
@@ -14,6 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenType;
 import de.jplag.golang.grammar.GoLexer;
@@ -23,18 +24,16 @@ public class GoParserAdapter extends AbstractParser {
     private File currentFile;
     private List<Token> tokens;
 
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
-            if (!parseFile(file)) {
-                errors++;
-            }
+            parseFile(file);
             tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
-    private boolean parseFile(File file) {
+    private void parseFile(File file) throws ParsingException {
         try (FileInputStream inputStream = new FileInputStream(file)) {
             currentFile = file;
 
@@ -52,9 +51,8 @@ public class GoParserAdapter extends AbstractParser {
             }
         } catch (IOException exception) {
             logger.error("Parsing Error in '%s':".formatted(file.getName()), exception);
-            return false;
+            throw new ParsingException(file, exception.getMessage(), exception);
         }
-        return true;
     }
 
     public void addToken(TokenType tokenType, int line, int column, int length) {

--- a/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
+++ b/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
@@ -20,7 +20,7 @@ import de.jplag.golang.grammar.GoLexer;
 import de.jplag.golang.grammar.GoParser;
 
 public class GoParserAdapter extends AbstractParser {
-    private String currentFile;
+    private File currentFile;
     private List<Token> tokens;
 
     public List<Token> parse(Set<File> files) {
@@ -29,14 +29,14 @@ public class GoParserAdapter extends AbstractParser {
             if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file.getName()));
+            tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
     private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = file.getName();
+            currentFile = file;
 
             GoLexer lexer = new GoLexer(CharStreams.fromStream(inputStream));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);

--- a/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
+++ b/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -22,21 +23,20 @@ public class GoParserAdapter extends AbstractParser {
     private String currentFile;
     private List<Token> tokens;
 
-    public List<Token> parse(File directory, String[] fileNames) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
-        for (String file : fileNames) {
-            if (!parseFile(directory, file)) {
+        for (File file : files) {
+            if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file));
+            tokens.add(Token.fileEnd(file.getName()));
         }
         return tokens;
     }
 
-    private boolean parseFile(File directory, String fileName) {
-        File file = new File(directory, fileName);
+    private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = fileName;
+            currentFile = file.getName();
 
             GoLexer lexer = new GoLexer(CharStreams.fromStream(inputStream));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
@@ -51,7 +51,7 @@ public class GoParserAdapter extends AbstractParser {
                 treeWalker.walk(listener, parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '%s':".formatted(fileName), exception);
+            logger.error("Parsing Error in '%s':".formatted(file.getName()), exception);
             return false;
         }
         return true;

--- a/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
+++ b/languages/golang/src/main/java/de/jplag/golang/GoParserAdapter.java
@@ -50,7 +50,6 @@ public class GoParserAdapter extends AbstractParser {
                 treeWalker.walk(listener, parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '%s':".formatted(file.getName()), exception);
             throw new ParsingException(file, exception.getMessage(), exception);
         }
     }

--- a/languages/golang/src/main/java/de/jplag/golang/Language.java
+++ b/languages/golang/src/main/java/de/jplag/golang/Language.java
@@ -2,6 +2,7 @@ package de.jplag.golang;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -41,8 +42,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File directory, String[] files) {
-        return parserAdapter.parse(directory, files);
+    public List<Token> parse(Set<File> files) {
+        return parserAdapter.parse(files);
     }
 
     @Override

--- a/languages/golang/src/main/java/de/jplag/golang/Language.java
+++ b/languages/golang/src/main/java/de/jplag/golang/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 @MetaInfServices(de.jplag.Language.class)
@@ -42,13 +43,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return parserAdapter.parse(files);
     }
-
-    @Override
-    public boolean hasErrors() {
-        return parserAdapter.hasErrors();
-    }
-
 }

--- a/languages/golang/src/test/java/de/jplag/golang/GoLanguageTest.java
+++ b/languages/golang/src/test/java/de/jplag/golang/GoLanguageTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.SharedTokenType;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
@@ -57,7 +58,7 @@ class GoLanguageTest {
     }
 
     @Test
-    void parseTestFiles() {
+    void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
             List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);

--- a/languages/golang/src/test/java/de/jplag/golang/GoLanguageTest.java
+++ b/languages/golang/src/test/java/de/jplag/golang/GoLanguageTest.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -58,7 +59,7 @@ class GoLanguageTest {
     @Test
     void parseTestFiles() {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(testFileLocation, new String[] {fileName});
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -40,7 +40,6 @@ public class JavacAdapter {
             final Trees trees = Trees.instance(task);
             final SourcePositions positions = trees.getSourcePositions();
             for (final CompilationUnitTree ast : executeCompilationTask(task, parser.logger)) {
-                final String filename = ast.getSourceFile().getName();
                 File file = new File(ast.getSourceFile().toUri());
                 final LineMap map = ast.getLineMap();
                 ast.accept(new TokenGeneratingTreeScanner(file, parser, map, positions, ast), null);

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -53,7 +53,6 @@ public class JavacAdapter {
                 parser.add(Token.fileEnd(file));
             }
         } catch (IOException exception) {
-            parser.logger.error(exception.getMessage(), exception);
             throw new ParsingException(null, exception.getMessage(), exception);
         }
         processErrors(parser.logger, listener);

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -3,12 +3,12 @@ package de.jplag.java;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
@@ -34,6 +34,7 @@ public class JavacAdapter {
     public void parseFiles(Set<File> files, final Parser parser) throws ParsingException {
         var listener = new DiagnosticCollector<>();
 
+        List<ParsingException> parsingExceptions = new ArrayList<>();
         try (final StandardJavaFileManager fileManager = javac.getStandardFileManager(listener, null, StandardCharsets.UTF_8)) {
             var javaFiles = fileManager.getJavaFileObjectsFromFiles(files);
 
@@ -47,15 +48,16 @@ public class JavacAdapter {
                 final LineMap map = ast.getLineMap();
                 var scanner = new TokenGeneratingTreeScanner(file, parser, map, positions, ast);
                 ast.accept(scanner, null);
-                if (scanner.getParsingException() != null) {
-                    throw scanner.getParsingException();
-                }
+                parsingExceptions.addAll(scanner.getParsingExceptions());
                 parser.add(Token.fileEnd(file));
             }
         } catch (IOException exception) {
             throw new ParsingException(null, exception.getMessage(), exception);
         }
-        processErrors(parser.logger, listener);
+        parsingExceptions.addAll(processErrors(parser.logger, listener));
+        if (!parsingExceptions.isEmpty()) {
+            throw ParsingException.wrappingExceptions(parsingExceptions);
+        }
     }
 
     private Iterable<? extends CompilationUnitTree> executeCompilationTask(final CompilationTask task, Logger logger) {
@@ -68,18 +70,16 @@ public class JavacAdapter {
         return abstractSyntaxTrees;
     }
 
-    private void processErrors(Logger logger, DiagnosticCollector<Object> listener) throws ParsingException {
-        for (Diagnostic<?> diagnosticItem : listener.getDiagnostics()) {
-            if (diagnosticItem.getKind() == javax.tools.Diagnostic.Kind.ERROR) {
-                File file = null;
-                if (diagnosticItem.getSource() instanceof JavaFileObject) {
-                    JavaFileObject fileObject = (JavaFileObject) diagnosticItem.getSource();
-                    file = new File(fileObject.toUri());
-                }
-                logger.error("{}", diagnosticItem);
-                throw new ParsingException(file, diagnosticItem.getMessage(Locale.getDefault()));
+    private List<ParsingException> processErrors(Logger logger, DiagnosticCollector<Object> listener) {
+        return listener.getDiagnostics().stream().filter(it -> it.getKind() == javax.tools.Diagnostic.Kind.ERROR).map(diagnosticItem -> {
+            File file = null;
+            if (diagnosticItem.getSource() instanceof JavaFileObject) {
+                JavaFileObject fileObject = (JavaFileObject) diagnosticItem.getSource();
+                file = new File(fileObject.toUri());
             }
-        }
+            logger.error("{}", diagnosticItem);
+            return new ParsingException(file, diagnosticItem.getMessage(Locale.getDefault()));
+        }).toList();
     }
 
 }

--- a/languages/java/src/main/java/de/jplag/java/Language.java
+++ b/languages/java/src/main/java/de/jplag/java/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 /**
@@ -42,13 +43,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return this.parser.parse(files);
     }
-
-    @Override
-    public boolean hasErrors() {
-        return this.parser.hasErrors();
-    }
-
 }

--- a/languages/java/src/main/java/de/jplag/java/Language.java
+++ b/languages/java/src/main/java/de/jplag/java/Language.java
@@ -2,6 +2,7 @@ package de.jplag.java;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -41,8 +42,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File directory, String[] files) {
-        return this.parser.parse(directory, files);
+    public List<Token> parse(Set<File> files) {
+        return this.parser.parse(files);
     }
 
     @Override

--- a/languages/java/src/main/java/de/jplag/java/Parser.java
+++ b/languages/java/src/main/java/de/jplag/java/Parser.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenType;
 
@@ -19,10 +20,9 @@ public class Parser extends AbstractParser {
         super();
     }
 
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
-        errors = 0;
-        errors += new JavacAdapter().parseFiles(files, this);
+        new JavacAdapter().parseFiles(files, this);
         return tokens;
     }
 
@@ -32,9 +32,5 @@ public class Parser extends AbstractParser {
 
     public void add(Token token) {
         tokens.add(token);
-    }
-
-    public void increaseErrors() {
-        errors++;
     }
 }

--- a/languages/java/src/main/java/de/jplag/java/Parser.java
+++ b/languages/java/src/main/java/de/jplag/java/Parser.java
@@ -2,8 +2,8 @@ package de.jplag.java;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import de.jplag.AbstractParser;
 import de.jplag.Token;
@@ -19,11 +19,10 @@ public class Parser extends AbstractParser {
         super();
     }
 
-    public List<Token> parse(File directory, String[] files) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        var pathedFiles = Arrays.stream(files).map(it -> new File(directory, it)).toList();
-        errors += new JavacAdapter().parseFiles(directory, pathedFiles, this);
+        errors += new JavacAdapter().parseFiles(files, this);
         return tokens;
     }
 

--- a/languages/java/src/main/java/de/jplag/java/Parser.java
+++ b/languages/java/src/main/java/de/jplag/java/Parser.java
@@ -26,8 +26,8 @@ public class Parser extends AbstractParser {
         return tokens;
     }
 
-    public void add(TokenType type, String filename, long line, long column, long length) {
-        add(new Token(type, filename, (int) line, (int) column, (int) length));
+    public void add(TokenType type, File file, long line, long column, long length) {
+        add(new Token(type, file, (int) line, (int) column, (int) length));
     }
 
     public void add(Token token) {

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -44,6 +44,8 @@ import com.sun.source.tree.YieldTree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreeScanner;
 
+import de.jplag.ParsingException;
+
 final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
     private final File file;
     private final Parser parser;
@@ -51,12 +53,18 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
     private final SourcePositions positions;
     private final CompilationUnitTree ast;
 
+    private ParsingException parsingException;
+
     public TokenGeneratingTreeScanner(File file, Parser parser, LineMap map, SourcePositions positions, CompilationUnitTree ast) {
         this.file = file;
         this.parser = parser;
         this.map = map;
         this.positions = positions;
         this.ast = ast;
+    }
+
+    public ParsingException getParsingException() {
+        return parsingException;
     }
 
     /**
@@ -393,7 +401,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
 
     @Override
     public Object visitErroneous(ErroneousTree node, Object p) {
-        parser.increaseErrors();
+        parsingException = new ParsingException(file, "error while visiting %s".formatted(node));
         return super.visitErroneous(node, p);
     }
 

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -1,5 +1,7 @@
 package de.jplag.java;
 
+import java.io.File;
+
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssertTree;
 import com.sun.source.tree.AssignmentTree;
@@ -43,14 +45,14 @@ import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreeScanner;
 
 final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
-    private final String filename;
+    private final File file;
     private final Parser parser;
     private final LineMap map;
     private final SourcePositions positions;
     private final CompilationUnitTree ast;
 
-    public TokenGeneratingTreeScanner(String filename, Parser parser, LineMap map, SourcePositions positions, CompilationUnitTree ast) {
-        this.filename = filename;
+    public TokenGeneratingTreeScanner(File file, Parser parser, LineMap map, SourcePositions positions, CompilationUnitTree ast) {
+        this.file = file;
         this.parser = parser;
         this.map = map;
         this.positions = positions;
@@ -64,7 +66,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
      * @param length is the length of the token.
      */
     private void addToken(JavaTokenType tokenType, long position, int length) {
-        parser.add(tokenType, filename, map.getLineNumber(position), map.getColumnNumber(position), length);
+        parser.add(tokenType, file, map.getLineNumber(position), map.getColumnNumber(position), length);
     }
 
     /**
@@ -74,7 +76,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
      * @param end is the end position of the token for the calculation of the length.
      */
     private void addToken(JavaTokenType tokenType, long start, long end) {
-        parser.add(tokenType, filename, map.getLineNumber(start), map.getColumnNumber(start), (end - start));
+        parser.add(tokenType, file, map.getLineNumber(start), map.getColumnNumber(start), (end - start));
     }
 
     @Override

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -1,6 +1,8 @@
 package de.jplag.java;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssertTree;
@@ -53,7 +55,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
     private final SourcePositions positions;
     private final CompilationUnitTree ast;
 
-    private ParsingException parsingException;
+    private List<ParsingException> parsingExceptions = new ArrayList<>();
 
     public TokenGeneratingTreeScanner(File file, Parser parser, LineMap map, SourcePositions positions, CompilationUnitTree ast) {
         this.file = file;
@@ -63,8 +65,8 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
         this.ast = ast;
     }
 
-    public ParsingException getParsingException() {
-        return parsingException;
+    public List<ParsingException> getParsingExceptions() {
+        return parsingExceptions;
     }
 
     /**
@@ -401,7 +403,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
 
     @Override
     public Object visitErroneous(ErroneousTree node, Object p) {
-        parsingException = new ParsingException(file, "error while visiting %s".formatted(node));
+        parsingExceptions.add(new ParsingException(file, "error while visiting %s".formatted(node)));
         return super.visitErroneous(node, p);
     }
 

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -29,26 +30,24 @@ public class KotlinParserAdapter extends AbstractParser {
     }
 
     /**
-     * Parsers a list of files into a single list of {@link Token}s.
-     * @param directory the directory of the files.
-     * @param fileNames the file names of the files.
+     * Parsers a set of files into a single list of {@link Token}s.
+     * @param files the set of files.
      * @return a list containing all tokens of all files.
      */
-    public List<Token> parse(File directory, String[] fileNames) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
-        for (String file : fileNames) {
-            if (!parseFile(directory, file)) {
+        for (File file : files) {
+            if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file));
+            tokens.add(Token.fileEnd(file.getName()));
         }
         return tokens;
     }
 
-    private boolean parseFile(File directory, String fileName) {
-        File file = new File(directory, fileName);
+    private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = fileName;
+            currentFile = file.getName();
 
             KotlinLexer lexer = new KotlinLexer(CharStreams.fromStream(inputStream));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
@@ -63,7 +62,7 @@ public class KotlinParserAdapter extends AbstractParser {
                 treeWalker.walk(listener, parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '{}': {}{}", fileName, File.separator, exception);
+            logger.error("Parsing Error in '{}': {}{}", file.getName(), File.separator, exception);
             return false;
         }
         return true;

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
@@ -14,6 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.kotlin.grammar.KotlinLexer;
 import de.jplag.kotlin.grammar.KotlinParser;
@@ -34,18 +35,16 @@ public class KotlinParserAdapter extends AbstractParser {
      * @param files the set of files.
      * @return a list containing all tokens of all files.
      */
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
-            if (!parseFile(file)) {
-                errors++;
-            }
+            parseFile(file);
             tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
-    private boolean parseFile(File file) {
+    private void parseFile(File file) throws ParsingException {
         try (FileInputStream inputStream = new FileInputStream(file)) {
             currentFile = file;
 
@@ -63,9 +62,8 @@ public class KotlinParserAdapter extends AbstractParser {
             }
         } catch (IOException exception) {
             logger.error("Parsing Error in '{}': {}{}", file.getName(), File.separator, exception);
-            return false;
+            throw new ParsingException(file, exception.getMessage(), exception);
         }
-        return true;
     }
 
     /**

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
@@ -61,7 +61,6 @@ public class KotlinParserAdapter extends AbstractParser {
                 treeWalker.walk(listener, parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '{}': {}{}", file.getName(), File.separator, exception);
             throw new ParsingException(file, exception.getMessage(), exception);
         }
     }

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinParserAdapter.java
@@ -19,7 +19,7 @@ import de.jplag.kotlin.grammar.KotlinLexer;
 import de.jplag.kotlin.grammar.KotlinParser;
 
 public class KotlinParserAdapter extends AbstractParser {
-    private String currentFile;
+    private File currentFile;
     private List<Token> tokens;
 
     /**
@@ -40,14 +40,14 @@ public class KotlinParserAdapter extends AbstractParser {
             if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file.getName()));
+            tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
     private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = file.getName();
+            currentFile = file;
 
             KotlinLexer lexer = new KotlinLexer(CharStreams.fromStream(inputStream));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/Language.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/Language.java
@@ -2,6 +2,7 @@ package de.jplag.kotlin;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -44,8 +45,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File directory, String[] files) {
-        return parserAdapter.parse(directory, files);
+    public List<Token> parse(Set<File> files) {
+        return parserAdapter.parse(files);
     }
 
     @Override

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/Language.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 /**
@@ -45,12 +46,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return parserAdapter.parse(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return parserAdapter.hasErrors();
     }
 }

--- a/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
+++ b/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -57,7 +58,7 @@ class KotlinLanguageTest {
     @Test
     void parseTestFiles() {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(testFileLocation, new String[] {fileName});
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
+++ b/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.SharedTokenType;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
@@ -56,7 +57,7 @@ class KotlinLanguageTest {
     }
 
     @Test
-    void parseTestFiles() {
+    void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
             List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);

--- a/languages/python-3/src/main/java/de/jplag/python3/Language.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Language.java
@@ -2,6 +2,7 @@ package de.jplag.python3;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -39,8 +40,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File dir, String[] files) {
-        return this.parser.parse(dir, files);
+    public List<Token> parse(Set<File> files) {
+        return this.parser.parse(files);
     }
 
     @Override

--- a/languages/python-3/src/main/java/de/jplag/python3/Language.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 @MetaInfServices(de.jplag.Language.class)
@@ -40,12 +41,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return this.parser.parse(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return this.parser.hasErrors();
     }
 }

--- a/languages/python-3/src/main/java/de/jplag/python3/Parser.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Parser.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -32,26 +33,26 @@ public class Parser extends AbstractParser {
         super();
     }
 
-    public List<Token> parse(File directory, String[] files) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        for (String file : files) {
-            logger.trace("Parsing file {}", file);
-            if (!parseFile(directory, file)) {
+        for (File file : files) {
+            logger.trace("Parsing file {}", file.getName());
+            if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file));
+            tokens.add(Token.fileEnd(file.getName()));
         }
         return tokens;
     }
 
-    private boolean parseFile(File directory, String file) {
+    private boolean parseFile(File file) {
         BufferedInputStream inputStream;
 
         CharStream input;
         try {
-            inputStream = new BufferedInputStream(new FileInputStream(new File(directory, file)));
-            currentFile = file;
+            inputStream = new BufferedInputStream(new FileInputStream(file));
+            currentFile = file.getName();
             input = CharStreams.fromStream(inputStream);
 
             // create a lexer that feeds off of input CharStream

--- a/languages/python-3/src/main/java/de/jplag/python3/Parser.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Parser.java
@@ -70,7 +70,6 @@ public class Parser extends AbstractParser {
             }
 
         } catch (IOException e) {
-            logger.error("Parsing Error in '" + file + "': " + e.getMessage(), e);
             throw new ParsingException(file, e.getMessage(), e);
         }
     }

--- a/languages/python-3/src/main/java/de/jplag/python3/Parser.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Parser.java
@@ -15,6 +15,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenType;
 import de.jplag.python3.grammar.Python3Lexer;
@@ -33,20 +34,17 @@ public class Parser extends AbstractParser {
         super();
     }
 
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
-        errors = 0;
         for (File file : files) {
             logger.trace("Parsing file {}", file.getName());
-            if (!parseFile(file)) {
-                errors++;
-            }
+            parseFile(file);
             tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
-    private boolean parseFile(File file) {
+    private void parseFile(File file) throws ParsingException {
         BufferedInputStream inputStream;
 
         CharStream input;
@@ -73,10 +71,8 @@ public class Parser extends AbstractParser {
 
         } catch (IOException e) {
             logger.error("Parsing Error in '" + file + "': " + e.getMessage(), e);
-            return false;
+            throw new ParsingException(file, e.getMessage(), e);
         }
-
-        return true;
     }
 
     public void add(TokenType type, org.antlr.v4.runtime.Token token) {

--- a/languages/python-3/src/main/java/de/jplag/python3/Parser.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Parser.java
@@ -24,7 +24,7 @@ import de.jplag.python3.grammar.Python3Parser.File_inputContext;
 public class Parser extends AbstractParser {
 
     private List<Token> tokens;
-    private String currentFile;
+    private File currentFile;
 
     /**
      * Creates the parser.
@@ -41,7 +41,7 @@ public class Parser extends AbstractParser {
             if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file.getName()));
+            tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
@@ -52,7 +52,7 @@ public class Parser extends AbstractParser {
         CharStream input;
         try {
             inputStream = new BufferedInputStream(new FileInputStream(file));
-            currentFile = file.getName();
+            currentFile = file;
             input = CharStreams.fromStream(inputStream);
 
             // create a lexer that feeds off of input CharStream
@@ -80,11 +80,10 @@ public class Parser extends AbstractParser {
     }
 
     public void add(TokenType type, org.antlr.v4.runtime.Token token) {
-        tokens.add(new Token(type, (currentFile == null ? "null" : currentFile), token.getLine(), token.getCharPositionInLine() + 1,
-                token.getText().length()));
+        tokens.add(new Token(type, currentFile, token.getLine(), token.getCharPositionInLine() + 1, token.getText().length()));
     }
 
     public void addEnd(TokenType type, org.antlr.v4.runtime.Token token) {
-        tokens.add(new Token(type, (currentFile == null ? "null" : currentFile), token.getLine(), tokens.get(tokens.size() - 1).getColumn() + 1, 0));
+        tokens.add(new Token(type, currentFile, token.getLine(), tokens.get(tokens.size() - 1).getColumn() + 1, 0));
     }
 }

--- a/languages/python-3/src/main/java/de/jplag/python3/Parser.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Parser.java
@@ -1,6 +1,5 @@
 package de.jplag.python3;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -8,7 +7,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -45,16 +43,11 @@ public class Parser extends AbstractParser {
     }
 
     private void parseFile(File file) throws ParsingException {
-        BufferedInputStream inputStream;
-
-        CharStream input;
-        try {
-            inputStream = new BufferedInputStream(new FileInputStream(file));
+        try (FileInputStream fileInputStream = new FileInputStream((file))) {
             currentFile = file;
-            input = CharStreams.fromStream(inputStream);
 
             // create a lexer that feeds off of input CharStream
-            Python3Lexer lexer = new Python3Lexer(input);
+            Python3Lexer lexer = new Python3Lexer(CharStreams.fromStream(fileInputStream));
 
             // create a buffer of tokens pulled from the lexer
             CommonTokenStream tokens = new CommonTokenStream(lexer);

--- a/languages/rlang/src/main/java/de/jplag/rlang/Language.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 /**
@@ -45,12 +46,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return parserAdapter.parse(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return parserAdapter.hasErrors();
     }
 }

--- a/languages/rlang/src/main/java/de/jplag/rlang/Language.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/Language.java
@@ -2,6 +2,7 @@ package de.jplag.rlang;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -44,8 +45,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File directory, String[] files) {
-        return parserAdapter.parse(directory, files);
+    public List<Token> parse(Set<File> files) {
+        return parserAdapter.parse(files);
     }
 
     @Override

--- a/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -36,27 +37,25 @@ public class RParserAdapter extends AbstractParser {
     }
 
     /**
-     * Parsers a list of files into a single token list of {@link Token}s.
-     * @param directory the directory of the files.
-     * @param fileNames the file names of the files.
+     * Parsers a set of files into a single token list of {@link Token}s.
+     * @param files the set of files.
      * @return a list containing all tokens of all files.
      */
-    public List<Token> parse(File directory, String[] fileNames) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        for (String fileName : fileNames) {
-            if (!parseFile(directory, fileName)) {
+        for (File file : files) {
+            if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(fileName));
+            tokens.add(Token.fileEnd(file.getName()));
         }
         return tokens;
     }
 
-    private boolean parseFile(File directory, String fileName) {
-        File file = new File(directory, fileName);
+    private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = fileName;
+            currentFile = file.getName();
 
             // create a lexer, a parser and a buffer between them.
             RLexer lexer = new RLexer(CharStreams.fromStream(inputStream));
@@ -78,7 +77,7 @@ public class RParserAdapter extends AbstractParser {
                 treeWalker.walk(new JPlagRListener(this), parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '" + fileName + "': " + File.separator + exception.getMessage(), exception);
+            logger.error("Parsing Error in '" + file.getName() + "': " + File.separator + exception.getMessage(), exception);
             return false;
         }
         return true;

--- a/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
@@ -26,7 +26,7 @@ import de.jplag.rlang.grammar.RParser;
  */
 public class RParserAdapter extends AbstractParser {
 
-    private String currentFile;
+    private File currentFile;
     private List<Token> tokens;
 
     /**
@@ -48,14 +48,14 @@ public class RParserAdapter extends AbstractParser {
             if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file.getName()));
+            tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
     private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = file.getName();
+            currentFile = file;
 
             // create a lexer, a parser and a buffer between them.
             RLexer lexer = new RLexer(CharStreams.fromStream(inputStream));

--- a/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
@@ -75,7 +75,6 @@ public class RParserAdapter extends AbstractParser {
                 treeWalker.walk(new JPlagRListener(this), parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '" + file.getName() + "': " + File.separator + exception.getMessage(), exception);
             throw new ParsingException(file, exception.getMessage(), exception);
         }
     }

--- a/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
@@ -14,6 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenType;
 import de.jplag.rlang.grammar.RFilter;
@@ -41,19 +42,16 @@ public class RParserAdapter extends AbstractParser {
      * @param files the set of files.
      * @return a list containing all tokens of all files.
      */
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
-        errors = 0;
         for (File file : files) {
-            if (!parseFile(file)) {
-                errors++;
-            }
+            parseFile(file);
             tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
-    private boolean parseFile(File file) {
+    private void parseFile(File file) throws ParsingException {
         try (FileInputStream inputStream = new FileInputStream(file)) {
             currentFile = file;
 
@@ -78,9 +76,8 @@ public class RParserAdapter extends AbstractParser {
             }
         } catch (IOException exception) {
             logger.error("Parsing Error in '" + file.getName() + "': " + File.separator + exception.getMessage(), exception);
-            return false;
+            throw new ParsingException(file, exception.getMessage(), exception);
         }
-        return true;
     }
 
     /**

--- a/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
+++ b/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.SharedTokenType;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
@@ -46,7 +47,7 @@ class RLanguageTest {
     }
 
     @Test
-    void parseTestFiles() {
+    void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
             List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);

--- a/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
+++ b/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -47,7 +48,7 @@ class RLanguageTest {
     @Test
     void parseTestFiles() {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(testFileLocation, new String[] {fileName});
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/rust/src/main/java/de/jplag/rust/Language.java
+++ b/languages/rust/src/main/java/de/jplag/rust/Language.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 public class Language implements de.jplag.Language {
@@ -40,13 +41,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return parserAdapter.parse(files);
     }
-
-    @Override
-    public boolean hasErrors() {
-        return parserAdapter.hasErrors();
-    }
-
 }

--- a/languages/rust/src/main/java/de/jplag/rust/Language.java
+++ b/languages/rust/src/main/java/de/jplag/rust/Language.java
@@ -2,6 +2,7 @@ package de.jplag.rust;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import de.jplag.Token;
 
@@ -39,8 +40,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File directory, String[] files) {
-        return parserAdapter.parse(directory, files);
+    public List<Token> parse(Set<File> files) {
+        return parserAdapter.parse(files);
     }
 
     @Override

--- a/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
+++ b/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -23,27 +24,25 @@ public class RustParserAdapter extends AbstractParser {
     private List<Token> tokens;
 
     /**
-     * Parsers a list of files into a single list of {@link Token}s.
-     * @param directory the directory of the files.
-     * @param fileNames the file names of the files.
+     * Parsers a set of files into a single list of {@link Token}s.
+     * @param files the set of files.
      * @return a list containing all tokens of all files.
      */
-    public List<Token> parse(File directory, String[] fileNames) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        for (String fileName : fileNames) {
-            if (!parseFile(directory, fileName)) {
+        for (File file : files) {
+            if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(fileName));
+            tokens.add(Token.fileEnd(file.getName()));
         }
         return tokens;
     }
 
-    private boolean parseFile(File directory, String fileName) {
-        File file = new File(directory, fileName);
+    private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = fileName;
+            currentFile = file.getName();
 
             // create a lexer, a parser and a buffer between them.
             RustLexer lexer = new RustLexer(CharStreams.fromStream(inputStream));
@@ -61,7 +60,7 @@ public class RustParserAdapter extends AbstractParser {
                 treeWalker.walk(new JPlagRustListener(this), parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '" + fileName + "':" + File.separator, exception);
+            logger.error("Parsing Error in '" + file.getName() + "':" + File.separator, exception);
             return false;
         }
         return true;

--- a/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
+++ b/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
@@ -20,7 +20,7 @@ import de.jplag.rust.grammar.RustParser;
 
 public class RustParserAdapter extends AbstractParser {
 
-    private String currentFile;
+    private File currentFile;
     private List<Token> tokens;
 
     /**
@@ -35,14 +35,14 @@ public class RustParserAdapter extends AbstractParser {
             if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file.getName()));
+            tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
     private boolean parseFile(File file) {
         try (FileInputStream inputStream = new FileInputStream(file)) {
-            currentFile = file.getName();
+            currentFile = file;
 
             // create a lexer, a parser and a buffer between them.
             RustLexer lexer = new RustLexer(CharStreams.fromStream(inputStream));

--- a/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
+++ b/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
@@ -58,7 +58,6 @@ public class RustParserAdapter extends AbstractParser {
                 treeWalker.walk(new JPlagRustListener(this), parseTree);
             }
         } catch (IOException exception) {
-            logger.error("Parsing Error in '" + file.getName() + "':" + File.separator, exception);
             throw new ParsingException(file, exception.getMessage(), exception);
         }
     }

--- a/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
+++ b/languages/rust/src/main/java/de/jplag/rust/RustParserAdapter.java
@@ -14,6 +14,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.rust.grammar.RustLexer;
 import de.jplag.rust.grammar.RustParser;
@@ -28,19 +29,16 @@ public class RustParserAdapter extends AbstractParser {
      * @param files the set of files.
      * @return a list containing all tokens of all files.
      */
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
-        errors = 0;
         for (File file : files) {
-            if (!parseFile(file)) {
-                errors++;
-            }
+            parseFile(file);
             tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
-    private boolean parseFile(File file) {
+    private void parseFile(File file) throws ParsingException {
         try (FileInputStream inputStream = new FileInputStream(file)) {
             currentFile = file;
 
@@ -61,9 +59,8 @@ public class RustParserAdapter extends AbstractParser {
             }
         } catch (IOException exception) {
             logger.error("Parsing Error in '" + file.getName() + "':" + File.separator, exception);
-            return false;
+            throw new ParsingException(file, exception.getMessage(), exception);
         }
-        return true;
     }
 
     /**

--- a/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
+++ b/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.SharedTokenType;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
@@ -50,7 +51,7 @@ class RustLanguageTest {
     }
 
     @Test
-    void parseTestFiles() {
+    void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
             List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);

--- a/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
+++ b/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -51,7 +52,7 @@ class RustLanguageTest {
     @Test
     void parseTestFiles() {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(testFileLocation, new String[] {fileName});
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/scala/src/main/scala/de/jplag/scala/Language.scala
+++ b/languages/scala/src/main/scala/de/jplag/scala/Language.scala
@@ -21,7 +21,4 @@ class Language extends de.jplag.Language {
   override def minimumTokenMatch = 8
 
   override def parse(files: util.Set[File]): java.util.List[Token] = this.parser.parse(files.asScala.toSet).asJava
-
-  override def hasErrors: Boolean = this.parser.hasErrors
-
 }

--- a/languages/scala/src/main/scala/de/jplag/scala/Language.scala
+++ b/languages/scala/src/main/scala/de/jplag/scala/Language.scala
@@ -5,7 +5,8 @@ import de.jplag.Token
 import java.io.File
 import org.kohsuke.MetaInfServices
 
-import scala.jdk.CollectionConverters.SeqHasAsJava
+import java.util
+import scala.jdk.CollectionConverters.{SeqHasAsJava, SetHasAsScala}
 
 class Language extends de.jplag.Language {
   private val parser = new Parser
@@ -19,7 +20,7 @@ class Language extends de.jplag.Language {
 
   override def minimumTokenMatch = 8
 
-  override def parse(dir: File, files: Array[String]): java.util.List[Token] = this.parser.parse(dir, files).asJava
+  override def parse(files: util.Set[File]): java.util.List[Token] = this.parser.parse(files.asScala.toSet).asJava
 
   override def hasErrors: Boolean = this.parser.hasErrors
 

--- a/languages/scala/src/main/scala/de/jplag/scala/Parser.scala
+++ b/languages/scala/src/main/scala/de/jplag/scala/Parser.scala
@@ -330,13 +330,12 @@ class Parser extends AbstractParser {
         }
     }
 
-    def parse(directory: File, files: Array[String]): List[Token] = {
+    def parse(files: Set[File]): List[Token] = {
         tokens = ListBuffer()
         errors = 0
 
         for (file <- files) {
-            currentFile = file
-            if (!parseFile(directory, file)) {
+            if (!parseFile(file)) {
                 errors += 1
             }
             System.gc()
@@ -345,11 +344,10 @@ class Parser extends AbstractParser {
         tokens.toList
     }
 
-    private def parseFile(directory: File, fileName: String): Boolean = {
-        currentFile = fileName
+    private def parseFile(file: File): Boolean = {
+        currentFile = file.getName
 
         try {
-            val file = new File(directory, fileName)
             val bytes = java.nio.file.Files.readAllBytes(file.toPath)
             val text = new String(bytes, "UTF-8")
             val input = Input.VirtualFile(file.getPath, text)

--- a/languages/scala/src/main/scala/de/jplag/scala/Parser.scala
+++ b/languages/scala/src/main/scala/de/jplag/scala/Parser.scala
@@ -1,11 +1,10 @@
 package de.jplag.scala
 
 import de.jplag.scala.ScalaTokenType._
-import de.jplag.{AbstractParser, Token}
+import de.jplag.{AbstractParser, ParsingException, Token}
 
 import java.io.File
-
-import scala.collection.mutable.ListBuffer 
+import scala.collection.mutable.ListBuffer
 import scala.meta._
 
 
@@ -332,19 +331,15 @@ class Parser extends AbstractParser {
 
     def parse(files: Set[File]): List[Token] = {
         tokens = ListBuffer()
-        errors = 0
-
         for (file <- files) {
-            if (!parseFile(file)) {
-                errors += 1
-            }
+            parseFile(file)
             System.gc()
         }
 
         tokens.toList
     }
 
-    private def parseFile(file: File): Boolean = {
+    private def parseFile(file: File) = {
         currentFile = file
 
         try {
@@ -358,10 +353,8 @@ class Parser extends AbstractParser {
         } catch {
             case exception: Throwable =>
                 exception.printStackTrace()
-                return false
+                throw new ParsingException(file, exception.getMessage, exception)
         }
-
-        true
     }
 
     /**

--- a/languages/scala/src/main/scala/de/jplag/scala/Parser.scala
+++ b/languages/scala/src/main/scala/de/jplag/scala/Parser.scala
@@ -10,7 +10,7 @@ import scala.meta._
 
 
 class Parser extends AbstractParser {
-    private var currentFile: String = _
+    private var currentFile: File = _
 
     private var tokens: ListBuffer[Token] = _
 
@@ -345,7 +345,7 @@ class Parser extends AbstractParser {
     }
 
     private def parseFile(file: File): Boolean = {
-        currentFile = file.getName
+        currentFile = file
 
         try {
             val bytes = java.nio.file.Files.readAllBytes(file.toPath)

--- a/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
+++ b/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -58,7 +59,7 @@ class ScalaLanguageTest {
     @Test
     void parseTestFiles() {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(testFileLocation, new String[] {fileName});
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/scheme/src/main/java/de/jplag/scheme/Language.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Language.java
@@ -2,6 +2,7 @@ package de.jplag.scheme;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -38,8 +39,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File dir, String[] files) {
-        return this.parser.parse(dir, files);
+    public List<Token> parse(Set<File> files) {
+        return this.parser.parse(files);
     }
 
     @Override

--- a/languages/scheme/src/main/java/de/jplag/scheme/Language.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 @MetaInfServices(de.jplag.Language.class)
@@ -39,12 +40,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return this.parser.parse(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return this.parser.hasErrors();
     }
 }

--- a/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
@@ -10,7 +10,7 @@ import de.jplag.Token;
 import de.jplag.TokenType;
 
 public class Parser extends AbstractParser {
-    private String currentFile;
+    private File currentFile;
 
     private List<Token> tokens;
 
@@ -25,7 +25,7 @@ public class Parser extends AbstractParser {
         tokens = new ArrayList<>();
         errors = 0;
         for (File file : files) {
-            currentFile = file.getName();
+            currentFile = file;
             logger.trace("Parsing file {}", file.getName());
             if (!SchemeParser.parseFile(file, null, this)) {
                 errors++;

--- a/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
@@ -3,6 +3,7 @@ package de.jplag.scheme;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import de.jplag.AbstractParser;
 import de.jplag.Token;
@@ -20,13 +21,13 @@ public class Parser extends AbstractParser {
         super();
     }
 
-    public List<Token> parse(File directory, String[] files) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        for (String file : files) {
-            currentFile = file;
-            logger.trace("Parsing file {}", file);
-            if (!SchemeParser.parseFile(directory, file, null, this)) {
+        for (File file : files) {
+            currentFile = file.getName();
+            logger.trace("Parsing file {}", file.getName());
+            if (!SchemeParser.parseFile(file, null, this)) {
                 errors++;
             }
             tokens.add(Token.fileEnd(currentFile));

--- a/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import de.jplag.AbstractParser;
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenType;
 
@@ -21,15 +22,12 @@ public class Parser extends AbstractParser {
         super();
     }
 
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         tokens = new ArrayList<>();
-        errors = 0;
         for (File file : files) {
             currentFile = file;
             logger.trace("Parsing file {}", file.getName());
-            if (!SchemeParser.parseFile(file, null, this)) {
-                errors++;
-            }
+            SchemeParser.parseFile(file, null, this);
             tokens.add(Token.fileEnd(currentFile));
         }
         return tokens;

--- a/languages/scheme/src/main/javacc/Scheme.jj
+++ b/languages/scheme/src/main/javacc/Scheme.jj
@@ -58,12 +58,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 
+import de.jplag.ParsingException;
+
 public class SchemeParser {
     /* used for context in the template production rule */
     private static int templateParam;
     private Parser parser2;
 
-    public static boolean parseFile(File file, SchemeParser parser, Parser parserX) {
+    public static void parseFile(File file, SchemeParser parser, Parser parserX) throws ParsingException {
         try {
             FileInputStream in = new FileInputStream(file);
             if (parser == null) {
@@ -74,18 +76,17 @@ public class SchemeParser {
             parser.parser2 = parserX;
         } catch (FileNotFoundException e) {
             System.out.println("Scheme Parser R4RS:  File " + file.getName() + " not found.");
-            return false;
+            throw new ParsingException(file, e.getMessage(), e);
         }
         try {
             parser.Program();
         } catch (ParseException e) {
             parserX.logger.error("Parsing Error in '" + file.getName() + "': " + e.getMessage());
-            return false;
+            throw new ParsingException(file, e.getMessage(), e);
         } catch (TokenMgrException e) {
             parserX.logger.error("Scanning Error in '" + file.getName() + "': " + e.getMessage());
-            return false;
+            throw new ParsingException(file, e.getMessage(), e);
         }
-        return true;
     }
 }
 PARSER_END(SchemeParser)

--- a/languages/scheme/src/main/javacc/Scheme.jj
+++ b/languages/scheme/src/main/javacc/Scheme.jj
@@ -63,10 +63,9 @@ public class SchemeParser {
     private static int templateParam;
     private Parser parser2;
 
-    public static boolean parseFile(File dir, String fileName, SchemeParser parser, Parser parserX) {
-        File file = null;
+    public static boolean parseFile(File file, SchemeParser parser, Parser parserX) {
         try {
-            FileInputStream in = new FileInputStream(file = new File(dir, fileName));
+            FileInputStream in = new FileInputStream(file);
             if (parser == null) {
                 parser = new SchemeParser(in, "UTF-8");
             } else {
@@ -74,16 +73,16 @@ public class SchemeParser {
             }
             parser.parser2 = parserX;
         } catch (FileNotFoundException e) {
-            System.out.println("Scheme Parser R4RS:  File " + fileName + " not found.");
+            System.out.println("Scheme Parser R4RS:  File " + file.getName() + " not found.");
             return false;
         }
         try {
             parser.Program();
         } catch (ParseException e) {
-            parserX.logger.error("Parsing Error in '" + fileName + "': " + e.getMessage());
+            parserX.logger.error("Parsing Error in '" + file.getName() + "': " + e.getMessage());
             return false;
         } catch (TokenMgrException e) {
-            parserX.logger.error("Scanning Error in '" + fileName + "': " + e.getMessage());
+            parserX.logger.error("Scanning Error in '" + file.getName() + "': " + e.getMessage());
             return false;
         }
         return true;

--- a/languages/text/src/main/java/de/jplag/text/Language.java
+++ b/languages/text/src/main/java/de/jplag/text/Language.java
@@ -2,6 +2,7 @@ package de.jplag.text;
 
 import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
@@ -43,8 +44,8 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(File dir, String[] files) {
-        return parserAdapter.parse(dir, files);
+    public List<Token> parse(Set<File> files) {
+        return parserAdapter.parse(files);
     }
 
     @Override

--- a/languages/text/src/main/java/de/jplag/text/Language.java
+++ b/languages/text/src/main/java/de/jplag/text/Language.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 
 /**
@@ -44,12 +45,7 @@ public class Language implements de.jplag.Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files) {
+    public List<Token> parse(Set<File> files) throws ParsingException {
         return parserAdapter.parse(files);
-    }
-
-    @Override
-    public boolean hasErrors() {
-        return parserAdapter.hasErrors();
     }
 }

--- a/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
+++ b/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
@@ -102,7 +102,6 @@ public class ParserAdapter extends AbstractParser {
         try {
             return Files.readString(file.toPath());
         } catch (IOException e) {
-            logger.error("Error reading from file {}", file.getName(), e);
             throw new ParsingException(file, e.getMessage(), e);
         }
     }

--- a/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
+++ b/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
@@ -24,7 +24,7 @@ public class ParserAdapter extends AbstractParser {
     private final StanfordCoreNLP pipeline;
 
     private List<Token> tokens;
-    private String currentFile;
+    private File currentFile;
     private int currentLine;
     /**
      * The position of the current line break in the content string
@@ -45,13 +45,13 @@ public class ParserAdapter extends AbstractParser {
             if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file.getName()));
+            tokens.add(Token.fileEnd(file));
         }
         return tokens;
     }
 
     private boolean parseFile(File file) {
-        this.currentFile = file.getName();
+        this.currentFile = file;
         this.currentLine = 1; // lines start at 1
         this.currentLineBreakIndex = 0;
         String content = readFile(file);

--- a/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
+++ b/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
@@ -3,10 +3,10 @@ package de.jplag.text;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import de.jplag.AbstractParser;
 import de.jplag.Token;
@@ -37,25 +37,24 @@ public class ParserAdapter extends AbstractParser {
         this.pipeline = new StanfordCoreNLP(properties);
     }
 
-    public List<Token> parse(File directory, String[] files) {
+    public List<Token> parse(Set<File> files) {
         tokens = new ArrayList<>();
         errors = 0;
-        for (String file : files) {
+        for (File file : files) {
             logger.trace("Parsing file {}", file);
-            if (!parseFile(directory, file)) {
+            if (!parseFile(file)) {
                 errors++;
             }
-            tokens.add(Token.fileEnd(file));
+            tokens.add(Token.fileEnd(file.getName()));
         }
         return tokens;
     }
 
-    private boolean parseFile(File directory, String file) {
-        this.currentFile = file;
+    private boolean parseFile(File file) {
+        this.currentFile = file.getName();
         this.currentLine = 1; // lines start at 1
         this.currentLineBreakIndex = 0;
-        Path filePath = directory.toPath().resolve(file);
-        String content = readFile(filePath);
+        String content = readFile(file);
         if (content == null) {
             return false;
         }
@@ -105,11 +104,11 @@ public class ParserAdapter extends AbstractParser {
         tokens.add(new Token(new TextTokenType(text), currentFile, currentLine, column, length));
     }
 
-    private String readFile(Path filePath) {
+    private String readFile(File file) {
         try {
-            return Files.readString(filePath);
+            return Files.readString(file.toPath());
         } catch (IOException e) {
-            logger.error("Error reading from file {}", filePath, e);
+            logger.error("Error reading from file {}", file.getName(), e);
             return null;
         }
     }

--- a/languages/text/src/test/java/jplag/text/TextLanguageTest.java
+++ b/languages/text/src/test/java/jplag/text/TextLanguageTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
 import de.jplag.TokenType;
@@ -41,7 +42,7 @@ class TextLanguageTest {
     }
 
     @Test
-    void testParsingJavaDoc() {
+    void testParsingJavaDoc() throws ParsingException {
         // Parse test input
         List<Token> result = language.parse(Set.of(new File(BASE_PATH.toFile(), TEST_SUBJECT)));
         logger.info(TokenPrinter.printTokens(result, baseDirectory));
@@ -53,7 +54,7 @@ class TextLanguageTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"\n", "\r", "\r\n",})
-    void testLineBreakInputs(String input, @TempDir Path tempDir) throws IOException {
+    void testLineBreakInputs(String input, @TempDir Path tempDir) throws IOException, ParsingException {
         Path filePath = tempDir.resolve("input.txt");
         Files.writeString(filePath, input);
         List<Token> result = language.parse(Set.of(filePath.toFile()));
@@ -62,7 +63,7 @@ class TextLanguageTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"\ntoken", "\rtoken", "\r\ntoken",})
-    void testTokenAfterLineBreak(String input, @TempDir Path tempDir) throws IOException {
+    void testTokenAfterLineBreak(String input, @TempDir Path tempDir) throws IOException, ParsingException {
         Path filePath = tempDir.resolve("input.txt");
         Files.writeString(filePath, input);
         List<Token> result = language.parse(Set.of(filePath.toFile()));

--- a/languages/text/src/test/java/jplag/text/TextLanguageTest.java
+++ b/languages/text/src/test/java/jplag/text/TextLanguageTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,8 +43,7 @@ class TextLanguageTest {
     @Test
     void testParsingJavaDoc() {
         // Parse test input
-        String[] input = new String[] {TEST_SUBJECT};
-        List<Token> result = language.parse(baseDirectory, input);
+        List<Token> result = language.parse(Set.of(new File(BASE_PATH.toFile(), TEST_SUBJECT)));
         logger.info(TokenPrinter.printTokens(result, baseDirectory));
 
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();
@@ -54,18 +54,18 @@ class TextLanguageTest {
     @ParameterizedTest
     @ValueSource(strings = {"\n", "\r", "\r\n",})
     void testLineBreakInputs(String input, @TempDir Path tempDir) throws IOException {
-        Path file = tempDir.resolve("input.txt");
-        Files.writeString(file, input);
-        List<Token> result = language.parse(tempDir.toFile(), new String[] {"input.txt"});
+        Path filePath = tempDir.resolve("input.txt");
+        Files.writeString(filePath, input);
+        List<Token> result = language.parse(Set.of(filePath.toFile()));
         assertEquals(1, result.size());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"\ntoken", "\rtoken", "\r\ntoken",})
     void testTokenAfterLineBreak(String input, @TempDir Path tempDir) throws IOException {
-        Path file = tempDir.resolve("input.txt");
-        Files.writeString(file, input);
-        List<Token> result = language.parse(tempDir.toFile(), new String[] {"input.txt"});
+        Path filePath = tempDir.resolve("input.txt");
+        Files.writeString(filePath, input);
+        List<Token> result = language.parse(Set.of(filePath.toFile()));
         assertEquals(2, result.get(0).getLine());
     }
 


### PR DESCRIPTION
- Replaces `parseFiles(File directory, String[] fileNames)` with `parseFiles(Set<File> files) throws ParsingException`
  - the exception replaces the `hasErrors` field (and solves #454, bullet point 8)
- Refactors `Token::file` to type `File` instead of `String` to avoid file-path magic in the language frontends
  - to preserve consistency with the previous state, in the `ComparisonReportWriter` the files are relativized to the submission root directory 