### PR TITLE
Make language identifiers private

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CommandLineArgument.java
+++ b/cli/src/main/java/de/jplag/cli/CommandLineArgument.java
@@ -37,7 +37,7 @@ public enum CommandLineArgument {
     NEW_DIRECTORY(new Builder("-new", String.class).nargs(NumberOfArgumentValues.ONE_OR_MORE_VALUES)),
     OLD_DIRECTORY(new Builder("-old", String.class).nargs(NumberOfArgumentValues.ONE_OR_MORE_VALUES)),
     LANGUAGE(
-            new Builder("-l", String.class).defaultsTo(de.jplag.java.Language.IDENTIFIER)
+            new Builder("-l", String.class).defaultsTo(new de.jplag.java.Language().getIdentifier())
                     .choices(LanguageLoader.getAllAvailableLanguageIdentifiers())),
     BASE_CODE("-bc", String.class),
 
@@ -85,7 +85,7 @@ public enum CommandLineArgument {
      * The identifier of the default {@link Language}.
      * @see Language#getIdentifier()
      */
-    public static final String DEFAULT_LANGUAGE_IDENTIFIER = de.jplag.java.Language.IDENTIFIER;
+    public static final String DEFAULT_LANGUAGE_IDENTIFIER = new de.jplag.java.Language().getIdentifier();
 
     private final String flag;
     private final NumberOfArgumentValues numberOfValues;

--- a/languages/cpp/src/main/java/de/jplag/cpp/Language.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/Language.java
@@ -11,7 +11,7 @@ import de.jplag.Token;
 
 @MetaInfServices(de.jplag.Language.class)
 public class Language implements de.jplag.Language {
-    public static final String IDENTIFIER = "cpp";
+    private static final String IDENTIFIER = "cpp";
 
     private final Scanner scanner; // cpp code is scanned not parsed
 

--- a/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/Language.java
+++ b/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/Language.java
@@ -12,7 +12,7 @@ import de.jplag.emf.dynamic.parser.DynamicEcoreParser;
 @MetaInfServices(de.jplag.Language.class)
 public class Language extends de.jplag.emf.Language {
     private static final String NAME = "EMF metamodels (dynamically created token set)";
-    public static final String IDENTIFIER = "emf-dynamic";
+    private static final String IDENTIFIER = "emf-dynamic";
 
     private static final int DEFAULT_MIN_TOKEN_MATCH = 10;
 

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/Language.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/Language.java
@@ -21,7 +21,7 @@ public class Language implements de.jplag.Language {
     public static final String FILE_ENDING = "." + EcorePackage.eNAME;
 
     private static final String NAME = "EMF metamodel";
-    public static final String IDENTIFIER = "emf";
+    private static final String IDENTIFIER = "emf";
     private static final int DEFAULT_MIN_TOKEN_MATCH = 6;
 
     protected final EcoreParser parser;

--- a/languages/golang/src/main/java/de/jplag/golang/Language.java
+++ b/languages/golang/src/main/java/de/jplag/golang/Language.java
@@ -13,7 +13,7 @@ import de.jplag.Token;
 public class Language implements de.jplag.Language {
 
     private static final String NAME = "Go Parser";
-    public static final String IDENTIFIER = "go";
+    private static final String IDENTIFIER = "go";
     private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
     private static final String[] FILE_EXTENSIONS = {".go"};
     private final GoParserAdapter parserAdapter;

--- a/languages/java/src/main/java/de/jplag/java/Language.java
+++ b/languages/java/src/main/java/de/jplag/java/Language.java
@@ -14,7 +14,7 @@ import de.jplag.Token;
  */
 @MetaInfServices(de.jplag.Language.class)
 public class Language implements de.jplag.Language {
-    public static final String IDENTIFIER = "java";
+    private static final String IDENTIFIER = "java";
 
     private final Parser parser;
 

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/Language.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/Language.java
@@ -16,7 +16,7 @@ import de.jplag.Token;
 public class Language implements de.jplag.Language {
 
     private static final String NAME = "Kotlin Parser";
-    public static final String IDENTIFIER = "kotlin";
+    private static final String IDENTIFIER = "kotlin";
     private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
     private static final String[] FILE_EXTENSIONS = {".kt"};
     private final KotlinParserAdapter parserAdapter;

--- a/languages/python-3/src/main/java/de/jplag/python3/Language.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/Language.java
@@ -12,7 +12,7 @@ import de.jplag.Token;
 @MetaInfServices(de.jplag.Language.class)
 public class Language implements de.jplag.Language {
 
-    public static final String IDENTIFIER = "python3";
+    private static final String IDENTIFIER = "python3";
 
     private final Parser parser;
 

--- a/languages/rlang/src/main/java/de/jplag/rlang/Language.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/Language.java
@@ -16,7 +16,7 @@ import de.jplag.Token;
 public class Language implements de.jplag.Language {
 
     private static final String NAME = "R Parser";
-    public static final String IDENTIFIER = "rlang";
+    private static final String IDENTIFIER = "rlang";
     private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
     private static final String[] FILE_EXTENSION = {".R", ".r"};
     private final RParserAdapter parserAdapter;

--- a/languages/rust/src/main/java/de/jplag/rust/Language.java
+++ b/languages/rust/src/main/java/de/jplag/rust/Language.java
@@ -16,9 +16,9 @@ import de.jplag.Token;
 public class Language implements de.jplag.Language {
 
     protected static final String[] FILE_EXTENSIONS = {".rs"};
-    public static final String NAME = "Rust Language Module";
-    public static final String IDENTIFIER = "rust";
-    public static final int MINIMUM_TOKEN_MATCH = 8;
+    private static final String NAME = "Rust Language Module";
+    private static final String IDENTIFIER = "rust";
+    private static final int MINIMUM_TOKEN_MATCH = 8;
 
     private final RustParserAdapter parserAdapter;
 

--- a/languages/scheme/src/main/java/de/jplag/scheme/Language.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Language.java
@@ -12,7 +12,7 @@ import de.jplag.Token;
 @MetaInfServices(de.jplag.Language.class)
 public class Language implements de.jplag.Language {
 
-    public static final String IDENTIFIER = "scheme";
+    private static final String IDENTIFIER = "scheme";
     private final de.jplag.scheme.Parser parser;
 
     public Language() {

--- a/languages/swift/src/main/java/de/jplag/swift/Language.java
+++ b/languages/swift/src/main/java/de/jplag/swift/Language.java
@@ -15,7 +15,7 @@ import de.jplag.Token;
 @MetaInfServices(de.jplag.Language.class)
 public class Language implements de.jplag.Language {
 
-    public static final String IDENTIFIER = "swift";
+    private static final String IDENTIFIER = "swift";
 
     private static final String NAME = "Swift Parser";
     private static final int DEFAULT_MIN_TOKEN_MATCH = 8;

--- a/languages/text/src/main/java/de/jplag/text/Language.java
+++ b/languages/text/src/main/java/de/jplag/text/Language.java
@@ -17,7 +17,7 @@ import de.jplag.Token;
 @MetaInfServices(de.jplag.Language.class)
 public class Language implements de.jplag.Language {
 
-    public static final String IDENTIFIER = "text";
+    private static final String IDENTIFIER = "text";
     private final ParserAdapter parserAdapter;
 
     public Language() {


### PR DESCRIPTION
Alternative solution to #713 (which was solved by #761) which makes all language identifiers private.