### PR TITLE
Suppress the StanfordNLP logger

### DIFF
--- a/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
+++ b/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
@@ -15,6 +15,7 @@ import de.jplag.Token;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.pipeline.CoreDocument;
 import edu.stanford.nlp.pipeline.StanfordCoreNLP;
+import edu.stanford.nlp.util.logging.RedwoodConfiguration;
 
 public class ParserAdapter extends AbstractParser {
 
@@ -33,6 +34,7 @@ public class ParserAdapter extends AbstractParser {
     private int currentLineBreakIndex;
 
     public ParserAdapter() {
+        RedwoodConfiguration.errorLevel().apply();
         Properties properties = new Properties();
         properties.put(ANNOTATORS_KEY, ANNOTATORS_VALUE);
         this.pipeline = new StanfordCoreNLP(properties);


### PR DESCRIPTION
Hotfix that suppresses the StanfordNLP logger directly, with the exception of errors.