### PR TITLE
Fix bug: representation for name of match and file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ JPlag is released on [Maven Central](https://search.maven.org/search?q=de.jplag)
 5. You will find the generated JARs in the subdirectory `jplag.cli/target`.
 
 ## Usage
-JPlag can either be used via the CLI or directly via its Java API. For more information, see the [usage information in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
+JPlag can either be used via the CLI or directly via its Java API. For more information, see the [usage information in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag). If you are using the CLI, you can display you results via [jplag.github.io](https://jplag.github.io/JPlag/). No data will be uploaded!
 
 ### CLI
 *Note that the [legacy CLI](https://github.com/jplag/jplag/blob/legacy/README.md) is varying slightly.*

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ JPlag is released on [Maven Central](https://search.maven.org/search?q=de.jplag)
 5. You will find the generated JARs in the subdirectory `jplag.cli/target`.
 
 ## Usage
-JPlag can either be used via the CLI or directly via its Java API. For more information, see the [usage information in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag). If you are using the CLI, you can display you results via [jplag.github.io](https://jplag.github.io/JPlag/). No data will be uploaded!
+JPlag can either be used via the CLI or directly via its Java API. For more information, see the [usage information in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag). If you are using the CLI, you can display your results via [jplag.github.io](https://jplag.github.io/JPlag/). No data will leave your computer!
 
 ### CLI
 *Note that the [legacy CLI](https://github.com/jplag/jplag/blob/legacy/README.md) is varying slightly.*

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -104,7 +104,7 @@ public class ComparisonReportWriter {
     }
 
     private String relativizedFilePath(File file, Submission submission) {
-        return submission.getRoot().toPath().relativize(file.toPath()).toString();
+        return submission.getName().concat(File.separator).concat(submission.getRoot().toPath().relativize(file.toPath()).toString());
     }
 
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/DirectoryManager.java
@@ -22,6 +22,30 @@ public class DirectoryManager {
     private static final Logger logger = LoggerFactory.getLogger(DirectoryManager.class);
 
     /**
+     * Creates a full path directory.
+     * @param path The path under which the new directory or file ought to be created
+     * @param name The name of the new directory. According to this name we can get sub-folder's structure after this
+     * directory.
+     * @param file The file, which has the path of sub-folders
+     * @return The created directory which has the whole structure as file
+     */
+    public static File createDirectory(String path, String name, File file) throws IOException {
+        File directory;
+        String fileName = file.getPath();
+        int lastDirectoryIndex = findLastDirectory(fileName, name);
+        fileName = fileName.substring(lastDirectoryIndex).replaceFirst(name, "");
+        if ("".equals(fileName)) {
+            directory = new File(path.concat(File.separator).concat(name).concat(File.separator).concat(name));
+        } else {
+            directory = new File(path.concat(File.separator).concat(name).concat(fileName));
+        }
+        if (!directory.exists() && !directory.mkdirs()) {
+            throw new IOException("Failed to create dir.");
+        }
+        return directory;
+    }
+
+    /**
      * Creates a directory.
      * @param path The path under which the new directory ought to be created
      * @param name The name of the new directory
@@ -91,5 +115,27 @@ public class DirectoryManager {
         logger.info("Successfully zipped report files: {}", zipName);
         logger.info("Display the results with the report viewer at https://jplag.github.io/JPlag/");
         return true;
+    }
+
+    /**
+     * Processes file path.
+     * @param filePath The path of the file that needs to be compared
+     * @param name The name of the new directory. According to this name we can get sub-folder's structure after this
+     * directory.
+     * @return The index of the new directory in filePath
+     */
+    public static int findLastDirectory(String filePath, String name) {
+        String filePathCopy = filePath;
+        int index;
+        while (true) {
+            index = filePathCopy.lastIndexOf(name);
+            if (index == -1)
+                return filePathCopy.length();
+            String tempPath = filePathCopy.substring(0, index + name.length());
+            if (Files.isDirectory(Path.of(tempPath))) {
+                return index;
+            }
+            filePathCopy = filePathCopy.substring(0, index);
+        }
     }
 }

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -102,13 +102,23 @@ public class ReportObjectFactory {
                 continue;
             }
             for (File file : submission.getFiles()) {
+                File fullPath = createSubmissionDirectory(path, submissionsPath, submission, file);
                 File fileToCopy = language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
                 try {
-                    Files.copy(fileToCopy.toPath(), (new File(directory, file.getName())).toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    Files.copy(fileToCopy.toPath(), fullPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {
                     logger.error("Could not save submission file " + fileToCopy, e);
                 }
             }
+        }
+    }
+
+    private File createSubmissionDirectory(String path, File submissionsPath, Submission submission, File file) {
+        try {
+            return createDirectory(submissionsPath.getPath(), submissionToIdFunction.apply(submission), file);
+        } catch (IOException e) {
+            logger.error("Could not create directory " + path + " for report viewer generation", e);
+            return null;
         }
     }
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -108,6 +108,8 @@ public class ReportObjectFactory {
                     Files.copy(fileToCopy.toPath(), fullPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {
                     logger.error("Could not save submission file " + fileToCopy, e);
+                } catch (NullPointerException e) {
+                    logger.error("Could not create full path for files under submissions directory", e);
                 }
             }
         }

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -105,11 +105,13 @@ public class ReportObjectFactory {
                 File fullPath = createSubmissionDirectory(path, submissionsPath, submission, file);
                 File fileToCopy = language.useViewFiles() ? new File(file.getPath() + language.viewFileSuffix()) : file;
                 try {
-                    Files.copy(fileToCopy.toPath(), fullPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    if (fullPath != null) {
+                        Files.copy(fileToCopy.toPath(), fullPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    }else {
+                        throw new NullPointerException("Could not create file with full path");
+                    }
                 } catch (IOException e) {
                     logger.error("Could not save submission file " + fileToCopy, e);
-                } catch (NullPointerException e) {
-                    logger.error("Could not create full path for files under submissions directory", e);
                 }
             }
         }

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -107,7 +107,7 @@ public class ReportObjectFactory {
                 try {
                     if (fullPath != null) {
                         Files.copy(fileToCopy.toPath(), fullPath.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                    }else {
+                    } else {
                         throw new NullPointerException("Could not create file with full path");
                     }
                 } catch (IOException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.13.4</version>
+                <version>2.13.4.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.13.4.1</version>
+                <version>2.14.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -8680,9 +8680,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+      "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -12256,9 +12256,9 @@
       }
     },
     "node_modules/thread-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -12907,9 +12907,9 @@
       }
     },
     "node_modules/vue-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+      "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -20157,9 +20157,9 @@
       "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw=="
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.1.tgz",
+      "integrity": "sha512-1Qo97Y2oKaU+Ro2xnDMR26g1BwMT29jNbem1EvcujW2jqt+j5COXyscjM7bLQkM9HaxI7pkWeW7gnI072yMI9Q==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -22838,9 +22838,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -23320,9 +23320,9 @@
           "dev": true
         },
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
+          "integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",

--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -25,7 +25,7 @@
         "vuex": "^4.0.2"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.39.0",
+        "@typescript-eslint/eslint-plugin": "^5.40.0",
         "@typescript-eslint/parser": "^5.40.0",
         "@vue/cli-plugin-babel": "~5.0.8",
         "@vue/cli-plugin-eslint": "~5.0.8",
@@ -2228,14 +2228,14 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
+      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/type-utils": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/type-utils": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
@@ -2301,7 +2301,7 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+    "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.40.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
       "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
@@ -2318,103 +2318,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
-      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
-      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.40.0",
-        "@typescript-eslint/visitor-keys": "5.40.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
-      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.40.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-      "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
+      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2435,9 +2346,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
+      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2448,13 +2359,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
+      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2490,17 +2401,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-      "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
+      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2513,13 +2425,28 @@
         "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.39.0",
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
+      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.40.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -15474,14 +15401,14 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.39.0.tgz",
-      "integrity": "sha512-xVfKOkBm5iWMNGKQ2fwX5GVgBuHmZBO1tCRwXmY5oAIsPscfwm2UADDuNB8ZVYCtpQvJK4xpjrK7jEhcJ0zY9A==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.40.0.tgz",
+      "integrity": "sha512-FIBZgS3DVJgqPwJzvZTuH4HNsZhHMa9SjxTKAZTlMsPw/UzpEjcf9f4dfgDJEHjK+HboUJo123Eshl6niwEm/Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/type-utils": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/type-utils": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
@@ -15510,96 +15437,44 @@
         "@typescript-eslint/types": "5.40.0",
         "@typescript-eslint/typescript-estree": "5.40.0",
         "debug": "^4.3.4"
-      },
-      "dependencies": {
-        "@typescript-eslint/scope-manager": {
-          "version": "5.40.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
-          "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.40.0",
-            "@typescript-eslint/visitor-keys": "5.40.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.40.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
-          "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.40.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
-          "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.40.0",
-            "@typescript-eslint/visitor-keys": "5.40.0",
-            "debug": "^4.3.4",
-            "globby": "^11.1.0",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.7",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.40.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
-          "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.40.0",
-            "eslint-visitor-keys": "^3.3.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.39.0.tgz",
-      "integrity": "sha512-/I13vAqmG3dyqMVSZPjsbuNQlYS082Y7OMkwhCfLXYsmlI0ca4nkL7wJ/4gjX70LD4P8Hnw1JywUVVAwepURBw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.40.0.tgz",
+      "integrity": "sha512-d3nPmjUeZtEWRvyReMI4I1MwPGC63E8pDoHy0BnrYjnJgilBD3hv7XOiETKLY/zTwI7kCnBDf2vWTRUVpYw0Uw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0"
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.39.0.tgz",
-      "integrity": "sha512-KJHJkOothljQWzR3t/GunL0TPKY+fGJtnpl+pX+sJ0YiKTz3q2Zr87SGTmFqsCMFrLt5E0+o+S6eQY0FAXj9uA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.40.0.tgz",
+      "integrity": "sha512-nfuSdKEZY2TpnPz5covjJqav+g5qeBqwSHKBvz7Vm1SAfy93SwKk/JeSTymruDGItTwNijSsno5LhOHRS1pcfw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.39.0",
-        "@typescript-eslint/utils": "5.39.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
+        "@typescript-eslint/utils": "5.40.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.39.0.tgz",
-      "integrity": "sha512-gQMZrnfEBFXK38hYqt8Lkwt8f4U6yq+2H5VDSgP/qiTzC8Nw8JO3OuSUOQ2qW37S/dlwdkHDntkZM6SQhKyPhw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.40.0.tgz",
+      "integrity": "sha512-V1KdQRTXsYpf1Y1fXCeZ+uhjW48Niiw0VGt4V8yzuaDTU8Z1Xl7yQDyQNqyAFcVhpYXIVCEuxSIWTsLDpHgTbw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.39.0.tgz",
-      "integrity": "sha512-qLFQP0f398sdnogJoLtd43pUgB18Q50QSA+BTE5h3sUxySzbWDpTSdgt4UyxNSozY/oDK2ta6HVAzvGgq8JYnA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.40.0.tgz",
+      "integrity": "sha512-b0GYlDj8TLTOqwX7EGbw2gL5EXS2CPEWhF9nGJiGmEcmlpNBjyHsTwbqpyIEPVpl6br4UcBOYlcI2FJVtJkYhg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/visitor-keys": "5.39.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/visitor-keys": "5.40.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -15619,26 +15494,38 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.39.0.tgz",
-      "integrity": "sha512-+DnY5jkpOpgj+EBtYPyHRjXampJfC0yUZZzfzLuUWVZvCuKqSdJVC8UhdWipIw7VKNTfwfAPiOWzYkAwuIhiAg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.40.0.tgz",
+      "integrity": "sha512-MO0y3T5BQ5+tkkuYZJBjePewsY+cQnfkYeRqS6tPh28niiIwPnQ1t59CSRcs1ZwJJNOdWw7rv9pF8aP58IMihA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.39.0",
-        "@typescript-eslint/types": "5.39.0",
-        "@typescript-eslint/typescript-estree": "5.39.0",
+        "@typescript-eslint/scope-manager": "5.40.0",
+        "@typescript-eslint/types": "5.40.0",
+        "@typescript-eslint/typescript-estree": "5.40.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "eslint-utils": "^3.0.0",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.39.0.tgz",
-      "integrity": "sha512-yyE3RPwOG+XJBLrhvsxAidUgybJVQ/hG8BhiJo0k8JSAYfk/CshVcxf0HwP4Jt7WZZ6vLmxdo1p6EyN3tzFTkg==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.40.0.tgz",
+      "integrity": "sha512-ijJ+6yig+x9XplEpG2K6FUdJeQGGj/15U3S56W9IqXKJqleuD7zJ2AX/miLezwxpd7ZxDAqO87zWufKg+RPZyQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.39.0",
+        "@typescript-eslint/types": "5.40.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },

--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -26,7 +26,7 @@
     "vuex": "^4.0.2"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.39.0",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
     "@vue/cli-plugin-babel": "~5.0.8",
     "@vue/cli-plugin-eslint": "~5.0.8",

--- a/report-viewer/src/components/FilesContainer.vue
+++ b/report-viewer/src/components/FilesContainer.vue
@@ -7,13 +7,13 @@
     <VueDraggableNext>
       <CodePanel
         v-for="(file, index) in files.keys()"
-        :key="file.concat(index.toString())"
+        :key="file"
         :collapse="files.get(file)?.collapsed"
         :file-index="index"
         :lines="!files.get(file)?.lines ? [] : files.get(file)?.lines"
         :matches="!matches.get(file) ? [] : matches.get(file)"
         :panel-id="containerId"
-        :title="file"
+        :title="file.length>40?'..'+file.substring(file.length-40,file.length):file"
         @toggle-collapse="$emit('toggle-collapse', file)"
         @line-selected="lineSelected"
       />

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -21,12 +21,6 @@ export class ComparisonFactory {
     );
 
     const matches = json.matches as Array<Record<string, unknown>>;
-    
-    // TODO: Quick fix for issue #658, requires deeper insights to be resolved completely
-    matches.forEach((match: Record<string, unknown>) => {
-      match["file1"] = this.removePathFromFileName(match["file1"] as string ?? "");
-      match["file2"] = this.removePathFromFileName(match["file2"] as string ?? "");
-    })
 
     const colors = this.generateColorsForMatches(matches.length);
     const coloredMatches = matches.map((match, index) =>
@@ -106,10 +100,6 @@ export class ComparisonFactory {
       }
     });
     return acc;
-  }
-
-  private static removePathFromFileName(filePath: string): string {
-    return  filePath.substring(filePath.lastIndexOf("\\") + 1).substring(filePath.lastIndexOf("/") + 1);
   }
 
   private static generateColorsForMatches(num: number): Array<string> {

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -61,6 +61,12 @@ export default defineComponent({
       );
       return folders[submissionFolderIndex + 1];
     };
+    const extractFileNameWithFullPath = (filePath: path.ParsedPath) => {
+      const pathWithoutSubmissions = filePath.dir.split("submissions");
+      const subfolderPathAfterSubmissions = pathWithoutSubmissions[1].substring(1);
+      const fullPath=(subfolderPathAfterSubmissions + '/' + filePath.base).replaceAll('/','\\');
+      return fullPath;
+    };
     /**
      * Handles zip file on drop. It extracts the zip and saves each file in the store.
      * @param file
@@ -76,10 +82,11 @@ export default defineComponent({
             const filePath = path.parse(unixFileName);
 
             const submissionFileName = extractSubmissionFileName(filePath);
+            const fullPathFileName = extractFileNameWithFullPath(filePath);
             await zip.files[originalFileName].async("string").then((data) => {
               store.commit("saveSubmissionFile", {
                 name: submissionFileName,
-                file: { fileName: filePath.base, data: data },
+                file: { fileName: fullPathFileName, data: data },
               });
             });
           } else {


### PR DESCRIPTION
This is new PR, because last one has conflict problem.
I have changed the submissions's folder structure and json file of comparison(i.e. A-B.json) in zip file. Now match and file name are represented with their full path (include root directory). And the problem in #658 is also solved. And when file name is too long, it only shows part of the full path(i.e. ..subfolder/subsubfolder/algorithm.java).