### PR TITLE
Experimental source analysis

### DIFF
--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
@@ -20,7 +20,7 @@ public class GCCSourceAnalysis implements SourceAnalysis {
 
     private final Logger logger;
 
-    public GCCSourceAnalysis(Logger logger) {
+    public GCCSourceAnalysis() {
         this.logger = LoggerFactory.getLogger(this.getClass());
     }
 

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
@@ -15,9 +15,10 @@ public class GCCSourceAnalysis implements SourceAnalysis {
     public static final String COMPILE_COMMAND = "gcc -Wall -fsyntax-only %s";
     private Map<String, List<Integer>> linesToDelete = new HashMap<>();
 
-    public boolean isTokenIgnored(de.jplag.cpp.Token token, String file) {
-        if (linesToDelete.containsKey(file)) {
-            var ignoredLineNumbers = linesToDelete.get(file);
+    public boolean isTokenIgnored(de.jplag.cpp.Token token, File file) {
+        String fileName = file.getName();
+        if (linesToDelete.containsKey(fileName)) {
+            var ignoredLineNumbers = linesToDelete.get(fileName);
             return ignoredLineNumbers.contains(token.beginLine);
         }
         return false;

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
@@ -7,13 +7,13 @@ import java.io.InputStreamReader;
 import java.util.*;
 
 /**
- * Uses GCC to find unused variables and saves their location. The scanner can then check if a token belongs to an unused variable
+ * Uses GCC to find unused variables and saves their location. The scanner can then check if a token belongs to an
+ * unused variable
  */
 public class GCCSourceAnalysis implements SourceAnalysis {
 
     public static final String COMPILE_COMMAND = "gcc -Wall -fsyntax-only %s";
     private Map<String, List<Integer>> linesToDelete = new HashMap<>();
-
 
     public boolean isTokenIgnored(de.jplag.cpp.Token token, String file) {
         if (linesToDelete.containsKey(file)) {
@@ -23,10 +23,8 @@ public class GCCSourceAnalysis implements SourceAnalysis {
         return false;
     }
 
-
     public void findUnusedVariableLines(Set<File> files) {
         linesToDelete = new HashMap<>();
-
 
         for (File file : files) {
             try {

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
@@ -1,0 +1,70 @@
+package de.jplag.cpp.experimental;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+/**
+ * Uses GCC to find unused variables and saves their location. The scanner can then check if a token belongs to an unused variable
+ */
+public class GCCSourceAnalysis implements SourceAnalysis {
+
+    public static final String COMPILE_COMMAND = "gcc -Wall -fsyntax-only %s";
+    private Map<String, List<Integer>> linesToDelete = new HashMap<>();
+
+
+    public boolean isTokenIgnored(de.jplag.cpp.Token token, String file) {
+        if (linesToDelete.containsKey(file)) {
+            var ignoredLineNumbers = linesToDelete.get(file);
+            return ignoredLineNumbers.contains(token.beginLine);
+        }
+        return false;
+    }
+
+
+    public void findUnusedVariableLines(Set<File> files) {
+        linesToDelete = new HashMap<>();
+
+
+        for (File file : files) {
+            try {
+                Runtime runtime = Runtime.getRuntime();
+                Process gcc = runtime.exec(COMPILE_COMMAND.formatted(file.getAbsolutePath()));
+                gcc.waitFor();
+
+                // gcc prints compiler warnings to the error stream, not the standard stream
+                BufferedReader stdError = new BufferedReader(new InputStreamReader(gcc.getErrorStream()));
+
+                String line;
+                while ((line = stdError.readLine()) != null) {
+                    processOutputLine(line);
+                }
+            } catch (IOException | InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private void processOutputLine(String line) {
+        // example output:
+        // sourceFile.c:151:8: warning: unused variable 't' [-Wunused-variable]
+        if (!line.contains("unused variable")) {
+            return;
+        }
+
+        // contains [sourceFile, line, column, (warning|error), description]
+        var lineSplit = line.split(":");
+
+        String fileName = new File(lineSplit[0]).getName();
+
+        int lineNumber = Integer.parseInt(lineSplit[1]);
+
+        if (linesToDelete.containsKey(fileName)) {
+            linesToDelete.get(fileName).add(lineNumber);
+        } else {
+            linesToDelete.put(fileName, new ArrayList<>(lineNumber));
+        }
+    }
+}

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
@@ -70,10 +70,6 @@ public class GCCSourceAnalysis implements SourceAnalysis {
 
         int lineNumber = Integer.parseInt(lineSplit[1]);
 
-        if (linesToDelete.containsKey(fileName)) {
-            linesToDelete.get(fileName).add(lineNumber);
-        } else {
-            linesToDelete.put(fileName, new ArrayList<>(lineNumber));
-        }
+        linesToDelete.computeIfAbsent(fileName, key -> new ArrayList<>()).add(lineNumber);
     }
 }

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Uses GCC to find unused variables and saves their location. The scanner can then check if a token belongs to an
  * unused variable
@@ -14,6 +17,12 @@ public class GCCSourceAnalysis implements SourceAnalysis {
 
     public static final String COMPILE_COMMAND = "gcc -Wall -fsyntax-only %s";
     private Map<String, List<Integer>> linesToDelete = new HashMap<>();
+
+    private final Logger logger;
+
+    public GCCSourceAnalysis(Logger logger) {
+        this.logger = LoggerFactory.getLogger(this.getClass());
+    }
 
     public boolean isTokenIgnored(de.jplag.cpp.Token token, File file) {
         String fileName = file.getName();
@@ -41,7 +50,8 @@ public class GCCSourceAnalysis implements SourceAnalysis {
                     processOutputLine(line);
                 }
             } catch (IOException | InterruptedException e) {
-                e.printStackTrace();
+                // error during compilation, skip this submission
+                logger.warn("Failed to compile file {}", file.getAbsolutePath());
             }
         }
     }

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/GCCSourceAnalysis.java
@@ -33,7 +33,7 @@ public class GCCSourceAnalysis implements SourceAnalysis {
         return false;
     }
 
-    public void findUnusedVariableLines(Set<File> files) {
+    public void findUnusedVariableLines(Set<File> files) throws InterruptedException {
         linesToDelete = new HashMap<>();
 
         for (File file : files) {
@@ -49,7 +49,7 @@ public class GCCSourceAnalysis implements SourceAnalysis {
                 while ((line = stdError.readLine()) != null) {
                     processOutputLine(line);
                 }
-            } catch (IOException | InterruptedException e) {
+            } catch (IOException e) {
                 // error during compilation, skip this submission
                 logger.warn("Failed to compile file {}", file.getAbsolutePath());
             }

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
@@ -1,0 +1,27 @@
+package de.jplag.cpp.experimental;
+
+
+import java.io.File;
+import java.util.Set;
+
+/**
+ * Strategy for analyzing source code for unused variables querying the corresponding lines
+ */
+public interface SourceAnalysis {
+
+    /**
+     * Tells the caller if a token is located in a line containing an unused variable.
+     * This usually indicates that the token belongs to a declaration of an unused variable.
+     * An edge case is multiple variable declarations in a single line, e.g. 'int a, b;' where a is used an b is unused.
+     * @param token The token that will be checked
+     * @param file The file the token was scanned in
+     * @return True, if the token should not be added to a TokenList, false if it should
+     */
+    boolean isTokenIgnored(de.jplag.cpp.Token token, String file);
+
+    /**
+     * Executes the source analysis on the files of a submission.
+     * @param files Set of the files contained in the submission
+     */
+    void findUnusedVariableLines(Set<File> files);
+}

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
@@ -22,5 +22,5 @@ public interface SourceAnalysis {
      * Executes the source analysis on the files of a submission.
      * @param files Set of the files contained in the submission
      */
-    void findUnusedVariableLines(Set<File> files);
+    void findUnusedVariableLines(Set<File> files) throws InterruptedException;
 }

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
@@ -16,7 +16,7 @@ public interface SourceAnalysis {
      * @param file The file the token was scanned in
      * @return True, if the token should not be added to a TokenList, false if it should
      */
-    boolean isTokenIgnored(de.jplag.cpp.Token token, String file);
+    boolean isTokenIgnored(de.jplag.cpp.Token token, File file);
 
     /**
      * Executes the source analysis on the files of a submission.

--- a/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/experimental/SourceAnalysis.java
@@ -1,6 +1,5 @@
 package de.jplag.cpp.experimental;
 
-
 import java.io.File;
 import java.util.Set;
 
@@ -10,9 +9,9 @@ import java.util.Set;
 public interface SourceAnalysis {
 
     /**
-     * Tells the caller if a token is located in a line containing an unused variable.
-     * This usually indicates that the token belongs to a declaration of an unused variable.
-     * An edge case is multiple variable declarations in a single line, e.g. 'int a, b;' where a is used an b is unused.
+     * Tells the caller if a token is located in a line containing an unused variable. This usually indicates that the token
+     * belongs to a declaration of an unused variable. An edge case is multiple variable declarations in a single line, e.g.
+     * 'int a, b;' where a is used an b is unused.
      * @param token The token that will be checked
      * @param file The file the token was scanned in
      * @return True, if the token should not be added to a TokenList, false if it should


### PR DESCRIPTION
Inserting unused variables into source code can prevent plagiarism detection.

To counteract this, this PR contains a prototypical implementation for using GCC to find unused variables.
The lines containing unused variables are stored and the `de.jplag.cpp.Scanner` can then query if a token should be added to the token list during scanning.

This is a prototypical implementation and can not be enabled using options.
For testing purposes, this can be enabled by adding an `GCCSourceAnalysis` instance to `de.jplag.cpp.Scanner`.
The `findUnusedVariableLines` method has to be called at the beginning of the `scan` method.
The `isTokenIgnored` has to be called in the `add` method to check if the token should be skipped.

This PR is part of the implementation from my Bachelor's Thesis _"Preventing Code Insertion Attacks on Token-Based Software Plagiarism Detectors"_.