### PR TITLE
Add hint for creating PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+<!--
+Pull requests regarding major or minor updates need to target the `develop` branch.
+Pull requests regarding patch updates need to target the `main` branch.
+Please make sure to select the appropriate branch while creating the pull request.
+For a reference on semantic versioning, see https://semver.org.
+-->


### PR DESCRIPTION
Shows a hint message when creating a pull request to select the appropriate branch as by default PRs should go to `develop` but the default branch is `main`.
Since the message is formatted as markdown comment, it is only visible when creating / editing the PR and not when viewing it.