### PR TITLE
Relative Paths for Viewer

### DIFF
--- a/report-viewer/public/index.html
+++ b/report-viewer/public/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <script type="text/javascript">window.PUBLIC_PATH = window.location.pathname;</script>
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/report-viewer/src/router/index.ts
+++ b/report-viewer/src/router/index.ts
@@ -1,4 +1,5 @@
-import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
+import "./public-path"
+import {createRouter, createWebHistory, RouteRecordRaw} from "vue-router";
 import OverviewView from "@/views/OverviewView.vue";
 import ComparisonView from "@/views/ComparisonView.vue";
 import FileUploadView from "@/views/FileUploadView.vue";
@@ -26,7 +27,7 @@ const routes: Array<RouteRecordRaw> = [
 ];
 
 const router = createRouter({
-  history: createWebHistory("/JPlag"),
+  history: createWebHistory(__webpack_public_path__),
   routes,
 });
 

--- a/report-viewer/src/router/public-path.js
+++ b/report-viewer/src/router/public-path.js
@@ -1,0 +1,4 @@
+/* global __webpack_public_path__:writable */
+/* exported __webpack_public_path__ */
+
+__webpack_public_path__ = window.PUBLIC_PATH;

--- a/report-viewer/vue.config.js
+++ b/report-viewer/vue.config.js
@@ -1,8 +1,7 @@
 const { defineConfig } = require("@vue/cli-service");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 module.exports = defineConfig({
-  publicPath: "/JPlag",
-
+  publicPath: '',
   transpileDependencies: true,
   configureWebpack: {
     plugins: [new NodePolyfillPlugin()],


### PR DESCRIPTION
Allow the use of relative paths within the Viewer (e.g., for deployments in subfolders)

Based on:
* https://medium.com/js-dojo/how-to-solve-vue-js-prod-build-assets-relative-path-problem-71f91138dd79
* https://medium.com/@gentritabazi01/vue-js-make-publicpath-dynamic-33c065960eb9