### PR TITLE
Make swift identifier public

### DIFF
--- a/languages/swift/src/main/java/de/jplag/swift/Language.java
+++ b/languages/swift/src/main/java/de/jplag/swift/Language.java
@@ -15,8 +15,9 @@ import de.jplag.Token;
 @MetaInfServices(de.jplag.Language.class)
 public class Language implements de.jplag.Language {
 
+    public static final String IDENTIFIER = "swift";
+
     private static final String NAME = "Swift Parser";
-    private static final String IDENTIFIER = "swift";
     private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
     private static final String[] FILE_EXTENSIONS = {".swift"};
     private final SwiftParserAdapter parserAdapter;


### PR DESCRIPTION
Exposes the swift language identifer, thus closing #713.