### PR TITLE
Fix NPE when calling ParsingException constructors with null reason

### DIFF
--- a/language-api/src/main/java/de/jplag/ParsingException.java
+++ b/language-api/src/main/java/de/jplag/ParsingException.java
@@ -79,7 +79,7 @@ public class ParsingException extends Exception {
     private static String constructMessage(File file, String reason) {
         StringBuilder messageBuilder = new StringBuilder();
         messageBuilder.append("failed to parse '%s'".formatted(file));
-        if (!reason.isEmpty() && !reason.isBlank()) {
+        if (reason != null && !reason.isBlank()) {
             messageBuilder.append(" with reason: %s".formatted(reason));
         }
         return messageBuilder.toString();

--- a/language-api/src/test/java/de/jplag/ParsingExceptionTest.java
+++ b/language-api/src/test/java/de/jplag/ParsingExceptionTest.java
@@ -6,7 +6,7 @@ import java.io.File;
 
 import org.junit.jupiter.api.Test;
 
-public class ParsingExceptionTest {
+class ParsingExceptionTest {
 
     @Test
     void testParsingExceptionAcceptsNullReason() {

--- a/language-api/src/test/java/de/jplag/ParsingExceptionTest.java
+++ b/language-api/src/test/java/de/jplag/ParsingExceptionTest.java
@@ -1,0 +1,23 @@
+package de.jplag;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+
+public class ParsingExceptionTest {
+
+    @Test
+    void testParsingExceptionAcceptsNullReason() {
+        // placeholder exception to have a non-null argument
+        File file = new File("myFile");
+        // placeholder exception to have a non-null argument
+        Exception exception = new RuntimeException();
+
+        assertDoesNotThrow(() -> new ParsingException(file));
+        assertDoesNotThrow(() -> new ParsingException(file, (String) null));
+        assertDoesNotThrow(() -> new ParsingException(file, exception));
+        assertDoesNotThrow(() -> new ParsingException(file, null, exception));
+    }
+}


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
A per the Javadocs, `null` values are permitted for the `reason`, however passing `null` or using a constructor that doesn't take a `String` causes a NullPointerException.

I addressed this issue and created a regression test for it.

Note: `String#isBlank` returns true if the string is empty, so this check wasn't needed.