### PR TITLE
Use Maven to load version of JPlag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ JPlag is a system that finds similarities among multiple sets of source code fil
 
 In the following, a list of all supported languages with their supported language version is provided. A language can be selected from the command line using the `-l <cli argument name>` argument.
 
-| Language                                                         | Version | CLI Argument Name     | [state](https://github.com/jplag/JPlag/wiki/3.-Language-Modules) | parser |
-|------------------------------------------------------------------|--------:|-----------------------| :---: | :---: |
-| [Java](https://www.java.com)                                     |      17 | java                  | mature | JavaC |
-| [C++](https://isocpp.org)                                        |      11 | cpp                   | legacy | JavaCC |
-| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/)            |       8 | csharp                | beta | ANTLR 4 |
-| [Go](https://go.dev)                                             |    1.17 | golang                | beta | ANTLR 4 |
-| [Kotlin](https://kotlinlang.org)                                 |     1.3 | kotlin                | beta | ANTLR 4 |
-| [Python](https://www.python.org)                                 |     3.6 | python3               | legacy | ANTLR 4 |
-| [R](https://www.r-project.org/)                                  |   3.5.0 | rlang                 | beta | ANTLR 4 |
-| [Rust](https://www.rust-lang.org/)                               |  1.60.0 | rust                  | beta | ANTLR 4 |
-| [Scala](https://www.scala-lang.org)                              |  2.13.8 | scala                 | beta | Scalameta |
-| [Scheme](http://www.scheme-reports.org)                          |       ? | scheme                | unknown | JavaCC |
-| [Swift](https://www.swift.org)                                   |     5.4 | swift                 | beta | ANTLR 4 |
-| [EMF Metamodel](https://www.eclipse.org/modeling/emf/)           |  2.25.0 | emf                   | alpha | EMF |
-| Text (naive)                                                     |       - | text                  | legacy | CoreNLP |
+| Language                                               | Version | CLI Argument Name | [state](https://github.com/jplag/JPlag/wiki/3.-Language-Modules) |  parser   |
+|--------------------------------------------------------|--------:|-------------------|:----------------------------------------------------------------:|:---------:|
+| [Java](https://www.java.com)                           |      17 | java              |                              mature                              |   JavaC   |
+| [C++](https://isocpp.org)                              |      11 | cpp               |                              legacy                              |  JavaCC   |
+| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/)  |       8 | csharp            |                               beta                               |  ANTLR 4  |
+| [Go](https://go.dev)                                   |    1.17 | golang            |                               beta                               |  ANTLR 4  |
+| [Kotlin](https://kotlinlang.org)                       |     1.3 | kotlin            |                               beta                               |  ANTLR 4  |
+| [Python](https://www.python.org)                       |     3.6 | python3           |                              legacy                              |  ANTLR 4  |
+| [R](https://www.r-project.org/)                        |   3.5.0 | rlang             |                               beta                               |  ANTLR 4  |
+| [Rust](https://www.rust-lang.org/)                     |  1.60.0 | rust              |                               beta                               |  ANTLR 4  |
+| [Scala](https://www.scala-lang.org)                    |  2.13.8 | scala             |                               beta                               | Scalameta |
+| [Scheme](http://www.scheme-reports.org)                |       ? | scheme            |                             unknown                              |  JavaCC   |
+| [Swift](https://www.swift.org)                         |     5.4 | swift             |                               beta                               |  ANTLR 4  |
+| [EMF Metamodel](https://www.eclipse.org/modeling/emf/) |  2.25.0 | emf               |                              alpha                               |    EMF    |
+| Text (naive)                                           |       - | text              |                              legacy                              |  CoreNLP  |
 
 ## Download and Installation
 
@@ -51,7 +51,7 @@ JPlag is released on [Maven Central](https://search.maven.org/search?q=de.jplag)
 1. Download or clone the code from this repository.
 2. Run `mvn clean package` from the root of the repository to compile and build all submodules.
    Run `mvn clean package assembly:single` instead if you need the full jar which includes all dependencies.
-5. You will find the generated JARs in the subdirectory `jplag.cli/target`.
+5. You will find the generated JARs in the subdirectory `cli/target`.
 
 ## Usage
 JPlag can either be used via the CLI or directly via its Java API. For more information, see the [usage information in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag). If you are using the CLI, you can display your results via [jplag.github.io](https://jplag.github.io/JPlag/). No data will leave your computer!

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -82,6 +82,7 @@ public final class CLI {
      */
     public static void main(String[] args) {
         try {
+            logger.debug("Your version of JPlag is {}", JPlag.JPLAG_VERSION);
             CLI cli = new CLI();
             Namespace arguments = cli.parseArguments(args);
             JPlagOptions options = cli.buildOptionsFromArguments(arguments);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,4 +74,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
 </project>

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -1,5 +1,7 @@
 package de.jplag;
 
+import java.util.ResourceBundle;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -7,6 +9,7 @@ import de.jplag.clustering.ClusteringFactory;
 import de.jplag.exceptions.ExitException;
 import de.jplag.exceptions.SubmissionException;
 import de.jplag.options.JPlagOptions;
+import de.jplag.reporting.reportobject.model.Version;
 import de.jplag.strategy.ComparisonStrategy;
 import de.jplag.strategy.ParallelComparisonStrategy;
 
@@ -15,6 +18,15 @@ import de.jplag.strategy.ParallelComparisonStrategy;
  */
 public class JPlag {
     private static final Logger logger = LoggerFactory.getLogger(JPlag.class);
+
+    public static final Version JPLAG_VERSION = loadVersion();
+
+    private static Version loadVersion() {
+        ResourceBundle versionProperties = ResourceBundle.getBundle("de.jplag.version");
+        String versionString = versionProperties.getString("version");
+        Version currentVersion = Version.parseVersion(versionString);
+        return currentVersion == null ? Version.DEVELOPMENT : currentVersion;
+    }
 
     private final JPlagOptions options;
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.JPlag;
 import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
 import de.jplag.Language;

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -42,9 +42,8 @@ public class ReportObjectFactory {
     private static final ToDiskWriter fileWriter = new ToDiskWriter();
     public static final String OVERVIEW_FILE_NAME = "overview.json";
     public static final String SUBMISSIONS_FOLDER = "submissions";
+    public static final Version REPORT_VIEWER_VERSION = JPlag.JPLAG_VERSION;
 
-    // TODO: This shall be moved to a better visible and upgradable position. Shall be fixed in a future version.
-    public static final Version REPORT_VIEWER_VERSION = new Version(4, 0, 0);
     private Map<String, String> submissionNameToIdMap;
     private Function<Submission, String> submissionToIdFunction;
     private Map<String, Map<String, String>> submissionNameToNameToComparisonFileName;

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/Version.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/Version.java
@@ -1,5 +1,8 @@
 package de.jplag.reporting.reportobject.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -10,4 +13,33 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @param patch PATCH version when you make backwards compatible bug fixes
  */
 public record Version(@JsonProperty("major") int major, @JsonProperty("minor") int minor, @JsonProperty("patch") int patch) {
+
+    private static final Logger logger = LoggerFactory.getLogger(Version.class);
+
+    /**
+     * The default version for development (0.0.0).
+     */
+    public static final Version DEVELOPMENT = new Version(0, 0, 0);
+
+    /**
+     * Parse a version string (e.g., {@code v0.0.1} or {@code 0.0.1} or {@code 0.0.1-SNAPSHOT}).
+     * @param version the version string
+     * @return the parsed version or {@code null} if not parsable
+     */
+    public static Version parseVersion(String version) {
+        String plainVersion = version.startsWith("v") ? version.substring(1) : version;
+        plainVersion = plainVersion.replace("-SNAPSHOT", "");
+
+        if (!plainVersion.matches("\\d+\\.\\d+\\.\\d+")) {
+            logger.debug("Version {} could not be parsed. Defaulting to null.", version);
+            return null;
+        }
+        String[] versionParts = plainVersion.split("\\.");
+        return new Version(Integer.parseInt(versionParts[0]), Integer.parseInt(versionParts[1]), Integer.parseInt(versionParts[2]));
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d.%d.%d", major, minor, patch);
+    }
 }

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -1,9 +1,9 @@
 package de.jplag.reporting.reportobject;
 
-import de.jplag.reporting.reportobject.model.Version;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import de.jplag.reporting.reportobject.model.Version;
 
 class ReportObjectFactoryTest {
     @Test

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -1,5 +1,7 @@
 package de.jplag.reporting.reportobject;
 
+import de.jplag.reporting.reportobject.model.Version;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -7,5 +9,6 @@ class ReportObjectFactoryTest {
     @Test
     void testVersion() {
         Assertions.assertNotNull(ReportObjectFactory.REPORT_VIEWER_VERSION);
+        Assertions.assertNotEquals(Version.DEVELOPMENT, ReportObjectFactory.REPORT_VIEWER_VERSION);
     }
 }

--- a/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
+++ b/core/src/test/java/de/jplag/reporting/reportobject/ReportObjectFactoryTest.java
@@ -1,0 +1,11 @@
+package de.jplag.reporting.reportobject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class ReportObjectFactoryTest {
+    @Test
+    void testVersion() {
+        Assertions.assertNotNull(ReportObjectFactory.REPORT_VIEWER_VERSION);
+    }
+}


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

Basically, this PR adds a mechanism to load the version based on the current revision of the JPlag project.
(And fixes an issue in the readme: Wrong directory of the build)