### PR TITLE
Prepare for new branch management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -11,6 +12,7 @@ updates:
       prefix: "Dependency"
       include: "scope"
   - package-ecosystem: "maven"
+    target-branch: "develop"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -24,6 +26,7 @@ updates:
       - "dependencies"
       - "minor"
   - package-ecosystem: "npm"
+    target-branch: "develop"
     directory: "/report-viewer"
     schedule:
       interval: "weekly"

--- a/.github/workflows/report-viewer.yml
+++ b/.github/workflows/report-viewer.yml
@@ -4,7 +4,7 @@ on:
  workflow_dispatch: # Use this to dispatch from the Actions Tab
  push:
     branches:
-      - master
+      - main
       
 jobs:
   build-and-deploy:

--- a/.github/workflows/sonarcloud-branch.yml
+++ b/.github/workflows/sonarcloud-branch.yml
@@ -1,9 +1,10 @@
-name: SonarCloud Scan (master branch)
+name: SonarCloud Scan (main and develop branch)
 
 on:
   push:
     branches:
-      - master
+      - main
+      - develop
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI Build](https://github.com/jplag/jplag/actions/workflows/maven.yml/badge.svg)](https://github.com/jplag/jplag/actions/workflows/maven.yml)
 [![Latest Release](https://img.shields.io/github/release/jplag/jplag.svg)](https://github.com/jplag/jplag/releases/latest)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/de.jplag/jplag/badge.svg)](https://maven-badges.herokuapp.com/maven-central/de.jplag/jplag)
-[![License](https://img.shields.io/github/license/jplag/jplag.svg)](https://github.com/jplag/jplag/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/jplag/jplag.svg)](https://github.com/jplag/jplag/blob/main/LICENSE)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/jplag/JPlag)](https://github.com/jplag/JPlag/pulse)
 
 JPlag is a system that finds similarities among multiple sets of source code files. This way it can detect software plagiarism and collusion in software development. JPlag currently supports various programming languages, EMF metamodels, and natural language text.

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <scm>
         <connection>scm:git:git://github.com/jplag/JPlag.git</connection>
         <developerConnection>scm:git:ssh://github.com:jplag/JPlag.git</developerConnection>
-        <url>https://github.com/jplag/JPlag/tree/master</url>
+        <url>https://github.com/jplag/JPlag</url>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Prepares the repository for the new branch management.
This includes using the new `develop` branch as the default branch to which all changes are committed and the `main` branch to replace the `master` branch which always points to the latest release.

⚠️ We need to discuss how to deal with the report viewer. In particular, if the GH pages shall point to the viewer state of `main`, of `develop`, or if we want to support hosting two pages for both branches. ⚠️ 

⚠️ After merging this PR, the default branch has to be changed to `develop`. ⚠️ 
⚠️ After merging this PR, `master` has to be renamed to `main`. ⚠️ 


Closes #635 