### PR TITLE
Removed C/C++ "scope" token

### DIFF
--- a/languages/cpp/src/main/java/de/jplag/cpp/CPPTokenType.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/CPPTokenType.java
@@ -5,7 +5,6 @@ import de.jplag.TokenType;
 public enum CPPTokenType implements TokenType {
     C_BLOCK_BEGIN("BLOCK{"),
     C_BLOCK_END("}BLOCK"),
-    C_SCOPE("SCOPE"),
     C_QUESTIONMARK("COND"),
     C_ELLIPSIS("..."),
     C_ASSIGN("ASSIGN"),

--- a/languages/cpp/src/main/javacc/CPP.jj
+++ b/languages/cpp/src/main/javacc/CPP.jj
@@ -282,7 +282,7 @@ void token(): {}
 | "]"
 | "("
 | ")"
-| "::"           { delegatingScanner.add(C_SCOPE,token); }
+| "::"
 | ":"
 | ";"
 | ","


### PR DESCRIPTION
Currently, the C/C++ language module uses scope tokens (`::` ).
This allows simple obfuscation attacks by adding (or, if possible, removing) explicit namespaces (e.g. `cout` to `std::cout`).

Thus, this PR removes this token from the C/C++ tokenization.