### PR TITLE
Fix IDs being sometimes null in the overview.json

### DIFF
--- a/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
@@ -2,10 +2,8 @@ package de.jplag.reporting.reportobject.mapper;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
 import de.jplag.Submission;
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
@@ -23,9 +23,7 @@ public class SubmissionNameToIdMapper {
      */
     public static Map<String, String> buildSubmissionNameToIdMap(JPlagResult result) {
         HashMap<String, String> idToName = new HashMap<>();
-        result.getSubmissions().getSubmissions().forEach(submission -> {
-            idToName.put(submission.getName(), sanitizeNameOf(submission));
-        });
+        result.getSubmissions().getSubmissions().forEach(submission -> idToName.put(submission.getName(), sanitizeNameOf(submission)));
         return idToName;
     }
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
@@ -34,9 +34,4 @@ public class SubmissionNameToIdMapper {
     private static String sanitizeNameOf(Submission comparison) {
         return comparison.getName().replace(File.separator, FILE_SEPARATOR_REPLACEMENT);
     }
-
-    private static List<JPlagComparison> getComparisons(JPlagResult result) {
-        int numberOfComparisons = result.getOptions().maximumNumberOfComparisons();
-        return result.getComparisons(numberOfComparisons);
-    }
 }

--- a/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/mapper/SubmissionNameToIdMapper.java
@@ -25,9 +25,8 @@ public class SubmissionNameToIdMapper {
      */
     public static Map<String, String> buildSubmissionNameToIdMap(JPlagResult result) {
         HashMap<String, String> idToName = new HashMap<>();
-        getComparisons(result).forEach(comparison -> {
-            idToName.put(comparison.firstSubmission().getName(), sanitizeNameOf(comparison.firstSubmission()));
-            idToName.put(comparison.secondSubmission().getName(), sanitizeNameOf(comparison.secondSubmission()));
+        result.getSubmissions().getSubmissions().forEach(submission -> {
+            idToName.put(submission.getName(), sanitizeNameOf(submission));
         });
         return idToName;
     }


### PR DESCRIPTION
This PR replaces the build of the mapping form IDs to names so that all submissions are contained in the map, not only the ones in the top comparisons. This broke the serialization of clusters.

I propose to squash this PR due to my terrible tiny-commit style :)