### PR TITLE
Change documentation of language usage to constructor invocation

### DIFF
--- a/endtoend-testing/README.md
+++ b/endtoend-testing/README.md
@@ -5,10 +5,10 @@ With the help of elaborated plagiarism, which has been worked out from suggestio
 
 ## References
 These elaborations provide basic ideas on how a modification of the plagiarized source code can look or be adapted.
-These code adaptations refer to a wide range of changes starting from
+These code adaptations refer to a wide range of changes, from
 adding/removing comments to architectural changes in the deliverables.
 
-The following elaborations were used to be able to create the plagiarisms with the largest coverage:
+The following elaborations were used to be able to create the plagiarisms with the broadest coverage:
 - [Detecting Source Code Plagiarism on Introductory Programming Course Assignments Using a Bytecode Approach - Oscar Karnalim](https://ieeexplore.ieee.org/abstract/document/7910274 "Detecting Source Code Plagiarism on Introductory Programming Course Assignments Using a Bytecode Approach - Oscar Karnalim")
 - [Detecting Disguised Plagiarism - Hatem A. Mahmoud](https://arxiv.org/abs/1711.02149 "Detecting Disguised Plagiarism - Hatem A. Mahmoud")
 - [Instructor-centric source code plagiarism detection and plagiarism corpus](https://dl.acm.org/doi/abs/10.1145/2325296.2325328 "Instructor-centric source code plagiarism detection and plagiarism corpus")
@@ -19,7 +19,7 @@ The following changes were applied to sample tasks to create test cases:
 	<li>Inserting comments or empty lines (normalization level)</li>
 	<li>Changing variable names or function names (normalization level)</li>
 	<li>Insertion of unnecessary or changed code lines (token generation)</li>
-	<li>Changing the program flow (token generation) (statments and functions must be independent of each other)</li>
+	<li>Changing the program flow (token generation) (statements and functions must be independent of each other)</li>
 		<ul type="1">
 			<li>Variable declaration at the beginning of the program</li>
 			<li>Combining declarations of variables</li>
@@ -44,46 +44,33 @@ More detailed information about the creation as well as about the subject of the
 
 **The changes listed above have been developed and evaluated for purely scientific purposes and are not intended to be used for plagiarism in the public or private domain.**
 
-Software is according to [§ 2 of the copyright law](https://www.gesetze-im-internet.de/urhg/__2.html "§ 2 of the copyright law") a protected work that may not be plagiarized. 
-
 ## JPlag - End-To-End TestSuite Structure
-The construction of an end-to-end test is done with the help of the JPlag api. 
-The tests are generated dynamically according to the existing test data and allow the creation of end-to-end tests for all supported languages of JPlag without having to make any changes to the code.
-The helper loads the existing test data from the designated directory and creates dynamic tests for the individual directories. It is therefore possible to create different test classes for the different languages.
-- JPlagTestSuiteHelper:
+The construction of an end-to-end test is done with the help of the JPlag API. 
+The tests are generated dynamically according to the existing test data and allow the creation of end-to-end tests for all supported languages of JPlag without making any changes to the code.
+The helper loads the existing test data from the designated directory and creates dynamic tests for the individual directories. It is possible to create different test classes for the different languages.
 
-```JAVA 
-public static Map<LanguageOption, Map<String, Path>> getAllLanguageResources()
-```
-
-The list of languages created in this way and their associated data are dynamically generated into test cases in the Test Suite.
-
-```JAVA
- Collection<DynamicTest> dynamicOverAllTest()
-```
-
-To be able to distinguish in which domain of the recognition changes have occurred, fine granular test cases are used. These are composed of the changes already mentioned above. The plagiarism is compared with the original delivery and thus it is possible to detect and test small sections of the recognition. 
+To distinguish which domain of the recognition changes have occurred, fine granular test cases are used. These are composed of the changes already mentioned above. The plagiarism is compared with the original delivery; thus, it is possible to detect and test small sections of the recognition. 
 
 The comparative values were discussed and tested. The following results of the JPlag scan are used for the comparison:
 1. minimal similarity as `float`
 2. maximum similarity as `float`
 3. matched token number as `int`
 
-The comparative values were disscussed and elaborated in the issue [End-to-end testing - "comparative values"](https://github.com/jplag/JPlag/issues/548 "End-to-end testing - \"comparative values\""). 
+The comparative values were discussed and elaborated in the issue [End-to-end testing - "comparative values"](https://github.com/jplag/JPlag/issues/548 "End-to-end testing - \"comparative values\""). 
 
-Additionally, it is possible to create several options for the test data. More information about the test options can be found at [JPlag - option variants for the end-to-end tests #590](https://github.com/jplag/JPlag/issues/590 "JPlag - option variants for the end-to-end tests #590"). Currently, various settings are supported by the `minimumTokenMatch`.  This can be extended as desired in the record class `Options`.
+Additionally, it is possible to create several options for the test data. More information about the test options can be found at [JPlag - option variants for the end-to-end tests #590](https://github.com/jplag/JPlag/issues/590 "JPlag - option variants for the end-to-end tests #590"). Currently, various settings are supported by the `minimumTokenMatch`. This can be extended as desired in the record class `Options`.
 
 The current JPlag scans will be compared with the stored ones.
 This was done by storing the data in a *.json file which is read at the beginning of each test run.
 
 ### JSON Result Structure
 
-The structures of the Json file can be traced using the individual record classen which can be found under `de.jplag.endtoend.model`.
+The structures of the Json file can be traced using the individual record classes, which can be found under `de.jplag.endtoend.model`.
 The outer structure of the JSON file is recorded in the `ResultDescription` record. 
 The record contains a map of several options and the corresponding results. 
-The internal structure consists of several `Option` records, each of which contains information about the current configuration for the test run. 
+The internal structure consists of several `Option` records, each containing information about the test run's current configuration. 
 Thus the results can be kept apart from the other configurations. 
-The test results for the specified options are also specified in the object. This consists of the `ExpectedResult` record which contains the results of the detection.
+The test results for the specified options are also specified in the object. This consists of the `ExpectedResult` record, which contains the results of the detection.
 
 Here the hierarchy is as follows:
 
@@ -122,11 +109,11 @@ Here the hierarchy is as follows:
 
 This section explains how to create new end-to-end tests in the existing test suite. 
 ### Creating The Plagiarism
-Before you add a new language to the end-to-end tests I would like to point out that the quality of the tests depends dreadfully on the plagiarism techniques you choose which were explained in section [Steps Towards Plagiarism](#steps-towards-plagiarism).
+Before you add a new language to the end-to-end tests, I would like to point out that the quality of the tests depends dreadfully on the plagiarism techniques you choose, which were explained in section [Steps Towards Plagiarism](#steps-towards-plagiarism).
 If you need more information about the creation of plans for this purpose, you can also read the elaborations that can be found under [References](#references).
-The more varied changes you apply, the more accurate the end-to-end tests for the language will be.
+The more various changes you apply, the more accurate the end-to-end tests for the language will be.
 
-In the following an example is shown which is in the JavaEndToEnd tests and is used.
+In the following, an example is shown, which is in the JavaEndToEnd tests and is used.
 
 **Changing control structures for(…) to while(…):**
 
@@ -172,11 +159,11 @@ public void BubbleSortWithoutRecursion(Integer arr[]) {
 ```
 ### Copying Plagiarism To The Resources
 
-The plagiarisms created in [Creating The Plagiarism](#creating-the-plagiarism) need now to be copied to the corresponding resources folder. For each test suite, the resources must be placed in `JPlag/jplag.endToEndTesting/src/test/resources/languageTestFiles/<languageIdentifier>/<testSuiteIdentifier>`. For example, for the existing test suite `sortAlgo` of language `java`, the path is `JPlag/jplag.endToEndTesting/src/test/resources/languageTestFiles/java/sortAlgo`.
-It is important to note that the language identifier must match `Language#getIdentifier` to correctly load the language during testing.
+The plagiarisms created in [Creating The Plagiarism](#creating-the-plagiarism) must now be copied to the corresponding resources folder. For each test suite, the resources must be placed in `JPlag/jplag.endToEndTesting/src/test/resources/languageTestFiles/<languageIdentifier>/<testSuiteIdentifier>`. For example, for the existing test suite `sortAlgo` of language `java`, the path is `JPlag/jplag.endToEndTesting/src/test/resources/languageTestFiles/java/sortAlgo`.
+It is important to note that the language identifier must match `Language#getIdentifier` to load the language during testing correctly.
 
 To automatically generate expected results, the test in `EndToEndGeneratorTest` can be executed to generate a JSON result description file. This file has to be copied to `JPlag/jplag.endToEndTesting/src/test/resources/results/<languageIdentifier>/<testSuiteIdentifier>.json`.
-Once the test data has been copied, the end-to-end tests can be successfully tested. As soon as a change in the detection takes place, the results will differ from the stored results and the tests will fail if the results have changed.
+Once the test data has been copied, the end-to-end tests can be successfully tested. As soon as a change in the detection takes place, the results will differ from the stored results, and the tests will fail if the results have changed.
 
 ### Extending The Comparison Value
 
@@ -184,7 +171,7 @@ As already described, the current comparisons in the end-to-end test treat the v
 As soon as there is a need to extend these comparison values, this section describes how this can be achieved.
 Beforehand, however, this should be discussed in a new issue about this need.
 
-- For new comparison values these properties must be extended in the `ExpectedResult` record at the package `de.jplag.endtoend.model`. Here it is sufficient to add the values in the record and to enter the JSON name as `@JsonProperty("json_name")`.
+- For new comparison values, these properties must be extended in the `ExpectedResult` record at the package `de.jplag.endtoend.model`. Here it is sufficient to add the values in the record and to enter the JSON name as `@JsonProperty("json_name")`.
 
 ```JAVA
 public record ExpectedResult(
@@ -205,13 +192,13 @@ public record ExpectedResult(
 //...
 ```
 
-- Once the tests run the first time they will fail due to the missing values in the old JSON result file used for the test cases. The old results must then be replaced with new ones. 
+- Once the tests run the first time, they will fail due to the missing values in the old JSON result file used for the test cases. The old results must then be replaced with new ones. 
 For this purpose, the last section of the chapter [Copying Plagiarism To The Resources](#copying-plagiarism-to-the-resources) can be used as help. 
 
 ###  Extending JPlar Test Run Options
-The endToEnd tests support the possible scan options of the JPlag API. Currently `minimumTokenMatch` is used in the end-to-end tests. These values are also stored in the JSON as configuration to keep the test cases at the options apart. Likewise, also changes in the logic of the different options are to be determined to be able.
+The end-to-end tests support the possible scan options of the JPlag API. Currently, `minimumTokenMatch` is used in the end-to-end tests. These values are also stored in the JSON as configuration to keep the test cases at the options apart. Likewise, also changes in the logic of the different options are to be determined to be able.
 
-- To extend new options to the end-to-end tests they have to be added to the record object `Options` in the package `de.jplag.endtoend.model`.  Here it is sufficient to add the values in the record and to enter the JSON name as `@JsonProperty("json_name")`.
+- To extend new options to the end-to-end tests, they have to be added to the record object `Options` in the package `de.jplag.endtoend.model`. Here it is sufficient to add the values in the record and to enter the JSON name as `@JsonProperty("json_name")`.
 
 ```JAVA
 public record Options(
@@ -219,7 +206,7 @@ public record Options(
 }
 ```
 
-- After the new value has been added to the record, the creation of the object must now also be adjusted in the `EndToEndSuiteTest`.  The 'setRunOptions' function is provided for this purpose. The options can be added in any order and combination. It should be noted that each test case is run with these options. 
+- After the new value has been added to the record, the creation of the object must now also be adjusted in the `EndToEndSuiteTest`. The 'setRunOptions' function is provided for this purpose. The options can be added in any order and combination. It should be noted that each test case is run with these options. 
 
 ```JAVA
     private void setRunOptions() {
@@ -229,10 +216,10 @@ public record Options(
     }
 ```
 
-- If you want to create individual test cases by testing the options only on a specific set of dates, a new test case must be created for this purpose. For the new test cases, the options in the transfer parameters can be adjusted and specified. This can then be tested with the function `runTests`. 
+- If you want to create individual test cases by testing the options only on a specific set of dates, a new test case must be created for this purpose. The transfer parameter options can be adjusted and specified for the new test cases. This can then be tested with the function `runTests`. 
  ```JAVA 
  runTests(directoryName, option, currentLanguageIdentifier, testCase, currentResultDescription);
 ```
 
-- Once the tests run the first time they will fail due to the missing values in the old JSON result file used for the test cases. The old results must then be replaced with new ones. 
+- Once the tests run the first time, they will fail due to the missing values in the old JSON result file used for the test cases. The old results must then be replaced with new ones. 
 For this purpose, the last section of the chapter [Copying Plagiarism To The Resources](#copying-plagiarism-to-the-resources) can be used as help. 

--- a/languages/emf-metamodel-dynamic/README.md
+++ b/languages/emf-metamodel-dynamic/README.md
@@ -9,7 +9,7 @@ This module is based on the EMF dependencies available on maven central. These m
 For the token extraction, we visit the containment tree of the metamodel and extract tokens for all metamodel elements based on their concrete metaclass. In this module, we thus extract tokens based on a dynamic token set.
 
 ### Usage
-To use this module, add the `-l emf-metamodel-dynamic` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.EMF_DYNAMIC` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
+To use this module, add the `-l emf-metamodel-dynamic` flag in the CLI, or use a `JPlagOption` object with `new de.jplag.emf.dynamic.Language()` as `language` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
 
 ### More Info
 More information can be found in the paper [*"Token-based Plagiarism Detection for Metamodels" (MODELS-C'22)*](https://dl.acm.org/doi/10.1145/3550356.3556508).

--- a/languages/emf-metamodel/README.md
+++ b/languages/emf-metamodel/README.md
@@ -9,7 +9,7 @@ This module is based on the EMF dependencies available on maven central. These m
 For the token extraction, we visit the containment tree of the metamodel and extract tokens for certain metamodel elements based on their metaclass. In this module, we extract tokens based on a [handcrafted token set](https://github.com/jplag/JPlag/blob/master/languages/emf-metamodel/src/main/java/de/jplag/emf/MetamodelTokenType.java). Note that not for all concrete metaclasses tokens are extracted. `EFactory`, `EGenericType`, and `EObject` are ignored. Moreover, for some metaclasses, multiple token types are extracted. Finally, some references are also used for token extraction.
 
 ### Usage
-To use this module, add the `-l emf-metamodel` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.EMF` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
+To use this module, add the `-l emf-metamodel` flag in the CLI, or use a `JPlagOption` object with `new de.jplag.emf.Language()` as `language` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
 
 ### More Info
 More information can be found in the paper [*"Token-based Plagiarism Detection for Metamodels" (MODELS-C'22)*](https://dl.acm.org/doi/10.1145/3550356.3556508).

--- a/languages/golang/README.md
+++ b/languages/golang/README.md
@@ -21,7 +21,7 @@ More syntactic elements of Go may turn out to be helpful to include in the futur
 
 ### Usage
 
-To use the Go frontend, add the `-l golang` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.GO_LANG` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
+To use the Go frontend, add the `-l golang` flag in the CLI, or use a `JPlagOption` object with `new de.jplag.golang.Language()` as `language` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
 
 <br>
 

--- a/languages/kotlin/README.md
+++ b/languages/kotlin/README.md
@@ -20,7 +20,7 @@ More syntactic elements of Kotlin may turn out to be helpful to include in the f
 
 ### Usage
 
-To use the Kotlin module, add the `-l kotlin` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.KOTLIN` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
+To use the Kotlin module, add the `-l kotlin` flag in the CLI, or use a `JPlagOption` object with `new de.jplag.kotlin.Language()` as `language` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
 
 <br>
 

--- a/languages/rlang/README.md
+++ b/languages/rlang/README.md
@@ -13,4 +13,4 @@ The choice of tokens is based directly on the CodeGra-de version, whereas the ex
 Like in other modules, e.g. for Java and C#, the tokens account for the beginning and the end of control flow structures, for control flow keywords, and some kinds of expressions. As R is very different from other programming languages in JPlag, it remains to be seen whether the R module can hold up to the others.
 
 ### Usage
-To use the R module, add the `-l R` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.R` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
+To use the R module, add the `-l R` flag in the CLI, or use a `JPlagOption` object with `new de.jplag.rlang.Language()` as `language` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).

--- a/languages/rust/README.md
+++ b/languages/rust/README.md
@@ -87,7 +87,7 @@ Currently, macro rule definition bodies and macro macro invocation arguments/bod
 
 ### Usage
 
-To use the Rust module, add the `-l rust` flag in the CLI, or use a `JPlagOption` object set
-to `LanguageOption.RUST` in the Java API as described in the usage information in
+To use the Rust module, add the `-l rust` flag in the CLI, or use a `JPlagOption` object
+with `new de.jplag.rust.Language()` as `language` in the Java API as described in the usage information in
 the [readme of the main project](https://github.com/jplag/JPlag#usage)
 and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).

--- a/languages/scala/README.md
+++ b/languages/scala/README.md
@@ -86,7 +86,7 @@ For the moment, implicit block values are neglected.
 
 ### Usage
 
-To use the Scala module, add the `-l scala` flag in the CLI, or use a `JPlagOption` object set
-to `LanguageOption.SCALA` in the Java API as described in the usage information in
+To use the Scala module, add the `-l scala` flag in the CLI, or use a `JPlagOption` object
+with `new de.jplag.scala.Language()` as `language` in the Java API as described in the usage information in
 the [readme of the main project](https://github.com/jplag/JPlag#usage)
 and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).

--- a/languages/swift/README.md
+++ b/languages/swift/README.md
@@ -16,7 +16,7 @@ The choice of tokens is intended to be similar to the Java or C# frontends. It i
 
 ### Usage
 
-To use the Swift frontend, add the `-l swift` flag in the CLI, or use a `JPlagOption` object set to `LanguageOption.SWIFT` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
+To use the Swift frontend, add the `-l swift` flag in the CLI, or use a `JPlagOption` object with `new de.jplag.swift.Language()` as `language` in the Java API as described in the usage information in the [readme of the main project](https://github.com/jplag/JPlag#usage) and [in the wiki](https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag).
 
 <br>
 


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

The documentation of how to use a specific language module seems to be outdated. `LanguageOption` does not exist anymore, and the `JPlagOptions` has a `language` component instead.

I updated all readmes from language modules. `LanguageOption` also seems to be referenced in the readme in `endtoend-testing`, however I don't know what the exact replacement would be there, so I left that out.

I'm not sure if you want this to target `develop` or `main`, so let me know if you want me to change it.
