### PR TITLE
Report viewer: Allow loading results by URL

### DIFF
--- a/report-viewer/src/utils/Utils.ts
+++ b/report-viewer/src/utils/Utils.ts
@@ -7,15 +7,3 @@
 export function generateLineCodeLink(index: number, fileName: string, line: number): string {
     return String(index).concat(fileName).concat(String(line))
 }
-
-/**
- * Get the extension of a given file.
- * @param file The file.
- */
-export function getFileExtension(file: File): string {
-    if (file.name.includes(".")) {
-        const split = file.name.split(".")
-        return split[split.length - 1]
-    }
-    return "";
-}

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -5,28 +5,35 @@
   <div class="container" @dragover.prevent @drop.prevent="uploadFile">
     <img alt="JPlag" src="@/assets/logo-nobg.png" />
     <h1>JPlag Report Viewer</h1>
-    <h2>Select an overview or comparison file or a zip to display.</h2>
-    <h3>(No files get uploaded anywhere)</h3>
-    <div class="drop-container">
-      <p>Drop a .json or .zip on this page</p>
+    <div v-if="!hasQueryFile">
+      <h2>Select an overview or comparison file or a zip to display.</h2>
+      <h3>(No files get uploaded anywhere)</h3>
+      <div class="drop-container">
+        <p>Drop a .json or .zip on this page</p>
+      </div>
+      <div v-if="hasLocalFile" class="local-files-container">
+        <p class="local-files-text">Detected local files!</p>
+        <button class="local-files-button" @click="continueWithLocal">
+          Continue with local files
+        </button>
+      </div>
     </div>
-    <div v-if="hasLocalFile" class="local-files-container">
-      <p class="local-files-text">Detected local files!</p>
-      <button class="local-files-button" @click="continueWithLocal">
-        Continue with local files
-      </button>
-    </div>
+    <p v-else>
+      Loading file…
+    </p>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { useRoute } from "vue-router";
 import jszip from "jszip";
 import router from "@/router";
 import store from "@/store/store";
-import { getFileExtension } from "@/utils/Utils";
 import path from "path";
 import slash from "slash";
+
+class LoadError extends Error {}
 
 export default defineComponent({
   name: "FileUploadView",
@@ -39,6 +46,22 @@ export default defineComponent({
     } catch (e) {
       console.log(e);
       hasLocalFile = false;
+    }
+
+    // Loads file passed in query param, if any.
+    const queryParams = useRoute().query;
+    let queryFileURL = null;
+    if (typeof queryParams.file === 'string' && queryParams.file !== '') {
+      try {
+        queryFileURL = new URL(queryParams.file);
+      } catch (e) {
+        if (e instanceof TypeError) {
+          console.warn(`Invalid URL '${queryParams.file}'`)
+          queryFileURL = null;
+        } else {
+          throw e;
+        }
+      }
     }
 
     const navigateToOverview = () => {
@@ -93,8 +116,8 @@ export default defineComponent({
      * Handles zip file on drop. It extracts the zip and saves each file in the store.
      * @param file
      */
-    const handleZipFile = (file: File) => {
-      jszip.loadAsync(file).then(async (zip) => {
+    const handleZipFile = (file: Blob) => {
+      return jszip.loadAsync(file).then(async (zip) => {
         for (const originalFileName of Object.keys(zip.files)) {
           const unixFileName = slash(originalFileName);
           if (
@@ -148,32 +171,53 @@ export default defineComponent({
           fileString: str,
         });
         navigateToComparisonView(json["id1"], json["id2"]);
+      } else {
+        throw new LoadError('Invalid JSON', json);
       }
     };
+    const handleFile = (file: Blob) => {
+      switch (file.type) {
+        case "application/zip":
+          return handleZipFile(file);
+        case "application/json":
+          return file.text().then(handleJsonFile);
+        default:
+          throw new LoadError(`Unknown MIME type '${file.type}'`);
+      }
+    }
     /**
      * Handles file drop.
      * @param e
      */
-    const uploadFile = (e: DragEvent) => {
+    const uploadFile = async (e: DragEvent) => {
       let dropped = e.dataTransfer?.files;
-      if (!dropped) return; // TODO add some kind of error message
-      let files = [...dropped];
-      if (files.length > 1 || files.length === 0) return;
-      let read = new FileReader();
-      read.onload = (e) => {
-        let extension = getFileExtension(files[0]);
-        if (extension === "zip") {
-          handleZipFile(files[0]);
-        } else if (extension === "json") {
-          let file = e.target?.result;
-          if (!file) return;
-          if (typeof file === "string") {
-            handleJsonFile(file);
-          }
+      try {
+        if (dropped?.length === 1) {
+          await handleFile(dropped[0]);
+        } else {
+          throw new LoadError('Not exactly one file');
         }
-      };
-      read.readAsText(files[0]);
+      } catch (e) {
+        if (e instanceof LoadError) {
+          console.warn(e);
+          alert(e.message);
+        } else {
+          throw e;
+        }
+      }
     };
+    const loadQueryFile = async (url: URL) => {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new LoadError('Response not OK');
+        }
+        await handleFile(await response.blob());
+      } catch (e) {
+        console.warn(e);
+        alert(e);
+      }
+    }
     /**
      * Handles click on Continue with local files.
      */
@@ -186,10 +230,16 @@ export default defineComponent({
       });
       navigateToOverview();
     };
+
+    if (queryFileURL !== null) {
+      loadQueryFile(queryFileURL);
+    }
+
     return {
       continueWithLocal,
       uploadFile,
       hasLocalFile,
+      hasQueryFile: queryFileURL !== null,
     };
   },
 });


### PR DESCRIPTION
When integrating with other software ([TMS](https://gitlab.com/tms-elte) in my case), it’s useful to be able to send users to a URL that will automatically load the results, without having to recompile the report viewer on the live server every time (to make use of overview.json). This pull request introduces a new `file` query parameter, which, if provided, makes the report viewer load the results from the given URL. Similarly to the drag-and-drop upload, the URL can point to both ZIPs and JSONs; since the URL may not have an appropriate extension, let the browser figure out the type based on the HTTP headers. Browsers can figure out the MIME type of drag-and-drop files as well (usually based on the extension), so migrate also the drag-and-drop to MIME-based type determination, dropping the `getFileExtension` function. Also improve error handling: instead of just logging to the browser console, present the error using `alert` – not a five-star UX, but still much better than nothing.

<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
