### PR TITLE
Link metamodel plagiarism paper in the EMF language Module readme files

### DIFF
--- a/languages/emf-metamodel-dynamic/README.md
+++ b/languages/emf-metamodel-dynamic/README.md
@@ -12,4 +12,5 @@ For the token extraction, we visit the containment tree of the metamodel and ext
 To use this module, add the `-l emf-metamodel-dynamic` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.EMF_DYNAMIC` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
 
 ### More Info
-More information can be found in the paper *"Token-based Plagiarism Detection for Metamodels"* (MODELS-C 2022, accepted for publication, link coming soon). 
+More information can be found in the paper [*"Token-based Plagiarism Detection for Metamodels" (MODELS-C'22)*](https://dl.acm.org/doi/10.1145/3550356.3556508).
+A short summary can be found on [Kudos](https://www.growkudos.com/publications/10.1145%25252F3550356.3556508/reader).

--- a/languages/emf-metamodel/README.md
+++ b/languages/emf-metamodel/README.md
@@ -12,4 +12,5 @@ For the token extraction, we visit the containment tree of the metamodel and ext
 To use this module, add the `-l emf-metamodel` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.EMF` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
 
 ### More Info
-More information can be found in the paper *"Token-based Plagiarism Detection for Metamodels"* (MODELS-C 2022, accepted for publication, link coming soon). 
+More information can be found in the paper [*"Token-based Plagiarism Detection for Metamodels" (MODELS-C'22)*](https://dl.acm.org/doi/10.1145/3550356.3556508).
+A short summary can be found on [Kudos](https://www.growkudos.com/publications/10.1145%25252F3550356.3556508/reader).


### PR DESCRIPTION
Adds:
> More information can be found in the paper [*"Token-based Plagiarism Detection for Metamodels" (MODELS-C'22)*](https://dl.acm.org/doi/10.1145/3550356.3556508).
> A short summary can be found on [Kudos](https://www.growkudos.com/publications/10.1145%25252F3550356.3556508/reader). 