### PR TITLE
Fix/clicking problem on match highlighting

### DIFF
--- a/report-viewer/src/components/CodePanel.vue
+++ b/report-viewer/src/components/CodePanel.vue
@@ -3,7 +3,7 @@
 -->
 <template>
   <div
-    :id="panelId.toString().concat(title).concat(fileIndex.toString())"
+    :id="panelId.toString().concat(filePath).concat(fileIndex.toString())"
     class="code-panel-container"
   >
     <div class="file-title">
@@ -29,7 +29,7 @@
       <div v-if="!isEmpty(lines)" class="code-container">
         <LineOfCode
           v-for="(line, index) in lines"
-          :id="String(panelId).concat(title).concat(index)"
+          :id="String(panelId).concat(filePath).concat(index+1)"
           :key="index"
           :color="coloringArray[index]"
           :is-first="isFirst[index]"
@@ -63,6 +63,12 @@ export default defineComponent({
   name: "CodePanel",
   components: { LineOfCode },
   props: {
+    /**
+     * Path of the displayed file.
+     */
+    filePath: {
+      type: String
+    },
     /**
      * Title of the displayed file.
      */

--- a/report-viewer/src/components/FilesContainer.vue
+++ b/report-viewer/src/components/FilesContainer.vue
@@ -7,7 +7,7 @@
     <VueDraggableNext>
       <CodePanel
         v-for="(file, index) in files.keys()"
-        :key="file"
+        :key="file.concat(index.toString())"
         :collapse="files.get(file)?.collapsed"
         :file-index="index"
         :lines="!files.get(file)?.lines ? [] : files.get(file)?.lines"

--- a/report-viewer/src/components/FilesContainer.vue
+++ b/report-viewer/src/components/FilesContainer.vue
@@ -16,6 +16,7 @@
         :title="convertSubmissionIdToName(file, submissionId).length > 40?
         '..' + convertSubmissionIdToName(file, submissionId).substring(file.length - 40, file.length):
         convertSubmissionIdToName(file, submissionId)"
+        :filePath="file"
         @toggle-collapse="$emit('toggle-collapse', file)"
         @line-selected="lineSelected"
       />

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -21,6 +21,9 @@
           />
         </button>
       </div>
+      <div>
+        <button class="animated-back-button" title="Back button" @click="back">back</button>
+      </div>
       <TextInformation
         :anonymous="isAnonymous(firstId)"
         :value="store.getters.submissionDisplayName(firstId)"
@@ -202,6 +205,10 @@ export default defineComponent({
       hideLeftPanel.value = !hideLeftPanel.value;
     };
 
+    const back = () => {
+      router.back();
+    };
+
     return {
       comparison,
       filesOfFirst,
@@ -216,6 +223,7 @@ export default defineComponent({
       showMatch,
       togglePanel,
       isAnonymous,
+      back,
     };
   },
 });
@@ -297,5 +305,38 @@ h1 {
 
 #show-button:hover img {
   display: block;
+}
+
+.animated-back-button{
+  float: right;
+  height: 100%;
+  position: relative;
+
+  font-size: 1.4rem;
+  background: var(--primary-color-dark);
+  background-size: 46px 26px;
+  border: 1px solid #555;
+  color: black;
+  transition: all ease 0.3s;
+}
+
+.animated-back-button::after{
+  position: absolute;
+  top: 50%;
+  right: 0.6em;
+  transform: translateY(-50%);
+  content: "«";
+  font-size: 1.2em;
+  transition: all ease 0.3s;
+  opacity: 0;
+}
+
+.animated-back-button:hover{
+  padding: 20px 60px 20px 20px;
+}
+
+.animated-back-button:hover::after{
+  right: 1.2em;
+  opacity: 1;
 }
 </style>


### PR DESCRIPTION
This PR fixed a new issue: clicking on the colored match highlighting sometimes does not work (or stops working after several clicks). In addition, adding a back button in Comparisons viewer.
