### PR TITLE
 fix bug: representation for name of file and match

### DIFF
--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -104,7 +104,7 @@ public class ComparisonReportWriter {
     }
 
     private String relativizedFilePath(File file, Submission submission) {
-        return submission.getRoot().toPath().relativize(file.toPath()).toString();
+        return submission.getName().concat(File.separator).concat(submission.getRoot().toPath().relativize(file.toPath()).toString());
     }
 
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -104,6 +104,9 @@ public class ComparisonReportWriter {
     }
 
     private String relativizedFilePath(File file, Submission submission) {
+        if (file.toPath().equals(submission.getRoot().toPath())) {
+            return submission.getName().concat(File.separator).concat(submission.getName());
+        }
         return submission.getName().concat(File.separator).concat(submission.getRoot().toPath().relativize(file.toPath()).toString());
     }
 

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -1,6 +1,7 @@
 package de.jplag.reporting.jsonfactory;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -105,9 +106,9 @@ public class ComparisonReportWriter {
 
     private String relativizedFilePath(File file, Submission submission) {
         if (file.toPath().equals(submission.getRoot().toPath())) {
-            return submission.getName().concat(File.separator).concat(submission.getName());
+            return Path.of(submission.getName(), submission.getName()).toString();
         }
-        return submission.getName().concat(File.separator).concat(submission.getRoot().toPath().relativize(file.toPath()).toString());
+        return Path.of(submission.getName(), submission.getRoot().toPath().relativize(file.toPath()).toString()).toString();
     }
 
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
@@ -30,7 +30,7 @@ public class DirectoryManager {
      * @param submissionRoot The file, which has the root path of submission
      * @return The created directory which has the whole structure as file
      */
-    public static File createDirectory(String path, String name, File file,File submissionRoot) throws IOException {
+    public static File createDirectory(String path, String name, File file, File submissionRoot) throws IOException {
         File directory;
         String fileName = file.getPath();
         String submissionRootPath = submissionRoot.getPath();
@@ -126,7 +126,7 @@ public class DirectoryManager {
      * @param submissionRootPath The path of the root directory
      * @return The start index of the root directory
      */
-    public static int findRootDirIndex(String name,String submissionRootPath) {
+    public static int findRootDirIndex(String name, String submissionRootPath) {
         int submissionRootPathLength = submissionRootPath.length();
         int rootDirIndex = submissionRootPathLength - name.length();
         return rootDirIndex;

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
@@ -36,11 +36,11 @@ public class DirectoryManager {
         String submissionRootPath = submissionRoot.getPath();
         int lastDirectoryIndex = findRootDirIndex(name, submissionRootPath);
         fileName = fileName.substring(lastDirectoryIndex).replaceFirst(name, "");
-        String outputRootDirectory = path.concat(File.separator).concat(name);
+        String outputRootDirectory = Path.of(path, name).toString();
         if ("".equals(fileName)) {
-            directory = new File(outputRootDirectory.concat(File.separator).concat(name));
+            directory = new File(Path.of(outputRootDirectory, name).toString());
         } else {
-            directory = new File(outputRootDirectory.concat(fileName));
+            directory = new File(outputRootDirectory + fileName);
         }
         if (!directory.exists() && !directory.mkdirs()) {
             throw new IOException("Failed to create dir.");

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
@@ -22,6 +22,30 @@ public class DirectoryManager {
     private static final Logger logger = LoggerFactory.getLogger(DirectoryManager.class);
 
     /**
+     * Creates a full path directory.
+     * @param path The path under which the new directory or file ought to be created
+     * @param name The name of the new directory. According to this name we can get sub-folder's structure after this
+     * directory.
+     * @param file The file, which has the path of sub-folders
+     * @return The created directory which has the whole structure as file
+     */
+    public static File createDirectory(String path, String name, File file) throws IOException {
+        File directory;
+        String fileName = file.getPath();
+        int lastDirectoryIndex = findLastDirectory(fileName, name);
+        fileName = fileName.substring(lastDirectoryIndex).replaceFirst(name, "");
+        if ("".equals(fileName)) {
+            directory = new File(path.concat(File.separator).concat(name).concat(File.separator).concat(name));
+        } else {
+            directory = new File(path.concat(File.separator).concat(name).concat(fileName));
+        }
+        if (!directory.exists() && !directory.mkdirs()) {
+            throw new IOException("Failed to create dir.");
+        }
+        return directory;
+    }
+
+    /**
      * Creates a directory.
      * @param path The path under which the new directory ought to be created
      * @param name The name of the new directory
@@ -91,5 +115,27 @@ public class DirectoryManager {
         logger.info("Successfully zipped report files: {}", zipName);
         logger.info("Display the results with the report viewer at https://jplag.github.io/JPlag/");
         return true;
+    }
+
+    /**
+     * Processes file path.
+     * @param filePath The path of the file that needs to be compared
+     * @param name The name of the new directory. According to this name we can get sub-folder's structure after this
+     * directory.
+     * @return The index of the new directory in filePath
+     */
+    public static int findLastDirectory(String filePath, String name) {
+        String filePathCopy = filePath;
+        int index;
+        while (true) {
+            index = filePathCopy.lastIndexOf(name);
+            if (index == -1)
+                return filePathCopy.length();
+            String tempPath = filePathCopy.substring(0, index + name.length());
+            if (Files.isDirectory(Path.of(tempPath))) {
+                return index;
+            }
+            filePathCopy = filePathCopy.substring(0, index);
+        }
     }
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
@@ -128,7 +128,6 @@ public class DirectoryManager {
      */
     public static int findRootDirIndex(String name, String submissionRootPath) {
         int submissionRootPathLength = submissionRootPath.length();
-        int rootDirIndex = submissionRootPathLength - name.length();
-        return rootDirIndex;
+        return submissionRootPathLength - name.length();
     }
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
@@ -27,17 +27,20 @@ public class DirectoryManager {
      * @param name The name of the new directory. According to this name we can get sub-folder's structure after this
      * directory.
      * @param file The file, which has the path of sub-folders
+     * @param submissionRoot The file, which has the root path of submission
      * @return The created directory which has the whole structure as file
      */
-    public static File createDirectory(String path, String name, File file) throws IOException {
+    public static File createDirectory(String path, String name, File file,File submissionRoot) throws IOException {
         File directory;
         String fileName = file.getPath();
-        int lastDirectoryIndex = findLastDirectory(fileName, name);
+        String submissionRootPath = submissionRoot.getPath();
+        int lastDirectoryIndex = findRootDirIndex(name, submissionRootPath);
         fileName = fileName.substring(lastDirectoryIndex).replaceFirst(name, "");
+        String outputRootDirectory = path.concat(File.separator).concat(name);
         if ("".equals(fileName)) {
-            directory = new File(path.concat(File.separator).concat(name).concat(File.separator).concat(name));
+            directory = new File(outputRootDirectory.concat(File.separator).concat(name));
         } else {
-            directory = new File(path.concat(File.separator).concat(name).concat(fileName));
+            directory = new File(outputRootDirectory.concat(fileName));
         }
         if (!directory.exists() && !directory.mkdirs()) {
             throw new IOException("Failed to create dir.");
@@ -118,24 +121,14 @@ public class DirectoryManager {
     }
 
     /**
-     * Processes file path.
-     * @param filePath The path of the file that needs to be compared
-     * @param name The name of the new directory. According to this name we can get sub-folder's structure after this
-     * directory.
-     * @return The index of the new directory in filePath
+     * finds the start index of root directory according to this name
+     * @param name The name of the root directory. According to this name we can find the index of this directory.
+     * @param submissionRootPath The path of the root directory
+     * @return The start index of the root directory
      */
-    public static int findLastDirectory(String filePath, String name) {
-        String filePathCopy = filePath;
-        int index;
-        while (true) {
-            index = filePathCopy.lastIndexOf(name);
-            if (index == -1)
-                return filePathCopy.length();
-            String tempPath = filePathCopy.substring(0, index + name.length());
-            if (Files.isDirectory(Path.of(tempPath))) {
-                return index;
-            }
-            filePathCopy = filePathCopy.substring(0, index);
-        }
+    public static int findRootDirIndex(String name,String submissionRootPath) {
+        int submissionRootPathLength = submissionRootPath.length();
+        int rootDirIndex = submissionRootPathLength - name.length();
+        return rootDirIndex;
     }
 }

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -98,12 +98,13 @@ public class ReportObjectFactory {
         Language language = result.getOptions().language();
         for (Submission submission : submissions) {
             File directory = createSubmissionDirectory(path, submissionsPath, submission);
+            File submissionRoot = submission.getRoot();
             if (directory == null) {
                 continue;
             }
             for (File file : submission.getFiles()) {
-                File fullPath = createSubmissionDirectory(path, submissionsPath, submission, file);
-                File fileToCopy = language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
+                File fullPath = createSubmissionDirectory(path, submissionsPath, submission, file, submissionRoot);
+                File fileToCopy = getFileToCopy(language, file);
                 try {
                     if (fullPath != null) {
                         Files.copy(fileToCopy.toPath(), fullPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
@@ -117,9 +118,9 @@ public class ReportObjectFactory {
         }
     }
 
-    private File createSubmissionDirectory(String path, File submissionsPath, Submission submission, File file) {
+    private File createSubmissionDirectory(String path, File submissionsPath, Submission submission, File file, File submissionRoot) {
         try {
-            return createDirectory(submissionsPath.getPath(), submissionToIdFunction.apply(submission), file);
+            return createDirectory(submissionsPath.getPath(), submissionToIdFunction.apply(submission), file, submissionRoot);
         } catch (IOException e) {
             logger.error("Could not create directory " + path + " for report viewer generation", e);
             return null;
@@ -142,6 +143,11 @@ public class ReportObjectFactory {
             logger.error("Could not create directory " + path + " for report viewer generation", e);
             return null;
         }
+    }
+
+    private File getFileToCopy(Language language, File file){
+        File fileToCopy = language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
+        return fileToCopy;
     }
 
     private void writeComparisons(JPlagResult result, String path) {

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -145,7 +145,7 @@ public class ReportObjectFactory {
         }
     }
 
-    private File getFileToCopy(Language language, File file){
+    private File getFileToCopy(Language language, File file) {
         File fileToCopy = language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
         return fileToCopy;
     }

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -102,13 +102,27 @@ public class ReportObjectFactory {
                 continue;
             }
             for (File file : submission.getFiles()) {
+                File fullPath = createSubmissionDirectory(path, submissionsPath, submission, file);
                 File fileToCopy = language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
                 try {
-                    Files.copy(fileToCopy.toPath(), (new File(directory, file.getName())).toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    if (fullPath != null) {
+                        Files.copy(fileToCopy.toPath(), fullPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    } else {
+                        throw new NullPointerException("Could not create file with full path");
+                    }
                 } catch (IOException e) {
                     logger.error("Could not save submission file " + fileToCopy, e);
                 }
             }
+        }
+    }
+
+    private File createSubmissionDirectory(String path, File submissionsPath, Submission submission, File file) {
+        try {
+            return createDirectory(submissionsPath.getPath(), submissionToIdFunction.apply(submission), file);
+        } catch (IOException e) {
+            logger.error("Could not create directory " + path + " for report viewer generation", e);
+            return null;
         }
     }
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -146,8 +146,7 @@ public class ReportObjectFactory {
     }
 
     private File getFileToCopy(Language language, File file) {
-        File fileToCopy = language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
-        return fileToCopy;
+        return language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
     }
 
     private void writeComparisons(JPlagResult result, String path) {

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -6,11 +6,11 @@ import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class DirectoryManagerTest {
+class DirectoryManagerTest {
     String separator = File.separator;
 
     @Test
-    public void testCreateDirectoryWithBasecode() throws IOException {
+    void testCreateDirectoryWithBasecode() throws IOException {
         String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
                 + separator + "output" + separator + "submissions";
         String name = "A";
@@ -23,7 +23,7 @@ public class DirectoryManagerTest {
     }
 
     @Test
-    public void testCreateDirectoryWithFilesAssubmissions() throws IOException {
+    void testCreateDirectoryWithFilesAssubmissions() throws IOException {
         String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
                 + separator + "output" + separator + "submissions";
         String name = "Submission1.java";
@@ -38,7 +38,7 @@ public class DirectoryManagerTest {
     }
 
     @Test
-    public void testCreateDirectoryWithOtherSeparator() throws IOException {
+    void testCreateDirectoryWithOtherSeparator() throws IOException {
         String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
                 + separator + "output" + separator + "submissions";
         String name = "Submission1.java";
@@ -53,7 +53,7 @@ public class DirectoryManagerTest {
     }
 
     @Test
-    public void testCreateDirectoryAndFilenameContainsSubfoldername() throws IOException {
+    void testCreateDirectoryAndFilenameContainsSubfoldername() throws IOException {
         String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
                 + separator + "output" + separator + "submissions";
         String name = "A";
@@ -66,7 +66,7 @@ public class DirectoryManagerTest {
     }
 
     @Test
-    public void testCreateDirectoryWithMultipleFolders() throws IOException {
+    void testCreateDirectoryWithMultipleFolders() throws IOException {
         String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
                 + separator + "output" + separator + "submissions";
         String name = "A";

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -1,61 +1,68 @@
 package de.jplag.reporting.jsonfactory;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import de.jplag.TestBase;
 
+/**
+ * Test for the directory manager that persists the results for the report viewer.
+ */
 class DirectoryManagerTest extends TestBase {
-    private static final String OUTPUT_PATH = Path.of(BASE_PATH, "output", "submissions").toString();
+    private static final Path OUTPUT_PATH = Path.of(BASE_PATH, "output", "submissions");
 
-    // info of basecode-sample(in abbreviation BC)
-    private static final String SAMPLE_NAME_BC = "basecode";
-    private static final String ROOT_DIRECTORY_BC = "A";
-    private static final String FILE_NAME_BC = "TerrainType.java";
-    private static final File FILE_BC = new File(Path.of(BASE_PATH, SAMPLE_NAME_BC, ROOT_DIRECTORY_BC, FILE_NAME_BC).toString());
-    private static final File SUBMISSION_ROOT_BC = new File(Path.of(BASE_PATH, SAMPLE_NAME_BC, ROOT_DIRECTORY_BC).toString());
+    private static final String SUBMISSION_1 = "A";
+    private static final String FILE_PATH_1 = "TerrainType.java";
+    private static final String ROOT_1 = "basecode";
 
-    // info of FilesAsSubmissions-sample(in abbreviation FAS)
-    private static final String SAMPLE_NAME_FAS = "FilesAsSubmissions";
-    private static final String ROOT_DIRECTORY_FAS = "Submission1.java";
-    private static final String FILE_NAME_FAS = "Submission1.java";
-    private static final File FILE_FAS = new File(Path.of(BASE_PATH, SAMPLE_NAME_FAS, FILE_NAME_FAS).toString());
-    private static final File SUBMISSION_ROOT_FAS = new File(Path.of(BASE_PATH, SAMPLE_NAME_FAS, ROOT_DIRECTORY_FAS).toString());
+    private static final String SUBMISSION_2 = "Submission1.java";
+    private static final String ROOT_2 = "FilesAsSubmissions";
 
-    // info of basecode-sameNameOfSubdirectoryAndRootdirectory-sample(in abbreviation BC-SOSAR)
-    private static final String SAMPLE_NAME_BC_SOSAR = "basecode-sameNameOfSubdirectoryAndRootdirectory";
-    private static final String ROOT_DIRECTORY_BC_SOSAR = "A";
-    private static final String SUB_DIRECTORY_BC_SOSAR = Path.of("B", "A").toString();
-    private static final String FILE_NAME_BC_SOSAR = "TerrainType.java";
-    private static final File FILE_BC_SOSAR = new File(
-            Path.of(BASE_PATH, SAMPLE_NAME_BC_SOSAR, ROOT_DIRECTORY_BC_SOSAR, SUB_DIRECTORY_BC_SOSAR, FILE_NAME_BC_SOSAR).toString());
-    private static final File SUBMISSION_ROOT_BC_SOSAR = new File(Path.of(BASE_PATH, SAMPLE_NAME_BC_SOSAR, ROOT_DIRECTORY_BC_SOSAR).toString());
+    private static final String SUBMISSION_3 = "A";
+    private static final Path FILE_PATH_3 = Path.of("B", "A", "TerrainType.java");
+    private static final String ROOT_3 = "basecode-sameNameOfSubdirectoryAndRootdirectory";
 
     @Test
-    void testCreateDirectoryBC() throws IOException {
-        File expectedFile = new File(Path.of(OUTPUT_PATH, ROOT_DIRECTORY_BC, FILE_NAME_BC).toString());
-        test(expectedFile, OUTPUT_PATH, ROOT_DIRECTORY_BC, FILE_BC, SUBMISSION_ROOT_BC);
+    @DisplayName("test normal submission with file in folder")
+    void testCreateDirectoryBasecode() throws IOException {
+        testDirectoryManager(ROOT_1, SUBMISSION_1, FILE_PATH_1);
     }
 
     @Test
-    void testCreateDirectoryFAS() throws IOException {
-        File expectedFile = new File(Path.of(OUTPUT_PATH, ROOT_DIRECTORY_FAS, FILE_NAME_FAS).toString());
-        test(expectedFile, OUTPUT_PATH, ROOT_DIRECTORY_FAS, FILE_FAS, SUBMISSION_ROOT_FAS);
+    @DisplayName("test single file as submission")
+    void testCreateDirectoryFileAsSubmission() throws IOException {
+        testDirectoryManager(ROOT_2, SUBMISSION_2, "");
     }
 
     @Test
-    void testCreateDirectoryBC_SOSAR() throws IOException {
-        File expectedFile = new File(Path.of(OUTPUT_PATH, ROOT_DIRECTORY_BC_SOSAR, SUB_DIRECTORY_BC_SOSAR, FILE_NAME_BC_SOSAR).toString());
-        test(expectedFile, OUTPUT_PATH, ROOT_DIRECTORY_BC_SOSAR, FILE_BC_SOSAR, SUBMISSION_ROOT_BC_SOSAR);
+    @DisplayName("test same name of subdirectory and root directory")
+    void testCreateDirectorySharedName() throws IOException {
+        testDirectoryManager(ROOT_3, SUBMISSION_3, FILE_PATH_3.toString());
     }
 
-    void test(File expectedFile, String output, String rootDirectory, File file, File submissionRoot) throws IOException {
-        File directory = DirectoryManager.createDirectory(output, rootDirectory, file, submissionRoot);
-        Assertions.assertNotNull(directory);
-        Assertions.assertEquals(expectedFile.getPath(), directory.getPath());
+    /**
+     * Test the directory manager for a given scenario.
+     * @param rootName is the name of the root folder.
+     * @param submissionName is the name of the submission.
+     * @param filePath is the path to the file relative to the submission. Empty for single file submissions.
+     */
+    private static void testDirectoryManager(String rootName, String submissionName, String filePath) {
+        File submissionPath = Path.of(BASE_PATH, rootName, submissionName).toFile();
+        File fullFilePath = new File(submissionPath, filePath);
+        File expectation = new File(OUTPUT_PATH.toFile(), Path.of(submissionName, filePath.isEmpty() ? submissionName : filePath).toString());
+        try {
+            File directory = DirectoryManager.createDirectory(OUTPUT_PATH.toString(), submissionName, fullFilePath, submissionPath);
+            Assertions.assertNotNull(directory);
+            Assertions.assertEquals(expectation.getPath(), directory.getPath());
+        } catch (IOException e) {
+            fail("Directory manager threw an exception:", e);
+        }
     }
 }

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -10,42 +10,52 @@ import org.junit.jupiter.api.Test;
 import de.jplag.TestBase;
 
 class DirectoryManagerTest extends TestBase {
-    final String rootDirA = "A";
-    final String fileNameSubmission1AsRootDir = "Submission1.java";
-    final String emptySubDir = "";
-    final String multiSubDirBA = Path.of("B", "A").toString();
-    final String fileNameTerrainType = "TerrainType.java";
-    final String fileNameSubmission1 = "Submission1.java";
-    final String path = Path.of(BASE_PATH, "output", "submissions").toString();
-    final String basecode = "basecode";
-    final String FilesAsSubmissions = "FilesAsSubmissions";
-    final String basecodeWithSameNameOfSubdirectoryAndRootdirectory = "basecode-sameNameOfSubdirectoryAndRootdirectory";
+    private static final String OUTPUT_PATH = Path.of(BASE_PATH, "output", "submissions").toString();
 
-    String[] submissionDirectory = {basecode, FilesAsSubmissions, basecodeWithSameNameOfSubdirectoryAndRootdirectory};
-    String[] names = {rootDirA, fileNameSubmission1AsRootDir, rootDirA};
-    String[] subDirs = {emptySubDir, emptySubDir, multiSubDirBA};
-    String[] fileNames = {fileNameTerrainType, fileNameSubmission1, fileNameTerrainType};
-    File[] files = {new File(Path.of(BASE_PATH, submissionDirectory[0], names[0], subDirs[0], fileNames[0]).toString()),
-            new File(Path.of(BASE_PATH, submissionDirectory[1], subDirs[1], fileNames[1]).toString()),
-            new File(Path.of(BASE_PATH, submissionDirectory[2], names[2], subDirs[2], fileNames[2]).toString())};
-    File[] submissionRoots = new File[files.length];
-    File[] expectedFiles = new File[files.length];
+    // info of basecode-sample(in abbreviation BC)
+    private static final String SAMPLE_NAME_BC = "basecode";
+    private static final String ROOT_DIRECTORY_BC = "A";
+    private static final String FILE_NAME_BC = "TerrainType.java";
+    private static final File FILE_BC = new File(Path.of(BASE_PATH, SAMPLE_NAME_BC, ROOT_DIRECTORY_BC, FILE_NAME_BC).toString());
+    private static final File SUBMISSION_ROOT_BC = new File(Path.of(BASE_PATH, SAMPLE_NAME_BC, ROOT_DIRECTORY_BC).toString());
+
+    // info of FilesAsSubmissions-sample(in abbreviation FAS)
+    private static final String SAMPLE_NAME_FAS = "FilesAsSubmissions";
+    private static final String ROOT_DIRECTORY_FAS = "Submission1.java";
+    private static final String FILE_NAME_FAS = "Submission1.java";
+    private static final File FILE_FAS = new File(Path.of(BASE_PATH, SAMPLE_NAME_FAS, FILE_NAME_FAS).toString());
+    private static final File SUBMISSION_ROOT_FAS = new File(Path.of(BASE_PATH, SAMPLE_NAME_FAS, ROOT_DIRECTORY_FAS).toString());
+
+    // info of basecode-sameNameOfSubdirectoryAndRootdirectory-sample(in abbreviation BC-SOSAR)
+    private static final String SAMPLE_NAME_BC_SOSAR = "basecode-sameNameOfSubdirectoryAndRootdirectory";
+    private static final String ROOT_DIRECTORY_BC_SOSAR = "A";
+    private static final String SUB_DIRECTORY_BC_SOSAR = Path.of("B", "A").toString();
+    private static final String FILE_NAME_BC_SOSAR = "TerrainType.java";
+    private static final File FILE_BC_SOSAR = new File(
+            Path.of(BASE_PATH, SAMPLE_NAME_BC_SOSAR, ROOT_DIRECTORY_BC_SOSAR, SUB_DIRECTORY_BC_SOSAR, FILE_NAME_BC_SOSAR).toString());
+    private static final File SUBMISSION_ROOT_BC_SOSAR = new File(Path.of(BASE_PATH, SAMPLE_NAME_BC_SOSAR, ROOT_DIRECTORY_BC_SOSAR).toString());
 
     @Test
-    void testCreateDirectoryWithTestCases() throws IOException {
-        for (int index = 0; index < files.length; index++) {
-            expectedFiles[index] = new File(Path.of(path, names[index], subDirs[index], fileNames[index]).toString());
-            submissionRoots[index] = new File(Path.of(BASE_PATH, submissionDirectory[index], names[index]).toString());
-        }
-        testCreateDirectory(names, files, expectedFiles, submissionRoots);
+    void testCreateDirectoryBC() throws IOException {
+        File expectedFile = new File(Path.of(OUTPUT_PATH, ROOT_DIRECTORY_BC, FILE_NAME_BC).toString());
+        test(expectedFile, OUTPUT_PATH, ROOT_DIRECTORY_BC, FILE_BC, SUBMISSION_ROOT_BC);
     }
 
-    void testCreateDirectory(String[] names, File[] files, File[] expectedFiles, File[] submissionRoots) throws IOException {
-        int length = files.length;
-        for (int testCaseIndex = 0; testCaseIndex < length; testCaseIndex++) {
-            File directory = DirectoryManager.createDirectory(path, names[testCaseIndex], files[testCaseIndex], submissionRoots[testCaseIndex]);
-            Assertions.assertNotNull(directory);
-            Assertions.assertEquals(expectedFiles[testCaseIndex].getPath(), directory.getPath());
-        }
+    @Test
+    void testCreateDirectoryFAS() throws IOException {
+        File expectedFile = new File(Path.of(OUTPUT_PATH, ROOT_DIRECTORY_FAS, FILE_NAME_FAS).toString());
+        test(expectedFile, OUTPUT_PATH, ROOT_DIRECTORY_FAS, FILE_FAS, SUBMISSION_ROOT_FAS);
+    }
+
+    @Test
+    void testCreateDirectoryBC_SOSAR() throws IOException {
+        File expectedFile = new File(Path.of(OUTPUT_PATH, ROOT_DIRECTORY_BC_SOSAR, SUB_DIRECTORY_BC_SOSAR, FILE_NAME_BC_SOSAR).toString());
+        test(expectedFile, OUTPUT_PATH, ROOT_DIRECTORY_BC_SOSAR, FILE_BC_SOSAR, SUBMISSION_ROOT_BC_SOSAR);
+    }
+
+    void test(File expectedFile, String output, String rootDirectory, File file, File submissionRoot) throws IOException {
+        File directory = DirectoryManager.createDirectory(output, rootDirectory, file, submissionRoot);
+        Assertions.assertNotNull(directory);
+        Assertions.assertEquals(expectedFile.getPath(), directory.getPath());
     }
 }

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -2,81 +2,40 @@ package de.jplag.reporting.jsonfactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
+import de.jplag.TestBase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class DirectoryManagerTest {
-    String separator = File.separator;
+class DirectoryManagerTest extends TestBase {
+    String path = Path.of(BASE_PATH, "output", "submissions").toString();
+    String[] submissionDirectory={"basecode","FilesAsSubmissions","basecode-sameNameOfSubdirectoryAndRootdirectory"};
+    String[] names = {"A", "Submission1.java", "A"};
+    String[] subDirs = {"", "", Path.of("B", "A").toString()};
+    String[] fileNames = {"TerrainType.java", "Submission1.java", "TerrainType.java"};
+    File[] files = {new File(Path.of(BASE_PATH, submissionDirectory[0], names[0], subDirs[0], fileNames[0]).toString()),
+            new File(Path.of(BASE_PATH, submissionDirectory[1], subDirs[1], fileNames[1]).toString()),
+            new File(Path.of(BASE_PATH, submissionDirectory[2], names[2], subDirs[2], fileNames[2]).toString())
+            };
+    File[] submissionRoots = new File[files.length];
+    File[] expectedFiles = new File[files.length];
 
     @Test
-    void testCreateDirectoryWithBasecode() throws IOException {
-        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "output" + separator + "submissions";
-        String name = "A";
-        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "basecode" + separator + "A" + separator + "TerrainType.java");
-        File directory = DirectoryManager.createDirectory(path, name, file);
-        Assertions.assertNotNull(directory);
-        Assertions.assertEquals(new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator
-                + "samples" + separator + "output" + separator + "submissions" + separator + "A" + separator + "TerrainType.java"), directory);
+    void testCreateDirectoryWithTestCases() throws IOException {
+        for (int index = 0; index < files.length; index++) {
+            expectedFiles[index] = new File(Path.of(path, names[index], subDirs[index], fileNames[index]).toString());
+            submissionRoots[index]=new File(Path.of(BASE_PATH, submissionDirectory[index], names[index]).toString());
+        }
+        testCreateDirectory(names, files, expectedFiles,submissionRoots);
     }
 
-    @Test
-    void testCreateDirectoryWithFilesAssubmissions() throws IOException {
-        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "output" + separator + "submissions";
-        String name = "Submission1.java";
-        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "FilesAssubmissions" + separator + "Submission1.java");
-        File directory = DirectoryManager.createDirectory(path, name, file);
-        Assertions.assertNotNull(directory);
-        Assertions.assertEquals(
-                new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                        + separator + "output" + separator + "submissions" + separator + "Submission1.java" + separator + "Submission1.java"),
-                directory);
-    }
-
-    @Test
-    void testCreateDirectoryWithOtherSeparator() throws IOException {
-        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "output" + separator + "submissions";
-        String name = "Submission1.java";
-        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "FilesAssubmissions" + separator + "Submission1.java");
-        File directory = DirectoryManager.createDirectory(path, name, file);
-        Assertions.assertNotNull(directory);
-        Assertions.assertEquals(
-                new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                        + separator + "output" + separator + "submissions" + separator + "Submission1.java" + separator + "Submission1.java"),
-                directory);
-    }
-
-    @Test
-    void testCreateDirectoryAndFilenameContainsSubfoldername() throws IOException {
-        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "output" + separator + "submissions";
-        String name = "A";
-        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "basecode" + separator + "A" + separator + "ABCDEA.java");
-        File directory = DirectoryManager.createDirectory(path, name, file);
-        Assertions.assertNotNull(directory);
-        Assertions.assertEquals(new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator
-                + "samples" + separator + "output" + separator + "submissions" + separator + "A" + separator + "ABCDEA.java"), directory);
-    }
-
-    @Test
-    void testCreateDirectoryWithMultipleFolders() throws IOException {
-        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "output" + separator + "submissions";
-        String name = "A";
-        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
-                + separator + "basecode" + separator + "A" + separator + "B" + separator + "A" + separator + "ABCDEA.java");
-        File directory = DirectoryManager.createDirectory(path, name, file);
-        Assertions.assertNotNull(directory);
-        Assertions.assertEquals(new File(
-                "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples" + separator
-                        + "output" + separator + "submissions" + separator + "A" + separator + "B" + separator + "A" + separator + "ABCDEA.java"),
-                directory);
+    void testCreateDirectory(String[] names, File[] files, File[] expectedFiles,File[] submissionRoots) throws IOException {
+        int length = files.length;
+        for (int testCaseIndex = 0; testCaseIndex < length; testCaseIndex++) {
+            File directory = DirectoryManager.createDirectory(path, names[testCaseIndex], files[testCaseIndex],submissionRoots[testCaseIndex]);
+            Assertions.assertNotNull(directory);
+            Assertions.assertEquals(expectedFiles[testCaseIndex].getPath(), directory.getPath());
+        }
     }
 }

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -4,20 +4,20 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
-import de.jplag.TestBase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import de.jplag.TestBase;
+
 class DirectoryManagerTest extends TestBase {
     String path = Path.of(BASE_PATH, "output", "submissions").toString();
-    String[] submissionDirectory={"basecode","FilesAsSubmissions","basecode-sameNameOfSubdirectoryAndRootdirectory"};
+    String[] submissionDirectory = {"basecode", "FilesAsSubmissions", "basecode-sameNameOfSubdirectoryAndRootdirectory"};
     String[] names = {"A", "Submission1.java", "A"};
     String[] subDirs = {"", "", Path.of("B", "A").toString()};
     String[] fileNames = {"TerrainType.java", "Submission1.java", "TerrainType.java"};
     File[] files = {new File(Path.of(BASE_PATH, submissionDirectory[0], names[0], subDirs[0], fileNames[0]).toString()),
             new File(Path.of(BASE_PATH, submissionDirectory[1], subDirs[1], fileNames[1]).toString()),
-            new File(Path.of(BASE_PATH, submissionDirectory[2], names[2], subDirs[2], fileNames[2]).toString())
-            };
+            new File(Path.of(BASE_PATH, submissionDirectory[2], names[2], subDirs[2], fileNames[2]).toString())};
     File[] submissionRoots = new File[files.length];
     File[] expectedFiles = new File[files.length];
 
@@ -25,15 +25,15 @@ class DirectoryManagerTest extends TestBase {
     void testCreateDirectoryWithTestCases() throws IOException {
         for (int index = 0; index < files.length; index++) {
             expectedFiles[index] = new File(Path.of(path, names[index], subDirs[index], fileNames[index]).toString());
-            submissionRoots[index]=new File(Path.of(BASE_PATH, submissionDirectory[index], names[index]).toString());
+            submissionRoots[index] = new File(Path.of(BASE_PATH, submissionDirectory[index], names[index]).toString());
         }
-        testCreateDirectory(names, files, expectedFiles,submissionRoots);
+        testCreateDirectory(names, files, expectedFiles, submissionRoots);
     }
 
-    void testCreateDirectory(String[] names, File[] files, File[] expectedFiles,File[] submissionRoots) throws IOException {
+    void testCreateDirectory(String[] names, File[] files, File[] expectedFiles, File[] submissionRoots) throws IOException {
         int length = files.length;
         for (int testCaseIndex = 0; testCaseIndex < length; testCaseIndex++) {
-            File directory = DirectoryManager.createDirectory(path, names[testCaseIndex], files[testCaseIndex],submissionRoots[testCaseIndex]);
+            File directory = DirectoryManager.createDirectory(path, names[testCaseIndex], files[testCaseIndex], submissionRoots[testCaseIndex]);
             Assertions.assertNotNull(directory);
             Assertions.assertEquals(expectedFiles[testCaseIndex].getPath(), directory.getPath());
         }

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -1,0 +1,66 @@
+package de.jplag.reporting.jsonfactory;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import de.jplag.reporting.jsonfactory.DirectoryManager;
+
+public class DirectoryManagerTest {
+
+    @Test
+    public void TestCreateDirectoryWithBasecode() throws IOException {
+        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+        String name = "A";
+        File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\TerrainType.java");
+        File directory = DirectoryManager.createDirectory(path, name, file);
+        Assertions.assertNotNull(directory);
+        Assertions.assertEquals(directory,
+                new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\TerrainType.java"));
+    }
+
+    @Test
+    public void TestCreateDirectoryWithFilesAsSubmissions() throws IOException {
+        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+        String name = "Submission1.java";
+        File file = new File("src\\test\\resources\\de\\jplag\\samples\\FilesAsSubmissions\\Submission1.java");
+        File directory = DirectoryManager.createDirectory(path, name, file);
+        Assertions.assertNotNull(directory);
+        Assertions.assertEquals(directory,
+                new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\Submission1.java\\Submission1.java"));
+    }
+
+    @Test
+    public void TestCreateDirectoryWithOtherSeparator() throws IOException {
+        String path = "src/test/resources/de/jplag/samples/output/submissions";
+        String name = "Submission1.java";
+        File file = new File("src/test/resources/de/jplag/samples/FilesAsSubmissions/Submission1.java");
+        File directory = DirectoryManager.createDirectory(path, name, file);
+        Assertions.assertNotNull(directory);
+        Assertions.assertEquals(directory,
+                new File("src/test/resources/de/jplag/samples/output/submissions/Submission1.java/Submission1.java"));
+    }
+
+    @Test
+    public void TestCreateDirectoryAndFilenameContainsSubfoldername() throws IOException {
+        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+        String name = "A";
+        File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\ABCDEA.java");
+        File directory = DirectoryManager.createDirectory(path, name, file);
+        Assertions.assertNotNull(directory);
+        Assertions.assertEquals(directory, new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\ABCDEA.java"));
+    }
+
+    @Test
+    public void TestCreateDirectoryWithMultipleFolders() throws IOException {
+        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+        String name = "A";
+        File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\B\\A\\ABCDEA.java");
+        File directory = DirectoryManager.createDirectory(path, name, file);
+        Assertions.assertNotNull(directory);
+        Assertions.assertEquals(directory,
+                new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\B\\A\\ABCDEA.java"));
+    }
+}

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -6,8 +6,6 @@ import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import de.jplag.reporting.jsonfactory.DirectoryManager;
-
 public class DirectoryManagerTest {
 
     @Test
@@ -17,8 +15,7 @@ public class DirectoryManagerTest {
         File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\TerrainType.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory,
-                new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\TerrainType.java"));
+        Assertions.assertEquals(directory, new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\TerrainType.java"));
     }
 
     @Test
@@ -39,8 +36,7 @@ public class DirectoryManagerTest {
         File file = new File("src/test/resources/de/jplag/samples/FilesAsSubmissions/Submission1.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory,
-                new File("src/test/resources/de/jplag/samples/output/submissions/Submission1.java/Submission1.java"));
+        Assertions.assertEquals(directory, new File("src/test/resources/de/jplag/samples/output/submissions/Submission1.java/Submission1.java"));
     }
 
     @Test
@@ -60,7 +56,6 @@ public class DirectoryManagerTest {
         File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\B\\A\\ABCDEA.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory,
-                new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\B\\A\\ABCDEA.java"));
+        Assertions.assertEquals(directory, new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\B\\A\\ABCDEA.java"));
     }
 }

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -10,11 +10,21 @@ import org.junit.jupiter.api.Test;
 import de.jplag.TestBase;
 
 class DirectoryManagerTest extends TestBase {
-    String path = Path.of(BASE_PATH, "output", "submissions").toString();
-    String[] submissionDirectory = {"basecode", "FilesAsSubmissions", "basecode-sameNameOfSubdirectoryAndRootdirectory"};
-    String[] names = {"A", "Submission1.java", "A"};
-    String[] subDirs = {"", "", Path.of("B", "A").toString()};
-    String[] fileNames = {"TerrainType.java", "Submission1.java", "TerrainType.java"};
+    final String rootDirA = "A";
+    final String fileNameSubmission1AsRootDir = "Submission1.java";
+    final String emptySubDir = "";
+    final String multiSubDirBA = Path.of("B", "A").toString();
+    final String fileNameTerrainType = "TerrainType.java";
+    final String fileNameSubmission1 = "Submission1.java";
+    final String path = Path.of(BASE_PATH, "output", "submissions").toString();
+    final String basecode = "basecode";
+    final String FilesAsSubmissions = "FilesAsSubmissions";
+    final String basecodeWithSameNameOfSubdirectoryAndRootdirectory = "basecode-sameNameOfSubdirectoryAndRootdirectory";
+
+    String[] submissionDirectory = {basecode, FilesAsSubmissions, basecodeWithSameNameOfSubdirectoryAndRootdirectory};
+    String[] names = {rootDirA, fileNameSubmission1AsRootDir, rootDirA};
+    String[] subDirs = {emptySubDir, emptySubDir, multiSubDirBA};
+    String[] fileNames = {fileNameTerrainType, fileNameSubmission1, fileNameTerrainType};
     File[] files = {new File(Path.of(BASE_PATH, submissionDirectory[0], names[0], subDirs[0], fileNames[0]).toString()),
             new File(Path.of(BASE_PATH, submissionDirectory[1], subDirs[1], fileNames[1]).toString()),
             new File(Path.of(BASE_PATH, submissionDirectory[2], names[2], subDirs[2], fileNames[2]).toString())};

--- a/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
+++ b/core/src/test/java/de/jplag/reporting/jsonfactory/DirectoryManagerTest.java
@@ -7,55 +7,76 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class DirectoryManagerTest {
+    String separator = File.separator;
 
     @Test
-    public void TestCreateDirectoryWithBasecode() throws IOException {
-        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+    public void testCreateDirectoryWithBasecode() throws IOException {
+        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "output" + separator + "submissions";
         String name = "A";
-        File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\TerrainType.java");
+        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "basecode" + separator + "A" + separator + "TerrainType.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory, new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\TerrainType.java"));
+        Assertions.assertEquals(new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator
+                + "samples" + separator + "output" + separator + "submissions" + separator + "A" + separator + "TerrainType.java"), directory);
     }
 
     @Test
-    public void TestCreateDirectoryWithFilesAsSubmissions() throws IOException {
-        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+    public void testCreateDirectoryWithFilesAssubmissions() throws IOException {
+        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "output" + separator + "submissions";
         String name = "Submission1.java";
-        File file = new File("src\\test\\resources\\de\\jplag\\samples\\FilesAsSubmissions\\Submission1.java");
+        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "FilesAssubmissions" + separator + "Submission1.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory,
-                new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\Submission1.java\\Submission1.java"));
+        Assertions.assertEquals(
+                new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                        + separator + "output" + separator + "submissions" + separator + "Submission1.java" + separator + "Submission1.java"),
+                directory);
     }
 
     @Test
-    public void TestCreateDirectoryWithOtherSeparator() throws IOException {
-        String path = "src/test/resources/de/jplag/samples/output/submissions";
+    public void testCreateDirectoryWithOtherSeparator() throws IOException {
+        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "output" + separator + "submissions";
         String name = "Submission1.java";
-        File file = new File("src/test/resources/de/jplag/samples/FilesAsSubmissions/Submission1.java");
+        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "FilesAssubmissions" + separator + "Submission1.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory, new File("src/test/resources/de/jplag/samples/output/submissions/Submission1.java/Submission1.java"));
+        Assertions.assertEquals(
+                new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                        + separator + "output" + separator + "submissions" + separator + "Submission1.java" + separator + "Submission1.java"),
+                directory);
     }
 
     @Test
-    public void TestCreateDirectoryAndFilenameContainsSubfoldername() throws IOException {
-        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+    public void testCreateDirectoryAndFilenameContainsSubfoldername() throws IOException {
+        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "output" + separator + "submissions";
         String name = "A";
-        File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\ABCDEA.java");
+        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "basecode" + separator + "A" + separator + "ABCDEA.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory, new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\ABCDEA.java"));
+        Assertions.assertEquals(new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator
+                + "samples" + separator + "output" + separator + "submissions" + separator + "A" + separator + "ABCDEA.java"), directory);
     }
 
     @Test
-    public void TestCreateDirectoryWithMultipleFolders() throws IOException {
-        String path = "src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+    public void testCreateDirectoryWithMultipleFolders() throws IOException {
+        String path = "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "output" + separator + "submissions";
         String name = "A";
-        File file = new File("src\\test\\resources\\de\\jplag\\samples\\basecode\\A\\B\\A\\ABCDEA.java");
+        File file = new File("src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples"
+                + separator + "basecode" + separator + "A" + separator + "B" + separator + "A" + separator + "ABCDEA.java");
         File directory = DirectoryManager.createDirectory(path, name, file);
         Assertions.assertNotNull(directory);
-        Assertions.assertEquals(directory, new File("src\\test\\resources\\de\\jplag\\samples\\output\\submissions\\A\\B\\A\\ABCDEA.java"));
+        Assertions.assertEquals(new File(
+                "src" + separator + "test" + separator + "resources" + separator + "de" + separator + "jplag" + separator + "samples" + separator
+                        + "output" + separator + "submissions" + separator + "A" + separator + "B" + separator + "A" + separator + "ABCDEA.java"),
+                directory);
     }
 }

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -12,10 +12,10 @@ import de.jplag.exceptions.ExitException;
 import de.jplag.reporting.reportobject.model.Version;
 
 class ReportObjectFactoryTest extends TestBase {
-    final String basecode = "basecode";
-    final String basecodeBase = "basecode-base";
-    final String output = "output";
-    final String submissions = "submissions";
+    private static final String BASECODE = "basecode";
+    private static final String BASECODE_BASE = "basecode-base";
+    private static final String OUTPUT = "output";
+    private static final String SUBMISSIONS = "submissions";
 
     @Test
     void testVersionLoading() {
@@ -25,8 +25,8 @@ class ReportObjectFactoryTest extends TestBase {
 
     @Test
     void testCreateAndSaveReportWithBasecode() throws ExitException {
-        JPlagResult result = runJPlag(basecode, it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, basecodeBase)));
-        String path = Path.of(BASE_PATH, output, submissions).toString();
+        JPlagResult result = runJPlag(BASECODE, it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, BASECODE_BASE)));
+        String path = Path.of(BASE_PATH, OUTPUT, SUBMISSIONS).toString();
         ReportObjectFactory reportObjectFactory = new ReportObjectFactory();
         reportObjectFactory.createAndSaveReport(result, path);
         Assertions.assertNotNull(result);

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -1,6 +1,7 @@
 package de.jplag.reporting.reportobject;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class ReportObjectFactoryTest extends TestBase {
     @Test
     void testCreateAndSaveReportWithBasecode() throws ExitException {
         JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, "basecode-base")));
-        String path = "JPlag\\core\\src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+        String path = Path.of(BASE_PATH, "output", "submissions").toString();
         ReportObjectFactory reportObjectFactory = new ReportObjectFactory();
         reportObjectFactory.createAndSaveReport(result, path);
         Assertions.assertNotNull(result);

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -1,14 +1,28 @@
 package de.jplag.reporting.reportobject;
 
+import java.io.File;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import de.jplag.JPlagResult;
+import de.jplag.TestBase;
+import de.jplag.exceptions.ExitException;
 import de.jplag.reporting.reportobject.model.Version;
 
-class ReportObjectFactoryTest {
+class ReportObjectFactoryTest extends TestBase {
     @Test
     void testVersionLoading() {
         Assertions.assertNotNull(ReportObjectFactory.REPORT_VIEWER_VERSION);
         Assertions.assertNotEquals(Version.DEVELOPMENT, ReportObjectFactory.REPORT_VIEWER_VERSION);
     }
+
+    @Test
+    void testCreateAndSaveReportWithBasecode() throws ExitException {
+        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, "basecode-base")));
+        String path = "JPlag\\core\\src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
+        ReportObjectFactory reportObjectFactory = new ReportObjectFactory();
+        reportObjectFactory.createAndSaveReport(result, path);
+    }
+
 }

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -23,6 +23,7 @@ class ReportObjectFactoryTest extends TestBase {
         String path = "JPlag\\core\\src\\test\\resources\\de\\jplag\\samples\\output\\submissions";
         ReportObjectFactory reportObjectFactory = new ReportObjectFactory();
         reportObjectFactory.createAndSaveReport(result, path);
+        Assertions.assertNotNull(result);
     }
 
 }

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -12,6 +12,11 @@ import de.jplag.exceptions.ExitException;
 import de.jplag.reporting.reportobject.model.Version;
 
 class ReportObjectFactoryTest extends TestBase {
+    final String basecode = "basecode";
+    final String basecodeBase = "basecode-base";
+    final String output = "output";
+    final String submissions = "submissions";
+
     @Test
     void testVersionLoading() {
         Assertions.assertNotNull(ReportObjectFactory.REPORT_VIEWER_VERSION);
@@ -20,8 +25,8 @@ class ReportObjectFactoryTest extends TestBase {
 
     @Test
     void testCreateAndSaveReportWithBasecode() throws ExitException {
-        JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, "basecode-base")));
-        String path = Path.of(BASE_PATH, "output", "submissions").toString();
+        JPlagResult result = runJPlag(basecode, it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, basecodeBase)));
+        String path = Path.of(BASE_PATH, output, submissions).toString();
         ReportObjectFactory reportObjectFactory = new ReportObjectFactory();
         reportObjectFactory.createAndSaveReport(result, path);
         Assertions.assertNotNull(result);

--- a/core/src/test/resources/de/jplag/samples/basecode-sameNameOfSubdirectoryAndRootdirectory/A/B/A/TerrainType.java
+++ b/core/src/test/resources/de/jplag/samples/basecode-sameNameOfSubdirectoryAndRootdirectory/A/B/A/TerrainType.java
@@ -1,0 +1,27 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ * @author Timur Saglam
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(0) + toString().substring(1).toLowerCase();
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/basecode-sameNameOfSubdirectoryAndRootdirectory/B/TerrainType.java
+++ b/core/src/test/resources/de/jplag/samples/basecode-sameNameOfSubdirectoryAndRootdirectory/B/TerrainType.java
@@ -1,0 +1,30 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ * @author Mean Plagiarizer
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+    private static final int CONST_0 = 0;
+    private static final int CONST_1 = 1;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(CONST_0) + toString().substring(CONST_1).toLowerCase();
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/basecode-sameNameOfSubdirectoryAndRootdirectory/base/TerrainType.java
+++ b/core/src/test/resources/de/jplag/samples/basecode-sameNameOfSubdirectoryAndRootdirectory/base/TerrainType.java
@@ -1,0 +1,12 @@
+package carcassonne.model.terrain;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+}

--- a/report-viewer/src/components/FilesContainer.vue
+++ b/report-viewer/src/components/FilesContainer.vue
@@ -7,13 +7,13 @@
     <VueDraggableNext>
       <CodePanel
         v-for="(file, index) in files.keys()"
-        :key="file.concat(index.toString())"
+        :key="file"
         :collapse="files.get(file)?.collapsed"
         :file-index="index"
         :lines="!files.get(file)?.lines ? [] : files.get(file)?.lines"
         :matches="!matches.get(file) ? [] : matches.get(file)"
         :panel-id="containerId"
-        :title="file"
+        :title="file.length>40?'..'+file.substring(file.length-40,file.length):file"
         @toggle-collapse="$emit('toggle-collapse', file)"
         @line-selected="lineSelected"
       />

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -21,12 +21,7 @@ export class ComparisonFactory {
     );
 
     const matches = json.matches as Array<Record<string, unknown>>;
-    
-    // TODO: Quick fix for issue #658, requires deeper insights to be resolved completely
-    matches.forEach((match: Record<string, unknown>) => {
-      match["file1"] = this.removePathFromFileName(match["file1"] as string ?? "");
-      match["file2"] = this.removePathFromFileName(match["file2"] as string ?? "");
-    })
+
 
     const colors = this.generateColorsForMatches(matches.length);
     const coloredMatches = matches.map((match, index) =>
@@ -108,9 +103,6 @@ export class ComparisonFactory {
     return acc;
   }
 
-  private static removePathFromFileName(filePath: string): string {
-    return  filePath.substring(filePath.lastIndexOf("\\") + 1).substring(filePath.lastIndexOf("/") + 1);
-  }
 
   private static generateColorsForMatches(num: number): Array<string> {
     const colors = [];

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -61,6 +61,12 @@ export default defineComponent({
       );
       return folders[submissionFolderIndex + 1];
     };
+    const extractFileNameWithFullPath = (filePath: path.ParsedPath) => {
+      const pathWithoutSubmissions = filePath.dir.split("submissions");
+      const subfolderPathAfterSubmissions = pathWithoutSubmissions[1].substring(1);
+      const fullPath=(subfolderPathAfterSubmissions + '/' + filePath.base).replaceAll('/','\\');
+      return fullPath;
+    };
     /**
      * Handles zip file on drop. It extracts the zip and saves each file in the store.
      * @param file
@@ -76,10 +82,11 @@ export default defineComponent({
             const filePath = path.parse(unixFileName);
 
             const submissionFileName = extractSubmissionFileName(filePath);
+            const fullPathFileName = extractFileNameWithFullPath(filePath);
             await zip.files[originalFileName].async("string").then((data) => {
               store.commit("saveSubmissionFile", {
                 name: submissionFileName,
-                file: { fileName: filePath.base, data: data },
+                file: { fileName: fullPathFileName, data: data },
               });
             });
           } else {

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -61,12 +61,18 @@ export default defineComponent({
       );
       return folders[submissionFolderIndex + 1];
     };
-    const extractFileNameWithFullPath = (filePath: path.ParsedPath) => {
-      const pathWithoutSubmissions = filePath.dir.split("submissions");
-      const subfolderPathAfterSubmissions = pathWithoutSubmissions[1].substring(1);
-      const fullPath=(subfolderPathAfterSubmissions + '/' + filePath.base).replaceAll('/','\\');
+    const extractFileNameWithFullPath = (filePath: path.ParsedPath, originalFileName: string) => {
+      let fullPath="";
+      const unixPathWithoutSubmissions = filePath.dir.split("submissions");
+      const originalPathWithoutSubmissions = originalFileName.split("submissions");
+      const unixSubfolderPathAfterSubmissions = unixPathWithoutSubmissions[1].substring(1);
+      if(originalPathWithoutSubmissions[1].charAt(0)==='\\'){
+        fullPath=(unixSubfolderPathAfterSubmissions + path.sep + filePath.base).replaceAll('/','\\');
+      }else {
+        fullPath=(unixSubfolderPathAfterSubmissions + path.sep + filePath.base);
+      }
       return fullPath;
-    };
+  };
     /**
      * Handles zip file on drop. It extracts the zip and saves each file in the store.
      * @param file
@@ -82,7 +88,7 @@ export default defineComponent({
             const filePath = path.parse(unixFileName);
 
             const submissionFileName = extractSubmissionFileName(filePath);
-            const fullPathFileName = extractFileNameWithFullPath(filePath);
+            const fullPathFileName = extractFileNameWithFullPath(filePath, originalFileName);
             await zip.files[originalFileName].async("string").then((data) => {
               store.commit("saveSubmissionFile", {
                 name: submissionFileName,


### PR DESCRIPTION
I have changed the submissions's folder structure and json file of comparison(i.e. A-B.json) in zip file. Now match and file name are represented with their full path (include root directory). And the problem in #658 is also solved. And when file name is too long, it only shows part of the full path(i.e. ..subfolder/subsubfolder/algorithm.java).