### PR TITLE
Prevent extraction of superfluous block tokens by the Java language module

### DIFF
--- a/core/src/test/java/de/jplag/BaseCodeTest.java
+++ b/core/src/test/java/de/jplag/BaseCodeTest.java
@@ -47,7 +47,7 @@ public class BaseCodeTest extends TestBase {
         assertEquals(1, result.getAllComparisons().size());
         assertEquals(1, result.getAllComparisons().get(0).matches().size());
         assertEquals(1, result.getSimilarityDistribution()[8]);
-        assertEquals(0.85, result.getAllComparisons().get(0).similarity(), DELTA);
+        assertEquals(0.8125, result.getAllComparisons().get(0).similarity(), DELTA);
     }
 
     @Test
@@ -94,8 +94,8 @@ public class BaseCodeTest extends TestBase {
         assertEquals(submissions, result.getNumberOfSubmissions());
         assertEquals(comparisons, result.getAllComparisons().size());
         assertEquals(1, result.getAllComparisons().get(0).matches().size());
-        assertEquals(1, result.getSimilarityDistribution()[6]);
-        assertEquals(0.6451, result.getAllComparisons().get(0).similarity(), DELTA);
+        assertEquals(1, result.getSimilarityDistribution()[9]);
+        assertEquals(0.9473, result.getAllComparisons().get(0).similarity(), DELTA);
     }
 
     private void hasSubdirectoryRoot(Submission submission) {

--- a/core/src/test/java/de/jplag/BasicFunctionalityTest.java
+++ b/core/src/test/java/de/jplag/BasicFunctionalityTest.java
@@ -23,20 +23,20 @@ class BasicFunctionalityTest extends TestBase {
         assertEquals(1, result.getAllComparisons().size());
         assertEquals(1, result.getAllComparisons().get(0).matches().size());
         assertEquals(1, result.getSimilarityDistribution()[6]);
-        assertEquals(0.6451, result.getAllComparisons().get(0).similarity(), DELTA);
+        assertEquals(0.666, result.getAllComparisons().get(0).similarity(), DELTA);
     }
 
     @Test
     @DisplayName("test submissions with a custom minimum token match")
     void testWithMinTokenMatch() throws ExitException {
         var expectedDistribution = new int[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-        JPlagResult result = runJPlag("SimpleDuplicate", it -> it.withMinimumTokenMatch(5));
+        JPlagResult result = runJPlag("SimpleDuplicate", it -> it.withMinimumTokenMatch(4));
 
         assertEquals(2, result.getNumberOfSubmissions());
         assertEquals(1, result.getAllComparisons().size());
         assertEquals(2, result.getAllComparisons().get(0).matches().size());
         assertArrayEquals(expectedDistribution, result.getSimilarityDistribution());
-        assertEquals(0.9677, result.getAllComparisons().get(0).similarity(), DELTA);
+        assertEquals(0.9629, result.getAllComparisons().get(0).similarity(), DELTA);
     }
 
     @Test
@@ -69,18 +69,18 @@ class BasicFunctionalityTest extends TestBase {
                 .forEach(comparison -> assertEquals(0, comparison.similarity(), DELTA));
 
         // Hard coded assertions on selected comparisons
-        assertEquals(0.242, getSelectedPercent(result, "A", "B"), DELTA);
-        assertEquals(0.997, getSelectedPercent(result, "A", "C"), DELTA);
-        assertEquals(0.770, getSelectedPercent(result, "A", "D"), DELTA);
-        assertEquals(0.242, getSelectedPercent(result, "B", "C"), DELTA);
-        assertEquals(0.285, getSelectedPercent(result, "B", "D"), DELTA);
-        assertEquals(0.770, getSelectedPercent(result, "C", "D"), DELTA);
+        assertEquals(0.238, getSelectedPercent(result, "A", "B"), DELTA);
+        assertEquals(0.996, getSelectedPercent(result, "A", "C"), DELTA);
+        assertEquals(0.748, getSelectedPercent(result, "A", "D"), DELTA);
+        assertEquals(0.238, getSelectedPercent(result, "B", "C"), DELTA);
+        assertEquals(0.283, getSelectedPercent(result, "B", "D"), DELTA);
+        assertEquals(0.748, getSelectedPercent(result, "C", "D"), DELTA);
 
         // More detailed assertions for the plagiarism in A-D
         var biggestMatch = getSelectedComparison(result, "A", "D");
-        assertEquals(0.964, biggestMatch.get().maximalSimilarity(), DELTA);
-        assertEquals(0.641, biggestMatch.get().minimalSimilarity(), DELTA);
-        assertEquals(12, biggestMatch.get().matches().size());
+        assertEquals(0.946, biggestMatch.get().maximalSimilarity(), DELTA);
+        assertEquals(0.619, biggestMatch.get().minimalSimilarity(), DELTA);
+        assertEquals(11, biggestMatch.get().matches().size());
     }
 
     @Test
@@ -91,7 +91,7 @@ class BasicFunctionalityTest extends TestBase {
         assertEquals(2, result.getNumberOfSubmissions());
         assertEquals(1, result.getAllComparisons().size());
         assertEquals(1, result.getSimilarityDistribution()[6]);
-        assertEquals(0.6451, result.getAllComparisons().get(0).similarity(), DELTA);
+        assertEquals(0.666, result.getAllComparisons().get(0).similarity(), DELTA);
 
         var matches = result.getAllComparisons().get(0).matches();
         // Run JPlag for same files but in submission folders:

--- a/core/src/test/resources/de/jplag/samples/NoDuplicate/B/NoDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/NoDuplicate/B/NoDuplicate.java
@@ -1,5 +1,10 @@
+import java.util.Arrays;
+
 public class NoDuplicate {
     public static void main(String[] args) {
         System.out.println("Hello World!");
+        if (args != null) {
+            System.out.println(Arrays.toString(args));
+        }
     }
 }

--- a/core/src/test/resources/de/jplag/samples/PartialPlagiarism/E/WhatAmIDoingHere.java
+++ b/core/src/test/resources/de/jplag/samples/PartialPlagiarism/E/WhatAmIDoingHere.java
@@ -1,5 +1,10 @@
+import java.util.Arrays;
+
 public class WhatAmIDoingHere {
     public static void main(String[] args) {
         System.out.println("Hello JPlag!");
+        if (args != null) {
+            System.out.println(Arrays.toString(args));
+        }
     }
 }

--- a/core/src/test/resources/de/jplag/samples/SimpleDuplicate/A/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SimpleDuplicate/A/SimpleDuplicate.java
@@ -3,9 +3,12 @@ public class SimpleDuplicate {
     public static void main(String[] args) {
         System.out.println("Hello World!");
 
-        for(int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
             System.out.println("Number is " + i);
         }
+
+        String message = "How are you?";
+        System.out.println(message);
     }
 
 }

--- a/core/src/test/resources/de/jplag/samples/SimpleDuplicate/B/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SimpleDuplicate/B/SimpleDuplicate.java
@@ -4,9 +4,12 @@ public class SimpleDuplicate {
         System.out.println("Hello Plagiarism!");
 
         int max = 10;
-        for(int j = 0; j < max; j++) {
+        for (int j = 0; j < max; j++) {
             System.out.println("Number is " + j);
         }
+
+        String msg = "How r u?";
+        System.out.println(msg);
     }
 
 }

--- a/core/src/test/resources/de/jplag/samples/SimpleSingleFile/SimpleDuplicateA.java
+++ b/core/src/test/resources/de/jplag/samples/SimpleSingleFile/SimpleDuplicateA.java
@@ -3,9 +3,12 @@ public class SimpleDuplicate {
     public static void main(String[] args) {
         System.out.println("Hello World!");
 
-        for(int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
             System.out.println("Number is " + i);
         }
+
+        String message = "How are you?";
+        System.out.println(message);
     }
 
 }

--- a/core/src/test/resources/de/jplag/samples/SimpleSingleFile/SimpleDuplicateB.java
+++ b/core/src/test/resources/de/jplag/samples/SimpleSingleFile/SimpleDuplicateB.java
@@ -4,9 +4,12 @@ public class SimpleDuplicate {
         System.out.println("Hello Plagiarism!");
 
         int max = 10;
-        for(int j = 0; j < max; j++) {
+        for (int j = 0; j < max; j++) {
             System.out.println("Number is " + j);
         }
+
+        String msg = "How r you?";
+        System.out.println(msg);
     }
 
 }

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryBase/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryBase/src/SimpleDuplicate.java
@@ -1,7 +1,12 @@
+import java.util.Arrays;
+
 public class SimpleDuplicate {
 
     public static void main(String[] args) {
         System.out.println("Hello World!");
+        if (args != null) {
+            System.out.println(Arrays.toString(args));
+        }
     }
 
 }

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/A/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/A/src/SimpleDuplicate.java
@@ -1,11 +1,18 @@
+import java.util.Arrays;
+
 public class SimpleDuplicate {
 
     public static void main(String[] args) {
         System.out.println("Hello World!");
+        if (args != null) {
+            System.out.println(Arrays.toString(args));
+        }
 
-        for(int i = 0; i < 10; i++) {
+        for (int i = 0; i < 10; i++) {
             System.out.println("Number is " + i);
         }
+        int msg = "how r u?";
+        System.out.println(msg);
     }
 
 }

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/B/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/B/src/SimpleDuplicate.java
@@ -1,12 +1,19 @@
+import java.util.Arrays;
+
 public class SimpleDuplicate {
 
     public static void main(String[] args) {
         System.out.println("Hello Plagiarism!");
+        if (args != null) {
+            System.out.println(Arrays.toString(args));
+        }
 
         int max = 10;
-        for(int j = 0; j < max; j++) {
+        for (int j = 0; j < max; j++) {
             System.out.println("Number is " + j);
         }
+        int message = "how are you?";
+        System.out.println(message);
     }
 
 }

--- a/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/Base/src/SimpleDuplicate.java
+++ b/core/src/test/resources/de/jplag/samples/SubdirectoryDuplicate/Base/src/SimpleDuplicate.java
@@ -1,7 +1,12 @@
+import java.util.Arrays;
+
 public class SimpleDuplicate {
 
     public static void main(String[] args) {
         System.out.println("Hello World!");
+        if (args != null) {
+            System.out.println(Arrays.toString(args));
+        }
     }
 
 }

--- a/endtoend-testing/src/test/resources/results/java/sortAlgo.json
+++ b/endtoend-testing/src/test/resources/results/java/sortAlgo.json
@@ -4,859 +4,859 @@
   },
   "tests" : {
     "SortAlgo-SortAlgo5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
     },
     "SortAlgo-SortAlgo6" : {
-      "minimal_similarity" : 0.7714285714285715,
-      "maximum_similarity" : 0.9152542372881356,
-      "matched_token_number" : 54
+      "minimal_similarity" : 0.625,
+      "maximum_similarity" : 0.7317073170731707,
+      "matched_token_number" : 30
     },
     "SortAlgo-SortAlgo7" : {
-      "minimal_similarity" : 0.7368421052631579,
-      "maximum_similarity" : 0.9491525423728814,
-      "matched_token_number" : 56
+      "minimal_similarity" : 0.6785714285714286,
+      "maximum_similarity" : 0.926829268292683,
+      "matched_token_number" : 38
     },
     "SortAlgo3_5-SortAlgo3_6" : {
-      "minimal_similarity" : 0.620253164556962,
-      "maximum_similarity" : 0.6621621621621622,
-      "matched_token_number" : 49
+      "minimal_similarity" : 0.6428571428571429,
+      "maximum_similarity" : 0.6545454545454545,
+      "matched_token_number" : 36
     },
     "SortAlgo6-SortAlgo7" : {
-      "minimal_similarity" : 0.6842105263157895,
-      "maximum_similarity" : 0.7428571428571429,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.44642857142857145,
+      "maximum_similarity" : 0.5208333333333334,
+      "matched_token_number" : 25
     },
     "SortAlgo1_3-SortAlgo7" : {
-      "minimal_similarity" : 0.7051282051282052,
-      "maximum_similarity" : 0.7236842105263158,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.5344827586206896,
+      "maximum_similarity" : 0.5535714285714286,
+      "matched_token_number" : 31
     },
     "SortAlgo1_3-SortAlgo6" : {
-      "minimal_similarity" : 0.7692307692307693,
-      "maximum_similarity" : 0.8571428571428571,
-      "matched_token_number" : 60
+      "minimal_similarity" : 0.6206896551724138,
+      "maximum_similarity" : 0.75,
+      "matched_token_number" : 36
     },
     "SortAlgo-SortAlgo1" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo1_3-SortAlgo3" : {
-      "minimal_similarity" : 0.8717948717948718,
-      "maximum_similarity" : 0.918918918918919,
-      "matched_token_number" : 68
+      "minimal_similarity" : 0.8275862068965517,
+      "maximum_similarity" : 0.8888888888888888,
+      "matched_token_number" : 48
     },
     "SortAlgo-SortAlgo2" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo1_3-SortAlgo2" : {
-      "minimal_similarity" : 0.7051282051282052,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
-    },
-    "SortAlgo-SortAlgo3" : {
-      "minimal_similarity" : 0.7432432432432432,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
-    },
-    "SortAlgo1_3-SortAlgo5" : {
-      "minimal_similarity" : 0.4358974358974359,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
-    },
-    "SortAlgo-SortAlgo4" : {
-      "minimal_similarity" : 0.8387096774193549,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
-    },
-    "SortAlgo1_3-SortAlgo4" : {
-      "minimal_similarity" : 0.6538461538461539,
-      "maximum_similarity" : 0.8225806451612904,
-      "matched_token_number" : 51
-    },
-    "SortAlgo2-SortAlgo2_5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
-    },
-    "SortAlgo1_2-SortAlgo2" : {
-      "minimal_similarity" : 0.7283950617283951,
-      "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
-    },
-    "SortAlgo1_2-SortAlgo3" : {
-      "minimal_similarity" : 0.6790123456790124,
-      "maximum_similarity" : 0.7432432432432432,
-      "matched_token_number" : 55
-    },
-    "SortAlgo5-SortAlgo6" : {
-      "minimal_similarity" : 0.5142857142857142,
-      "maximum_similarity" : 0.6101694915254238,
-      "matched_token_number" : 36
-    },
-    "SortAlgo1_2-SortAlgo4" : {
-      "minimal_similarity" : 0.7160493827160493,
-      "maximum_similarity" : 0.9354838709677419,
-      "matched_token_number" : 58
-    },
-    "SortAlgo5-SortAlgo7" : {
-      "minimal_similarity" : 0.40789473684210525,
-      "maximum_similarity" : 0.5254237288135594,
-      "matched_token_number" : 31
-    },
-    "SortAlgo1_2-SortAlgo5" : {
-      "minimal_similarity" : 0.4567901234567901,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
-    },
-    "SortAlgo1_2-SortAlgo6" : {
-      "minimal_similarity" : 0.6790123456790124,
-      "maximum_similarity" : 0.7857142857142857,
-      "matched_token_number" : 55
-    },
-    "SortAlgo1_2-SortAlgo7" : {
-      "minimal_similarity" : 0.7407407407407407,
-      "maximum_similarity" : 0.7894736842105263,
-      "matched_token_number" : 60
-    },
-    "SortAlgo1-SortAlgo2_5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
-    },
-    "SortAlgo1_3-SortAlgo3_6" : {
-      "minimal_similarity" : 0.8227848101265823,
-      "maximum_similarity" : 0.8333333333333334,
-      "matched_token_number" : 65
-    },
-    "SortAlgo4-SortAlgo5" : {
-      "minimal_similarity" : 0.532258064516129,
-      "maximum_similarity" : 0.559322033898305,
+      "minimal_similarity" : 0.5689655172413793,
+      "maximum_similarity" : 0.8048780487804879,
       "matched_token_number" : 33
     },
-    "SortAlgo4-SortAlgo6" : {
-      "minimal_similarity" : 0.6857142857142857,
-      "maximum_similarity" : 0.7741935483870968,
-      "matched_token_number" : 48
+    "SortAlgo-SortAlgo3" : {
+      "minimal_similarity" : 0.6111111111111112,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
     },
-    "SortAlgo4-SortAlgo7" : {
-      "minimal_similarity" : 0.631578947368421,
-      "maximum_similarity" : 0.7741935483870968,
-      "matched_token_number" : 48
+    "SortAlgo1_3-SortAlgo5" : {
+      "minimal_similarity" : 0.3620689655172414,
+      "maximum_similarity" : 0.4883720930232558,
+      "matched_token_number" : 21
     },
-    "SortAlgo1_4-SortAlgo3_5" : {
-      "minimal_similarity" : 0.3918918918918919,
-      "maximum_similarity" : 0.46774193548387094,
-      "matched_token_number" : 29
+    "SortAlgo-SortAlgo4" : {
+      "minimal_similarity" : 0.7380952380952381,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
-    "SortAlgo1_4-SortAlgo3_6" : {
-      "minimal_similarity" : 0.5569620253164557,
-      "maximum_similarity" : 0.7096774193548387,
+    "SortAlgo1_3-SortAlgo4" : {
+      "minimal_similarity" : 0.46551724137931033,
+      "maximum_similarity" : 0.6428571428571429,
+      "matched_token_number" : 27
+    },
+    "SortAlgo2-SortAlgo2_5" : {
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
+    },
+    "SortAlgo1_2-SortAlgo2" : {
+      "minimal_similarity" : 0.7454545454545455,
+      "maximum_similarity" : 1.0,
+      "matched_token_number" : 41
+    },
+    "SortAlgo1_2-SortAlgo3" : {
+      "minimal_similarity" : 0.6181818181818182,
+      "maximum_similarity" : 0.6296296296296297,
+      "matched_token_number" : 34
+    },
+    "SortAlgo5-SortAlgo6" : {
+      "minimal_similarity" : 0.4791666666666667,
+      "maximum_similarity" : 0.5348837209302325,
+      "matched_token_number" : 23
+    },
+    "SortAlgo1_2-SortAlgo4" : {
+      "minimal_similarity" : 0.6181818181818182,
+      "maximum_similarity" : 0.8095238095238095,
+      "matched_token_number" : 34
+    },
+    "SortAlgo5-SortAlgo7" : {
+      "minimal_similarity" : 0.3392857142857143,
+      "maximum_similarity" : 0.4418604651162791,
+      "matched_token_number" : 19
+    },
+    "SortAlgo1_2-SortAlgo5" : {
+      "minimal_similarity" : 0.4727272727272727,
+      "maximum_similarity" : 0.6046511627906976,
+      "matched_token_number" : 26
+    },
+    "SortAlgo1_2-SortAlgo6" : {
+      "minimal_similarity" : 0.5454545454545454,
+      "maximum_similarity" : 0.625,
+      "matched_token_number" : 30
+    },
+    "SortAlgo1_2-SortAlgo7" : {
+      "minimal_similarity" : 0.7857142857142857,
+      "maximum_similarity" : 0.8,
       "matched_token_number" : 44
     },
-    "SortAlgo1_5-SortAlgo3_6" : {
-      "minimal_similarity" : 0.4430379746835443,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
+    "SortAlgo1-SortAlgo2_5" : {
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
     },
-    "SortAlgo1_5-SortAlgo3_5" : {
-      "minimal_similarity" : 0.7432432432432432,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
-    },
-    "SortAlgo1_6-SortAlgo3_5" : {
-      "minimal_similarity" : 0.47297297297297297,
-      "maximum_similarity" : 0.5645161290322581,
-      "matched_token_number" : 35
-    },
-    "SortAlgo-SortAlgo4d3" : {
-      "minimal_similarity" : 0.8769230769230769,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
-    },
-    "SortAlgo1_6-SortAlgo3_6" : {
-      "minimal_similarity" : 0.7341772151898734,
-      "maximum_similarity" : 0.9354838709677419,
-      "matched_token_number" : 58
-    },
-    "SortAlgo-SortAlgo4d2" : {
-      "minimal_similarity" : 0.8507462686567164,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
-    },
-    "SortAlgo-SortAlgo4d1" : {
-      "minimal_similarity" : 0.8636363636363636,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
-    },
-    "SortAlgo1_4-SortAlgo3" : {
-      "minimal_similarity" : 0.6756756756756757,
-      "maximum_similarity" : 0.8064516129032258,
-      "matched_token_number" : 50
-    },
-    "SortAlgo3-SortAlgo3_5" : {
-      "minimal_similarity" : 0.6621621621621622,
-      "maximum_similarity" : 0.6621621621621622,
-      "matched_token_number" : 49
-    },
-    "SortAlgo1_4-SortAlgo4" : {
-      "minimal_similarity" : 0.9516129032258065,
-      "maximum_similarity" : 0.9516129032258065,
-      "matched_token_number" : 59
-    },
-    "SortAlgo3-SortAlgo3_6" : {
-      "minimal_similarity" : 0.8987341772151899,
-      "maximum_similarity" : 0.9594594594594594,
-      "matched_token_number" : 71
-    },
-    "SortAlgo1_4-SortAlgo2" : {
-      "minimal_similarity" : 0.8387096774193549,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
-    },
-    "SortAlgo1_4-SortAlgo7" : {
-      "minimal_similarity" : 0.6447368421052632,
-      "maximum_similarity" : 0.7903225806451613,
-      "matched_token_number" : 49
-    },
-    "SortAlgo2-SortAlgo3_5" : {
-      "minimal_similarity" : 0.4594594594594595,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
-    },
-    "SortAlgo1_4-SortAlgo5" : {
-      "minimal_similarity" : 0.45161290322580644,
-      "maximum_similarity" : 0.4745762711864407,
-      "matched_token_number" : 28
-    },
-    "SortAlgo2-SortAlgo3_6" : {
-      "minimal_similarity" : 0.6582278481012658,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
-    },
-    "SortAlgo1_4-SortAlgo6" : {
-      "minimal_similarity" : 0.6714285714285714,
-      "maximum_similarity" : 0.7580645161290323,
-      "matched_token_number" : 47
-    },
-    "SortAlgo1-SortAlgo3_6" : {
-      "minimal_similarity" : 0.6582278481012658,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
-    },
-    "SortAlgo1-SortAlgo3_5" : {
-      "minimal_similarity" : 0.4594594594594595,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
-    },
-    "SortAlgo-SortAlgo1_2" : {
-      "minimal_similarity" : 0.7283950617283951,
-      "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
-    },
-    "SortAlgo1_3-SortAlgo3_5" : {
-      "minimal_similarity" : 0.5769230769230769,
-      "maximum_similarity" : 0.6081081081081081,
+    "SortAlgo1_3-SortAlgo3_6" : {
+      "minimal_similarity" : 0.7758620689655172,
+      "maximum_similarity" : 0.8181818181818182,
       "matched_token_number" : 45
     },
-    "SortAlgo1_2-SortAlgo3_5" : {
-      "minimal_similarity" : 0.41975308641975306,
-      "maximum_similarity" : 0.4594594594594595,
-      "matched_token_number" : 34
+    "SortAlgo4-SortAlgo5" : {
+      "minimal_similarity" : 0.5813953488372093,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
     },
-    "SortAlgo1_2-SortAlgo3_6" : {
-      "minimal_similarity" : 0.6419753086419753,
-      "maximum_similarity" : 0.6582278481012658,
-      "matched_token_number" : 52
+    "SortAlgo4-SortAlgo6" : {
+      "minimal_similarity" : 0.4791666666666667,
+      "maximum_similarity" : 0.5476190476190477,
+      "matched_token_number" : 23
     },
-    "SortAlgo-SortAlgo1_6" : {
-      "minimal_similarity" : 0.9032258064516129,
-      "maximum_similarity" : 0.9491525423728814,
-      "matched_token_number" : 56
+    "SortAlgo4-SortAlgo7" : {
+      "minimal_similarity" : 0.5357142857142857,
+      "maximum_similarity" : 0.7142857142857143,
+      "matched_token_number" : 30
     },
-    "SortAlgo-SortAlgo1_5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
+    "SortAlgo1_4-SortAlgo3_5" : {
+      "minimal_similarity" : 0.35714285714285715,
+      "maximum_similarity" : 0.47619047619047616,
+      "matched_token_number" : 20
+    },
+    "SortAlgo1_4-SortAlgo3_6" : {
+      "minimal_similarity" : 0.509090909090909,
+      "maximum_similarity" : 0.6666666666666666,
+      "matched_token_number" : 28
+    },
+    "SortAlgo1_5-SortAlgo3_6" : {
+      "minimal_similarity" : 0.4,
+      "maximum_similarity" : 0.5116279069767442,
+      "matched_token_number" : 22
+    },
+    "SortAlgo1_5-SortAlgo3_5" : {
+      "minimal_similarity" : 0.6607142857142857,
+      "maximum_similarity" : 0.8604651162790697,
       "matched_token_number" : 37
     },
+    "SortAlgo1_6-SortAlgo3_5" : {
+      "minimal_similarity" : 0.39285714285714285,
+      "maximum_similarity" : 0.5238095238095238,
+      "matched_token_number" : 22
+    },
+    "SortAlgo-SortAlgo4d3" : {
+      "minimal_similarity" : 0.8297872340425532,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
+    },
+    "SortAlgo1_6-SortAlgo3_6" : {
+      "minimal_similarity" : 0.6181818181818182,
+      "maximum_similarity" : 0.8095238095238095,
+      "matched_token_number" : 34
+    },
+    "SortAlgo-SortAlgo4d2" : {
+      "minimal_similarity" : 0.7959183673469388,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
+    },
+    "SortAlgo-SortAlgo4d1" : {
+      "minimal_similarity" : 0.8125,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
+    },
+    "SortAlgo1_4-SortAlgo3" : {
+      "minimal_similarity" : 0.5925925925925926,
+      "maximum_similarity" : 0.7619047619047619,
+      "matched_token_number" : 32
+    },
+    "SortAlgo3-SortAlgo3_5" : {
+      "minimal_similarity" : 0.6428571428571429,
+      "maximum_similarity" : 0.6666666666666666,
+      "matched_token_number" : 36
+    },
+    "SortAlgo1_4-SortAlgo4" : {
+      "minimal_similarity" : 0.9523809523809523,
+      "maximum_similarity" : 0.9523809523809523,
+      "matched_token_number" : 40
+    },
+    "SortAlgo3-SortAlgo3_6" : {
+      "minimal_similarity" : 0.9272727272727272,
+      "maximum_similarity" : 0.9444444444444444,
+      "matched_token_number" : 51
+    },
+    "SortAlgo1_4-SortAlgo2" : {
+      "minimal_similarity" : 0.7857142857142857,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
+    },
+    "SortAlgo1_4-SortAlgo7" : {
+      "minimal_similarity" : 0.5178571428571429,
+      "maximum_similarity" : 0.6904761904761905,
+      "matched_token_number" : 29
+    },
+    "SortAlgo1_4-SortAlgo5" : {
+      "minimal_similarity" : 0.5348837209302325,
+      "maximum_similarity" : 0.5476190476190477,
+      "matched_token_number" : 23
+    },
+    "SortAlgo2-SortAlgo3_5" : {
+      "minimal_similarity" : 0.375,
+      "maximum_similarity" : 0.5121951219512195,
+      "matched_token_number" : 21
+    },
+    "SortAlgo1_4-SortAlgo6" : {
+      "minimal_similarity" : 0.6041666666666666,
+      "maximum_similarity" : 0.6904761904761905,
+      "matched_token_number" : 29
+    },
+    "SortAlgo2-SortAlgo3_6" : {
+      "minimal_similarity" : 0.4727272727272727,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
+    },
+    "SortAlgo1-SortAlgo3_6" : {
+      "minimal_similarity" : 0.4727272727272727,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
+    },
+    "SortAlgo1-SortAlgo3_5" : {
+      "minimal_similarity" : 0.375,
+      "maximum_similarity" : 0.5121951219512195,
+      "matched_token_number" : 21
+    },
+    "SortAlgo-SortAlgo1_2" : {
+      "minimal_similarity" : 0.7454545454545455,
+      "maximum_similarity" : 1.0,
+      "matched_token_number" : 41
+    },
+    "SortAlgo1_3-SortAlgo3_5" : {
+      "minimal_similarity" : 0.5172413793103449,
+      "maximum_similarity" : 0.5357142857142857,
+      "matched_token_number" : 30
+    },
+    "SortAlgo1_2-SortAlgo3_5" : {
+      "minimal_similarity" : 0.375,
+      "maximum_similarity" : 0.38181818181818183,
+      "matched_token_number" : 21
+    },
+    "SortAlgo1_2-SortAlgo3_6" : {
+      "minimal_similarity" : 0.5818181818181818,
+      "maximum_similarity" : 0.5818181818181818,
+      "matched_token_number" : 32
+    },
+    "SortAlgo-SortAlgo1_6" : {
+      "minimal_similarity" : 0.8095238095238095,
+      "maximum_similarity" : 0.8292682926829268,
+      "matched_token_number" : 34
+    },
+    "SortAlgo-SortAlgo1_5" : {
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
+    },
     "SortAlgo-SortAlgo1_4" : {
-      "minimal_similarity" : 0.8387096774193549,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.7857142857142857,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
     },
     "SortAlgo-SortAlgo1_3" : {
-      "minimal_similarity" : 0.7051282051282052,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.5689655172413793,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
     },
     "SortAlgo1_6-SortAlgo4d1" : {
-      "minimal_similarity" : 0.803030303030303,
-      "maximum_similarity" : 0.8548387096774194,
-      "matched_token_number" : 53
+      "minimal_similarity" : 0.6458333333333334,
+      "maximum_similarity" : 0.7380952380952381,
+      "matched_token_number" : 31
     },
     "SortAlgo4d2-SortAlgo7" : {
-      "minimal_similarity" : 0.6973684210526315,
-      "maximum_similarity" : 0.7910447761194029,
-      "matched_token_number" : 53
+      "minimal_similarity" : 0.6428571428571429,
+      "maximum_similarity" : 0.7346938775510204,
+      "matched_token_number" : 36
     },
     "SortAlgo1_6-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7910447761194029,
-      "maximum_similarity" : 0.8548387096774194,
-      "matched_token_number" : 53
+      "minimal_similarity" : 0.6326530612244898,
+      "maximum_similarity" : 0.7380952380952381,
+      "matched_token_number" : 31
     },
     "SortAlgo4d2-SortAlgo5" : {
-      "minimal_similarity" : 0.5223880597014925,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
+      "minimal_similarity" : 0.4897959183673469,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
     },
     "SortAlgo4d2-SortAlgo6" : {
-      "minimal_similarity" : 0.7571428571428571,
-      "maximum_similarity" : 0.7910447761194029,
-      "matched_token_number" : 53
+      "minimal_similarity" : 0.6326530612244898,
+      "maximum_similarity" : 0.6458333333333334,
+      "matched_token_number" : 31
     },
     "SortAlgo1_6-SortAlgo4d3" : {
-      "minimal_similarity" : 0.8153846153846154,
-      "maximum_similarity" : 0.8548387096774194,
-      "matched_token_number" : 53
+      "minimal_similarity" : 0.6595744680851063,
+      "maximum_similarity" : 0.7380952380952381,
+      "matched_token_number" : 31
     },
     "SortAlgo1_5-SortAlgo2_5" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 43
     },
     "SortAlgo1_3-SortAlgo4d3" : {
-      "minimal_similarity" : 0.7948717948717948,
-      "maximum_similarity" : 0.9538461538461539,
-      "matched_token_number" : 62
-    },
-    "SortAlgo2-SortAlgo3" : {
-      "minimal_similarity" : 0.7432432432432432,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.7241379310344828,
+      "maximum_similarity" : 0.8936170212765957,
+      "matched_token_number" : 42
     },
     "SortAlgo1_2-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7037037037037037,
-      "maximum_similarity" : 0.8636363636363636,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.7090909090909091,
+      "maximum_similarity" : 0.8125,
+      "matched_token_number" : 39
     },
-    "SortAlgo2-SortAlgo4" : {
-      "minimal_similarity" : 0.8387096774193549,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
-    },
-    "SortAlgo1_3-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7692307692307693,
-      "maximum_similarity" : 0.8955223880597015,
-      "matched_token_number" : 60
+    "SortAlgo2-SortAlgo3" : {
+      "minimal_similarity" : 0.6111111111111112,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
     },
     "SortAlgo1_2-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7037037037037037,
-      "maximum_similarity" : 0.8507462686567164,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.7090909090909091,
+      "maximum_similarity" : 0.7959183673469388,
+      "matched_token_number" : 39
+    },
+    "SortAlgo1_3-SortAlgo4d2" : {
+      "minimal_similarity" : 0.6896551724137931,
+      "maximum_similarity" : 0.8163265306122449,
+      "matched_token_number" : 40
+    },
+    "SortAlgo2-SortAlgo4" : {
+      "minimal_similarity" : 0.7380952380952381,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo1_6-SortAlgo2_5" : {
-      "minimal_similarity" : 0.6129032258064516,
-      "maximum_similarity" : 0.6440677966101694,
-      "matched_token_number" : 38
+      "minimal_similarity" : 0.627906976744186,
+      "maximum_similarity" : 0.6428571428571429,
+      "matched_token_number" : 27
     },
     "SortAlgo1_4-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7878787878787878,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.6458333333333334,
+      "maximum_similarity" : 0.7380952380952381,
+      "matched_token_number" : 31
     },
     "SortAlgo1_5-SortAlgo4d3" : {
-      "minimal_similarity" : 0.5384615384615384,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
+      "minimal_similarity" : 0.5106382978723404,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
     },
     "SortAlgo1_4-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7761194029850746,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.6326530612244898,
+      "maximum_similarity" : 0.7380952380952381,
+      "matched_token_number" : 31
     },
     "SortAlgo1_5-SortAlgo4d2" : {
-      "minimal_similarity" : 0.5223880597014925,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
+      "minimal_similarity" : 0.4897959183673469,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
     },
     "SortAlgo1_4-SortAlgo4d3" : {
-      "minimal_similarity" : 0.8,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.6595744680851063,
+      "maximum_similarity" : 0.7380952380952381,
+      "matched_token_number" : 31
     },
     "SortAlgo1_5-SortAlgo4d1" : {
-      "minimal_similarity" : 0.5303030303030303,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
     },
     "SortAlgo4d2-SortAlgo4d3" : {
-      "minimal_similarity" : 0.9402985074626866,
-      "maximum_similarity" : 0.9692307692307692,
-      "matched_token_number" : 63
+      "minimal_similarity" : 0.9183673469387755,
+      "maximum_similarity" : 0.9574468085106383,
+      "matched_token_number" : 45
     },
     "SortAlgo2-SortAlgo7" : {
-      "minimal_similarity" : 0.7368421052631579,
-      "maximum_similarity" : 0.9491525423728814,
-      "matched_token_number" : 56
+      "minimal_similarity" : 0.6785714285714286,
+      "maximum_similarity" : 0.926829268292683,
+      "matched_token_number" : 38
     },
     "SortAlgo4d1-SortAlgo4d2" : {
-      "minimal_similarity" : 0.9850746268656716,
+      "minimal_similarity" : 0.9795918367346939,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 66
-    },
-    "SortAlgo1_3-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7692307692307693,
-      "maximum_similarity" : 0.9090909090909091,
-      "matched_token_number" : 60
+      "matched_token_number" : 48
     },
     "SortAlgo1_2-SortAlgo4d3" : {
-      "minimal_similarity" : 0.7037037037037037,
-      "maximum_similarity" : 0.8769230769230769,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.7090909090909091,
+      "maximum_similarity" : 0.8297872340425532,
+      "matched_token_number" : 39
+    },
+    "SortAlgo1_3-SortAlgo4d1" : {
+      "minimal_similarity" : 0.6896551724137931,
+      "maximum_similarity" : 0.8333333333333334,
+      "matched_token_number" : 40
     },
     "SortAlgo2-SortAlgo5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
     },
     "SortAlgo4d1-SortAlgo4d3" : {
-      "minimal_similarity" : 0.9545454545454546,
-      "maximum_similarity" : 0.9692307692307692,
-      "matched_token_number" : 63
+      "minimal_similarity" : 0.9375,
+      "maximum_similarity" : 0.9574468085106383,
+      "matched_token_number" : 45
     },
     "SortAlgo2-SortAlgo6" : {
-      "minimal_similarity" : 0.7714285714285715,
-      "maximum_similarity" : 0.9152542372881356,
-      "matched_token_number" : 54
+      "minimal_similarity" : 0.625,
+      "maximum_similarity" : 0.7317073170731707,
+      "matched_token_number" : 30
     },
     "SortAlgo1_6-SortAlgo7" : {
-      "minimal_similarity" : 0.6578947368421053,
-      "maximum_similarity" : 0.8064516129032258,
-      "matched_token_number" : 50
-    },
-    "SortAlgo3_6-SortAlgo6" : {
-      "minimal_similarity" : 0.8607594936708861,
-      "maximum_similarity" : 0.9714285714285714,
-      "matched_token_number" : 68
-    },
-    "SortAlgo2_5-SortAlgo3_5" : {
-      "minimal_similarity" : 0.7432432432432432,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
-    },
-    "SortAlgo3_6-SortAlgo5" : {
-      "minimal_similarity" : 0.4430379746835443,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
-    },
-    "SortAlgo2_5-SortAlgo3_6" : {
-      "minimal_similarity" : 0.4430379746835443,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
-    },
-    "SortAlgo3_6-SortAlgo7" : {
-      "minimal_similarity" : 0.6329113924050633,
-      "maximum_similarity" : 0.6578947368421053,
-      "matched_token_number" : 50
-    },
-    "SortAlgo4d3-SortAlgo6" : {
-      "minimal_similarity" : 0.7571428571428571,
-      "maximum_similarity" : 0.8153846153846154,
-      "matched_token_number" : 53
-    },
-    "SortAlgo4d3-SortAlgo7" : {
-      "minimal_similarity" : 0.6973684210526315,
-      "maximum_similarity" : 0.8153846153846154,
-      "matched_token_number" : 53
-    },
-    "SortAlgo4d3-SortAlgo5" : {
-      "minimal_similarity" : 0.5384615384615384,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
-    },
-    "SortAlgo1_4-SortAlgo2_5" : {
-      "minimal_similarity" : 0.45161290322580644,
-      "maximum_similarity" : 0.4745762711864407,
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.6666666666666666,
       "matched_token_number" : 28
     },
+    "SortAlgo3_6-SortAlgo6" : {
+      "minimal_similarity" : 0.8,
+      "maximum_similarity" : 0.9166666666666666,
+      "matched_token_number" : 44
+    },
+    "SortAlgo2_5-SortAlgo3_5" : {
+      "minimal_similarity" : 0.6607142857142857,
+      "maximum_similarity" : 0.8604651162790697,
+      "matched_token_number" : 37
+    },
+    "SortAlgo3_6-SortAlgo5" : {
+      "minimal_similarity" : 0.4,
+      "maximum_similarity" : 0.5116279069767442,
+      "matched_token_number" : 22
+    },
+    "SortAlgo2_5-SortAlgo3_6" : {
+      "minimal_similarity" : 0.4,
+      "maximum_similarity" : 0.5116279069767442,
+      "matched_token_number" : 22
+    },
+    "SortAlgo3_6-SortAlgo7" : {
+      "minimal_similarity" : 0.42857142857142855,
+      "maximum_similarity" : 0.43636363636363634,
+      "matched_token_number" : 24
+    },
+    "SortAlgo4d3-SortAlgo6" : {
+      "minimal_similarity" : 0.6458333333333334,
+      "maximum_similarity" : 0.6595744680851063,
+      "matched_token_number" : 31
+    },
+    "SortAlgo4d3-SortAlgo7" : {
+      "minimal_similarity" : 0.6428571428571429,
+      "maximum_similarity" : 0.7659574468085106,
+      "matched_token_number" : 36
+    },
+    "SortAlgo4d3-SortAlgo5" : {
+      "minimal_similarity" : 0.5106382978723404,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
+    },
+    "SortAlgo1_4-SortAlgo2_5" : {
+      "minimal_similarity" : 0.5348837209302325,
+      "maximum_similarity" : 0.5476190476190477,
+      "matched_token_number" : 23
+    },
     "SortAlgo1-SortAlgo4" : {
-      "minimal_similarity" : 0.8387096774193549,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.7380952380952381,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo1-SortAlgo5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
     },
     "SortAlgo1-SortAlgo2" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo3_6-SortAlgo4" : {
-      "minimal_similarity" : 0.5822784810126582,
-      "maximum_similarity" : 0.7419354838709677,
-      "matched_token_number" : 46
+      "minimal_similarity" : 0.45454545454545453,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
     },
     "SortAlgo1-SortAlgo3" : {
-      "minimal_similarity" : 0.7432432432432432,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.6111111111111112,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
     },
     "SortAlgo1_3-SortAlgo2_5" : {
-      "minimal_similarity" : 0.4358974358974359,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
+      "minimal_similarity" : 0.3620689655172414,
+      "maximum_similarity" : 0.4883720930232558,
+      "matched_token_number" : 21
     },
     "SortAlgo1_6-SortAlgo2" : {
-      "minimal_similarity" : 0.9032258064516129,
-      "maximum_similarity" : 0.9491525423728814,
-      "matched_token_number" : 56
+      "minimal_similarity" : 0.8095238095238095,
+      "maximum_similarity" : 0.8292682926829268,
+      "matched_token_number" : 34
     },
     "SortAlgo1-SortAlgo6" : {
-      "minimal_similarity" : 0.7714285714285715,
-      "maximum_similarity" : 0.9152542372881356,
-      "matched_token_number" : 54
+      "minimal_similarity" : 0.625,
+      "maximum_similarity" : 0.7317073170731707,
+      "matched_token_number" : 30
     },
     "SortAlgo1-SortAlgo7" : {
-      "minimal_similarity" : 0.7368421052631579,
-      "maximum_similarity" : 0.9491525423728814,
-      "matched_token_number" : 56
-    },
-    "SortAlgo1_2-SortAlgo2_5" : {
-      "minimal_similarity" : 0.4567901234567901,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
-    },
-    "SortAlgo1_6-SortAlgo6" : {
-      "minimal_similarity" : 0.8571428571428571,
-      "maximum_similarity" : 0.967741935483871,
-      "matched_token_number" : 60
-    },
-    "SortAlgo-SortAlgo2_5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
-    },
-    "SortAlgo1_6-SortAlgo5" : {
-      "minimal_similarity" : 0.6129032258064516,
-      "maximum_similarity" : 0.6440677966101694,
+      "minimal_similarity" : 0.6785714285714286,
+      "maximum_similarity" : 0.926829268292683,
       "matched_token_number" : 38
     },
+    "SortAlgo1_2-SortAlgo2_5" : {
+      "minimal_similarity" : 0.4727272727272727,
+      "maximum_similarity" : 0.6046511627906976,
+      "matched_token_number" : 26
+    },
+    "SortAlgo1_6-SortAlgo6" : {
+      "minimal_similarity" : 0.7916666666666666,
+      "maximum_similarity" : 0.9047619047619048,
+      "matched_token_number" : 38
+    },
+    "SortAlgo-SortAlgo2_5" : {
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
+    },
+    "SortAlgo1_6-SortAlgo5" : {
+      "minimal_similarity" : 0.627906976744186,
+      "maximum_similarity" : 0.6428571428571429,
+      "matched_token_number" : 27
+    },
     "SortAlgo1_6-SortAlgo4" : {
-      "minimal_similarity" : 0.8064516129032258,
-      "maximum_similarity" : 0.8064516129032258,
-      "matched_token_number" : 50
+      "minimal_similarity" : 0.6428571428571429,
+      "maximum_similarity" : 0.6428571428571429,
+      "matched_token_number" : 27
     },
     "SortAlgo1_6-SortAlgo3" : {
-      "minimal_similarity" : 0.7027027027027027,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.48148148148148145,
+      "maximum_similarity" : 0.6190476190476191,
+      "matched_token_number" : 26
     },
     "SortAlgo1_5-SortAlgo6" : {
-      "minimal_similarity" : 0.5142857142857142,
-      "maximum_similarity" : 0.6101694915254238,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.4791666666666667,
+      "maximum_similarity" : 0.5348837209302325,
+      "matched_token_number" : 23
     },
     "SortAlgo2_5-SortAlgo7" : {
-      "minimal_similarity" : 0.40789473684210525,
-      "maximum_similarity" : 0.5254237288135594,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.3392857142857143,
+      "maximum_similarity" : 0.4418604651162791,
+      "matched_token_number" : 19
     },
     "SortAlgo1_5-SortAlgo7" : {
-      "minimal_similarity" : 0.40789473684210525,
-      "maximum_similarity" : 0.5254237288135594,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.3392857142857143,
+      "maximum_similarity" : 0.4418604651162791,
+      "matched_token_number" : 19
     },
     "SortAlgo1-SortAlgo4d3" : {
-      "minimal_similarity" : 0.8769230769230769,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.8297872340425532,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
     },
     "SortAlgo1_5-SortAlgo4" : {
-      "minimal_similarity" : 0.532258064516129,
-      "maximum_similarity" : 0.559322033898305,
-      "matched_token_number" : 33
+      "minimal_similarity" : 0.5813953488372093,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
     },
     "SortAlgo1_5-SortAlgo5" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 43
     },
     "SortAlgo1-SortAlgo4d2" : {
-      "minimal_similarity" : 0.8507462686567164,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.7959183673469388,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
     },
     "SortAlgo1-SortAlgo4d1" : {
-      "minimal_similarity" : 0.8636363636363636,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.8125,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
     },
     "SortAlgo1_5-SortAlgo2" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
     },
     "SortAlgo3_5-SortAlgo6" : {
-      "minimal_similarity" : 0.6081081081081081,
-      "maximum_similarity" : 0.6428571428571429,
-      "matched_token_number" : 45
-    },
-    "SortAlgo1_5-SortAlgo3" : {
-      "minimal_similarity" : 0.4594594594594595,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
-    },
-    "SortAlgo3_5-SortAlgo7" : {
-      "minimal_similarity" : 0.42105263157894735,
-      "maximum_similarity" : 0.43243243243243246,
+      "minimal_similarity" : 0.5714285714285714,
+      "maximum_similarity" : 0.6666666666666666,
       "matched_token_number" : 32
     },
+    "SortAlgo1_5-SortAlgo3" : {
+      "minimal_similarity" : 0.3888888888888889,
+      "maximum_similarity" : 0.4883720930232558,
+      "matched_token_number" : 21
+    },
+    "SortAlgo3_5-SortAlgo7" : {
+      "minimal_similarity" : 0.26785714285714285,
+      "maximum_similarity" : 0.26785714285714285,
+      "matched_token_number" : 15
+    },
     "SortAlgo3-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7837837837837838,
-      "maximum_similarity" : 0.8787878787878788,
-      "matched_token_number" : 58
+      "minimal_similarity" : 0.7407407407407407,
+      "maximum_similarity" : 0.8333333333333334,
+      "matched_token_number" : 40
     },
     "SortAlgo3-SortAlgo4d3" : {
-      "minimal_similarity" : 0.7837837837837838,
-      "maximum_similarity" : 0.8923076923076924,
-      "matched_token_number" : 58
+      "minimal_similarity" : 0.7407407407407407,
+      "maximum_similarity" : 0.851063829787234,
+      "matched_token_number" : 40
     },
     "SortAlgo3-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7837837837837838,
-      "maximum_similarity" : 0.8656716417910447,
-      "matched_token_number" : 58
+      "minimal_similarity" : 0.7407407407407407,
+      "maximum_similarity" : 0.8163265306122449,
+      "matched_token_number" : 40
     },
     "SortAlgo2-SortAlgo4d3" : {
-      "minimal_similarity" : 0.8769230769230769,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.8297872340425532,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
     },
     "SortAlgo2-SortAlgo4d1" : {
-      "minimal_similarity" : 0.8636363636363636,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.8125,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
     },
     "SortAlgo2-SortAlgo4d2" : {
-      "minimal_similarity" : 0.8507462686567164,
-      "maximum_similarity" : 0.9661016949152542,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.7959183673469388,
+      "maximum_similarity" : 0.9512195121951219,
+      "matched_token_number" : 39
     },
     "SortAlgo1_5-SortAlgo1_6" : {
-      "minimal_similarity" : 0.6129032258064516,
-      "maximum_similarity" : 0.6440677966101694,
-      "matched_token_number" : 38
-    },
-    "SortAlgo4d1-SortAlgo7" : {
-      "minimal_similarity" : 0.6973684210526315,
-      "maximum_similarity" : 0.803030303030303,
-      "matched_token_number" : 53
-    },
-    "SortAlgo3_6-SortAlgo4d2" : {
-      "minimal_similarity" : 0.6835443037974683,
-      "maximum_similarity" : 0.8059701492537313,
-      "matched_token_number" : 54
-    },
-    "SortAlgo4d1-SortAlgo6" : {
-      "minimal_similarity" : 0.7571428571428571,
-      "maximum_similarity" : 0.803030303030303,
-      "matched_token_number" : 53
-    },
-    "SortAlgo3_6-SortAlgo4d1" : {
-      "minimal_similarity" : 0.6835443037974683,
-      "maximum_similarity" : 0.8181818181818182,
-      "matched_token_number" : 54
-    },
-    "SortAlgo4-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7878787878787878,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
-    },
-    "SortAlgo4-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7761194029850746,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
-    },
-    "SortAlgo3_6-SortAlgo4d3" : {
-      "minimal_similarity" : 0.6835443037974683,
-      "maximum_similarity" : 0.8307692307692308,
-      "matched_token_number" : 54
-    },
-    "SortAlgo4-SortAlgo4d3" : {
-      "minimal_similarity" : 0.8,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
-    },
-    "SortAlgo4d1-SortAlgo5" : {
-      "minimal_similarity" : 0.5303030303030303,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
-    },
-    "SortAlgo3_5-SortAlgo4d2" : {
-      "minimal_similarity" : 0.4864864864864865,
-      "maximum_similarity" : 0.5373134328358209,
-      "matched_token_number" : 36
-    },
-    "SortAlgo3_5-SortAlgo4" : {
-      "minimal_similarity" : 0.36486486486486486,
-      "maximum_similarity" : 0.43548387096774194,
+      "minimal_similarity" : 0.627906976744186,
+      "maximum_similarity" : 0.6428571428571429,
       "matched_token_number" : 27
     },
+    "SortAlgo4d1-SortAlgo7" : {
+      "minimal_similarity" : 0.6428571428571429,
+      "maximum_similarity" : 0.75,
+      "matched_token_number" : 36
+    },
+    "SortAlgo3_6-SortAlgo4d2" : {
+      "minimal_similarity" : 0.5818181818181818,
+      "maximum_similarity" : 0.6530612244897959,
+      "matched_token_number" : 32
+    },
+    "SortAlgo4d1-SortAlgo6" : {
+      "minimal_similarity" : 0.6458333333333334,
+      "maximum_similarity" : 0.6458333333333334,
+      "matched_token_number" : 31
+    },
+    "SortAlgo3_6-SortAlgo4d1" : {
+      "minimal_similarity" : 0.5818181818181818,
+      "maximum_similarity" : 0.6666666666666666,
+      "matched_token_number" : 32
+    },
+    "SortAlgo4-SortAlgo4d1" : {
+      "minimal_similarity" : 0.5208333333333334,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
+    },
+    "SortAlgo3_6-SortAlgo4d3" : {
+      "minimal_similarity" : 0.5818181818181818,
+      "maximum_similarity" : 0.6808510638297872,
+      "matched_token_number" : 32
+    },
+    "SortAlgo4-SortAlgo4d2" : {
+      "minimal_similarity" : 0.5102040816326531,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
+    },
+    "SortAlgo4-SortAlgo4d3" : {
+      "minimal_similarity" : 0.5319148936170213,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
+    },
+    "SortAlgo4d1-SortAlgo5" : {
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
+    },
+    "SortAlgo3_5-SortAlgo4d2" : {
+      "minimal_similarity" : 0.4107142857142857,
+      "maximum_similarity" : 0.46938775510204084,
+      "matched_token_number" : 23
+    },
+    "SortAlgo3_5-SortAlgo4" : {
+      "minimal_similarity" : 0.30357142857142855,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
+    },
     "SortAlgo3_5-SortAlgo5" : {
-      "minimal_similarity" : 0.7432432432432432,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.6607142857142857,
+      "maximum_similarity" : 0.8604651162790697,
+      "matched_token_number" : 37
     },
     "SortAlgo3_5-SortAlgo4d3" : {
-      "minimal_similarity" : 0.4864864864864865,
-      "maximum_similarity" : 0.5538461538461539,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.4107142857142857,
+      "maximum_similarity" : 0.48936170212765956,
+      "matched_token_number" : 23
     },
     "SortAlgo2_5-SortAlgo4" : {
-      "minimal_similarity" : 0.532258064516129,
-      "maximum_similarity" : 0.559322033898305,
-      "matched_token_number" : 33
+      "minimal_similarity" : 0.5813953488372093,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
     },
     "SortAlgo3_5-SortAlgo4d1" : {
-      "minimal_similarity" : 0.4864864864864865,
-      "maximum_similarity" : 0.5454545454545454,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.4107142857142857,
+      "maximum_similarity" : 0.4791666666666667,
+      "matched_token_number" : 23
     },
     "SortAlgo2_5-SortAlgo3" : {
-      "minimal_similarity" : 0.4594594594594595,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
+      "minimal_similarity" : 0.3888888888888889,
+      "maximum_similarity" : 0.4883720930232558,
+      "matched_token_number" : 21
     },
     "SortAlgo2_5-SortAlgo6" : {
-      "minimal_similarity" : 0.5142857142857142,
-      "maximum_similarity" : 0.6101694915254238,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.4791666666666667,
+      "maximum_similarity" : 0.5348837209302325,
+      "matched_token_number" : 23
     },
     "SortAlgo2_5-SortAlgo5" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 43
     },
     "SortAlgo1-SortAlgo1_3" : {
-      "minimal_similarity" : 0.7051282051282052,
-      "maximum_similarity" : 0.9322033898305084,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.5689655172413793,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
     },
     "SortAlgo1-SortAlgo1_2" : {
-      "minimal_similarity" : 0.7283950617283951,
+      "minimal_similarity" : 0.7454545454545455,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo1-SortAlgo1_6" : {
-      "minimal_similarity" : 0.9032258064516129,
-      "maximum_similarity" : 0.9491525423728814,
-      "matched_token_number" : 56
+      "minimal_similarity" : 0.8095238095238095,
+      "maximum_similarity" : 0.8292682926829268,
+      "matched_token_number" : 34
     },
     "SortAlgo1-SortAlgo1_5" : {
-      "minimal_similarity" : 0.6271186440677966,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6046511627906976,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
     },
     "SortAlgo1-SortAlgo1_4" : {
-      "minimal_similarity" : 0.8387096774193549,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.7857142857142857,
+      "maximum_similarity" : 0.8048780487804879,
+      "matched_token_number" : 33
     },
     "SortAlgo3-SortAlgo7" : {
-      "minimal_similarity" : 0.7236842105263158,
-      "maximum_similarity" : 0.7432432432432432,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.5535714285714286,
+      "maximum_similarity" : 0.5740740740740741,
+      "matched_token_number" : 31
     },
     "SortAlgo2_5-SortAlgo4d1" : {
-      "minimal_similarity" : 0.5303030303030303,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
     },
     "SortAlgo3-SortAlgo6" : {
-      "minimal_similarity" : 0.8378378378378378,
-      "maximum_similarity" : 0.8857142857142857,
-      "matched_token_number" : 62
+      "minimal_similarity" : 0.6666666666666666,
+      "maximum_similarity" : 0.75,
+      "matched_token_number" : 36
     },
     "SortAlgo2_5-SortAlgo4d2" : {
-      "minimal_similarity" : 0.5223880597014925,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
-    },
-    "SortAlgo3-SortAlgo5" : {
-      "minimal_similarity" : 0.4594594594594595,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
+      "minimal_similarity" : 0.4897959183673469,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
     },
     "SortAlgo1_4-SortAlgo1_5" : {
-      "minimal_similarity" : 0.45161290322580644,
-      "maximum_similarity" : 0.4745762711864407,
-      "matched_token_number" : 28
+      "minimal_similarity" : 0.5348837209302325,
+      "maximum_similarity" : 0.5476190476190477,
+      "matched_token_number" : 23
+    },
+    "SortAlgo3-SortAlgo5" : {
+      "minimal_similarity" : 0.3888888888888889,
+      "maximum_similarity" : 0.4883720930232558,
+      "matched_token_number" : 21
     },
     "SortAlgo1_4-SortAlgo1_6" : {
-      "minimal_similarity" : 0.8064516129032258,
-      "maximum_similarity" : 0.8064516129032258,
-      "matched_token_number" : 50
+      "minimal_similarity" : 0.6904761904761905,
+      "maximum_similarity" : 0.6904761904761905,
+      "matched_token_number" : 29
     },
     "SortAlgo3-SortAlgo4" : {
-      "minimal_similarity" : 0.6891891891891891,
-      "maximum_similarity" : 0.8225806451612904,
-      "matched_token_number" : 51
+      "minimal_similarity" : 0.48148148148148145,
+      "maximum_similarity" : 0.6190476190476191,
+      "matched_token_number" : 26
     },
     "SortAlgo1_3-SortAlgo1_5" : {
-      "minimal_similarity" : 0.4358974358974359,
-      "maximum_similarity" : 0.576271186440678,
-      "matched_token_number" : 34
+      "minimal_similarity" : 0.3620689655172414,
+      "maximum_similarity" : 0.4883720930232558,
+      "matched_token_number" : 21
     },
     "SortAlgo1_3-SortAlgo1_4" : {
-      "minimal_similarity" : 0.6410256410256411,
-      "maximum_similarity" : 0.8064516129032258,
-      "matched_token_number" : 50
+      "minimal_similarity" : 0.5172413793103449,
+      "maximum_similarity" : 0.7142857142857143,
+      "matched_token_number" : 30
     },
     "SortAlgo2_5-SortAlgo4d3" : {
-      "minimal_similarity" : 0.5384615384615384,
-      "maximum_similarity" : 0.5932203389830508,
-      "matched_token_number" : 35
+      "minimal_similarity" : 0.5106382978723404,
+      "maximum_similarity" : 0.5581395348837209,
+      "matched_token_number" : 24
     },
     "SortAlgo1_3-SortAlgo1_6" : {
-      "minimal_similarity" : 0.6666666666666666,
-      "maximum_similarity" : 0.8387096774193549,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.4827586206896552,
+      "maximum_similarity" : 0.6666666666666666,
+      "matched_token_number" : 28
     },
     "SortAlgo-SortAlgo3_6" : {
-      "minimal_similarity" : 0.6582278481012658,
-      "maximum_similarity" : 0.8813559322033898,
-      "matched_token_number" : 52
+      "minimal_similarity" : 0.4727272727272727,
+      "maximum_similarity" : 0.6341463414634146,
+      "matched_token_number" : 26
     },
     "SortAlgo1_2-SortAlgo1_5" : {
-      "minimal_similarity" : 0.4567901234567901,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.4727272727272727,
+      "maximum_similarity" : 0.6046511627906976,
+      "matched_token_number" : 26
     },
     "SortAlgo1_2-SortAlgo1_6" : {
-      "minimal_similarity" : 0.7037037037037037,
-      "maximum_similarity" : 0.9193548387096774,
-      "matched_token_number" : 57
-    },
-    "SortAlgo-SortAlgo3_5" : {
-      "minimal_similarity" : 0.4594594594594595,
-      "maximum_similarity" : 0.576271186440678,
+      "minimal_similarity" : 0.6181818181818182,
+      "maximum_similarity" : 0.8095238095238095,
       "matched_token_number" : 34
     },
+    "SortAlgo-SortAlgo3_5" : {
+      "minimal_similarity" : 0.375,
+      "maximum_similarity" : 0.5121951219512195,
+      "matched_token_number" : 21
+    },
     "SortAlgo1_2-SortAlgo1_3" : {
-      "minimal_similarity" : 0.6790123456790124,
-      "maximum_similarity" : 0.7051282051282052,
-      "matched_token_number" : 55
+      "minimal_similarity" : 0.6206896551724138,
+      "maximum_similarity" : 0.6545454545454545,
+      "matched_token_number" : 36
     },
     "SortAlgo1_2-SortAlgo1_4" : {
-      "minimal_similarity" : 0.7037037037037037,
-      "maximum_similarity" : 0.9193548387096774,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.6,
+      "maximum_similarity" : 0.7857142857142857,
+      "matched_token_number" : 33
     }
   }
 }, {
@@ -865,309 +865,309 @@
   },
   "tests" : {
     "SortAlgo-SortAlgo5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
     },
     "SortAlgo-SortAlgo6" : {
-      "minimal_similarity" : 0.44285714285714284,
-      "maximum_similarity" : 0.5254237288135594,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.4375,
+      "maximum_similarity" : 0.5121951219512195,
+      "matched_token_number" : 21
     },
     "SortAlgo-SortAlgo7" : {
-      "minimal_similarity" : 0.4868421052631579,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6785714285714286,
+      "maximum_similarity" : 0.926829268292683,
+      "matched_token_number" : 38
     },
     "SortAlgo3_5-SortAlgo3_6" : {
-      "minimal_similarity" : 0.1518987341772152,
-      "maximum_similarity" : 0.16216216216216217,
-      "matched_token_number" : 12
+      "minimal_similarity" : 0.16071428571428573,
+      "maximum_similarity" : 0.16363636363636364,
+      "matched_token_number" : 9
     },
     "SortAlgo6-SortAlgo7" : {
-      "minimal_similarity" : 0.35526315789473684,
-      "maximum_similarity" : 0.38571428571428573,
-      "matched_token_number" : 27
+      "minimal_similarity" : 0.19642857142857142,
+      "maximum_similarity" : 0.22916666666666666,
+      "matched_token_number" : 11
     },
     "SortAlgo1_3-SortAlgo7" : {
-      "minimal_similarity" : 0.34615384615384615,
-      "maximum_similarity" : 0.35526315789473684,
-      "matched_token_number" : 27
+      "minimal_similarity" : 0.1896551724137931,
+      "maximum_similarity" : 0.19642857142857142,
+      "matched_token_number" : 11
     },
     "SortAlgo1_3-SortAlgo6" : {
-      "minimal_similarity" : 0.3333333333333333,
-      "maximum_similarity" : 0.37142857142857144,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.3103448275862069,
+      "maximum_similarity" : 0.375,
+      "matched_token_number" : 18
     },
     "SortAlgo-SortAlgo1" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo1_3-SortAlgo3" : {
-      "minimal_similarity" : 0.7307692307692307,
-      "maximum_similarity" : 0.7702702702702703,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.6896551724137931,
+      "maximum_similarity" : 0.7407407407407407,
+      "matched_token_number" : 40
     },
     "SortAlgo-SortAlgo2" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo1_3-SortAlgo2" : {
-      "minimal_similarity" : 0.5512820512820513,
-      "maximum_similarity" : 0.7288135593220338,
-      "matched_token_number" : 43
-    },
-    "SortAlgo-SortAlgo3" : {
-      "minimal_similarity" : 0.581081081081081,
-      "maximum_similarity" : 0.7288135593220338,
-      "matched_token_number" : 43
-    },
-    "SortAlgo1_3-SortAlgo5" : {
-      "minimal_similarity" : 0.11538461538461539,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
-    },
-    "SortAlgo-SortAlgo4" : {
-      "minimal_similarity" : 0.7258064516129032,
-      "maximum_similarity" : 0.7627118644067796,
-      "matched_token_number" : 45
-    },
-    "SortAlgo1_3-SortAlgo4" : {
-      "minimal_similarity" : 0.3974358974358974,
-      "maximum_similarity" : 0.5,
-      "matched_token_number" : 31
-    },
-    "SortAlgo2-SortAlgo2_5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
-    },
-    "SortAlgo1_2-SortAlgo2" : {
-      "minimal_similarity" : 0.7283950617283951,
-      "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
-    },
-    "SortAlgo1_2-SortAlgo3" : {
-      "minimal_similarity" : 0.5308641975308642,
-      "maximum_similarity" : 0.581081081081081,
-      "matched_token_number" : 43
-    },
-    "SortAlgo5-SortAlgo6" : {
-      "minimal_similarity" : 0.12857142857142856,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
-    },
-    "SortAlgo1_2-SortAlgo4" : {
-      "minimal_similarity" : 0.6172839506172839,
-      "maximum_similarity" : 0.8064516129032258,
-      "matched_token_number" : 50
-    },
-    "SortAlgo5-SortAlgo7" : {
-      "minimal_similarity" : 0.17105263157894737,
-      "maximum_similarity" : 0.22033898305084745,
-      "matched_token_number" : 13
-    },
-    "SortAlgo1_2-SortAlgo5" : {
-      "minimal_similarity" : 0.1728395061728395,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
-    },
-    "SortAlgo1_2-SortAlgo6" : {
-      "minimal_similarity" : 0.38271604938271603,
-      "maximum_similarity" : 0.44285714285714284,
-      "matched_token_number" : 31
-    },
-    "SortAlgo1_2-SortAlgo7" : {
-      "minimal_similarity" : 0.4567901234567901,
-      "maximum_similarity" : 0.4868421052631579,
-      "matched_token_number" : 37
-    },
-    "SortAlgo1-SortAlgo2_5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
-    },
-    "SortAlgo1_3-SortAlgo3_6" : {
-      "minimal_similarity" : 0.3291139240506329,
-      "maximum_similarity" : 0.3333333333333333,
-      "matched_token_number" : 26
-    },
-    "SortAlgo4-SortAlgo5" : {
-      "minimal_similarity" : 0.22580645161290322,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
-    },
-    "SortAlgo4-SortAlgo6" : {
-      "minimal_similarity" : 0.32857142857142857,
-      "maximum_similarity" : 0.3709677419354839,
-      "matched_token_number" : 23
-    },
-    "SortAlgo4-SortAlgo7" : {
-      "minimal_similarity" : 0.2894736842105263,
-      "maximum_similarity" : 0.3548387096774194,
-      "matched_token_number" : 22
-    },
-    "SortAlgo1_4-SortAlgo3_5" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.14516129032258066,
-      "matched_token_number" : 9
-    },
-    "SortAlgo1_4-SortAlgo3_6" : {
-      "minimal_similarity" : 0.3291139240506329,
-      "maximum_similarity" : 0.41935483870967744,
-      "matched_token_number" : 26
-    },
-    "SortAlgo1_5-SortAlgo3_6" : {
-      "minimal_similarity" : 0.11392405063291139,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
-    },
-    "SortAlgo1_5-SortAlgo3_5" : {
-      "minimal_similarity" : 0.5945945945945946,
-      "maximum_similarity" : 0.7457627118644068,
-      "matched_token_number" : 44
-    },
-    "SortAlgo1_6-SortAlgo3_5" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.14516129032258066,
-      "matched_token_number" : 9
-    },
-    "SortAlgo-SortAlgo4d3" : {
-      "minimal_similarity" : 0.7230769230769231,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
-    },
-    "SortAlgo1_6-SortAlgo3_6" : {
-      "minimal_similarity" : 0.569620253164557,
-      "maximum_similarity" : 0.7258064516129032,
-      "matched_token_number" : 45
-    },
-    "SortAlgo-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7014925373134329,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
-    },
-    "SortAlgo-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7121212121212122,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
-    },
-    "SortAlgo1_4-SortAlgo3" : {
       "minimal_similarity" : 0.5,
-      "maximum_similarity" : 0.5967741935483871,
-      "matched_token_number" : 37
-    },
-    "SortAlgo3-SortAlgo3_5" : {
-      "minimal_similarity" : 0.16216216216216217,
-      "maximum_similarity" : 0.16216216216216217,
-      "matched_token_number" : 12
-    },
-    "SortAlgo1_4-SortAlgo4" : {
-      "minimal_similarity" : 0.9516129032258065,
-      "maximum_similarity" : 0.9516129032258065,
-      "matched_token_number" : 59
-    },
-    "SortAlgo1_4-SortAlgo2" : {
-      "minimal_similarity" : 0.7096774193548387,
-      "maximum_similarity" : 0.7457627118644068,
-      "matched_token_number" : 44
-    },
-    "SortAlgo3-SortAlgo3_6" : {
-      "minimal_similarity" : 0.569620253164557,
-      "maximum_similarity" : 0.6081081081081081,
-      "matched_token_number" : 45
-    },
-    "SortAlgo1_4-SortAlgo7" : {
-      "minimal_similarity" : 0.4342105263157895,
-      "maximum_similarity" : 0.532258064516129,
-      "matched_token_number" : 33
-    },
-    "SortAlgo1_4-SortAlgo5" : {
-      "minimal_similarity" : 0.20967741935483872,
-      "maximum_similarity" : 0.22033898305084745,
-      "matched_token_number" : 13
-    },
-    "SortAlgo2-SortAlgo3_5" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
-    },
-    "SortAlgo1_4-SortAlgo6" : {
-      "minimal_similarity" : 0.4142857142857143,
-      "maximum_similarity" : 0.46774193548387094,
+      "maximum_similarity" : 0.7073170731707317,
       "matched_token_number" : 29
     },
+    "SortAlgo-SortAlgo3" : {
+      "minimal_similarity" : 0.5370370370370371,
+      "maximum_similarity" : 0.7073170731707317,
+      "matched_token_number" : 29
+    },
+    "SortAlgo1_3-SortAlgo5" : {
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
+    },
+    "SortAlgo-SortAlgo4" : {
+      "minimal_similarity" : 0.5714285714285714,
+      "maximum_similarity" : 0.5853658536585366,
+      "matched_token_number" : 24
+    },
+    "SortAlgo1_3-SortAlgo4" : {
+      "minimal_similarity" : 0.3793103448275862,
+      "maximum_similarity" : 0.5238095238095238,
+      "matched_token_number" : 22
+    },
+    "SortAlgo2-SortAlgo2_5" : {
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
+    },
+    "SortAlgo1_2-SortAlgo2" : {
+      "minimal_similarity" : 0.7454545454545455,
+      "maximum_similarity" : 1.0,
+      "matched_token_number" : 41
+    },
+    "SortAlgo1_2-SortAlgo3" : {
+      "minimal_similarity" : 0.5454545454545454,
+      "maximum_similarity" : 0.5555555555555556,
+      "matched_token_number" : 30
+    },
+    "SortAlgo5-SortAlgo6" : {
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
+    },
+    "SortAlgo1_2-SortAlgo4" : {
+      "minimal_similarity" : 0.4909090909090909,
+      "maximum_similarity" : 0.6428571428571429,
+      "matched_token_number" : 27
+    },
+    "SortAlgo5-SortAlgo7" : {
+      "minimal_similarity" : 0.17857142857142858,
+      "maximum_similarity" : 0.23255813953488372,
+      "matched_token_number" : 10
+    },
+    "SortAlgo1_2-SortAlgo5" : {
+      "minimal_similarity" : 0.2,
+      "maximum_similarity" : 0.2558139534883721,
+      "matched_token_number" : 11
+    },
+    "SortAlgo1_2-SortAlgo6" : {
+      "minimal_similarity" : 0.38181818181818183,
+      "maximum_similarity" : 0.4375,
+      "matched_token_number" : 21
+    },
+    "SortAlgo1_2-SortAlgo7" : {
+      "minimal_similarity" : 0.6785714285714286,
+      "maximum_similarity" : 0.6909090909090909,
+      "matched_token_number" : 38
+    },
+    "SortAlgo1-SortAlgo2_5" : {
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
+    },
+    "SortAlgo1_3-SortAlgo3_6" : {
+      "minimal_similarity" : 0.3103448275862069,
+      "maximum_similarity" : 0.32727272727272727,
+      "matched_token_number" : 18
+    },
+    "SortAlgo4-SortAlgo5" : {
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2619047619047619,
+      "matched_token_number" : 11
+    },
+    "SortAlgo4-SortAlgo6" : {
+      "minimal_similarity" : 0.3125,
+      "maximum_similarity" : 0.35714285714285715,
+      "matched_token_number" : 15
+    },
+    "SortAlgo4-SortAlgo7" : {
+      "minimal_similarity" : 0.17857142857142858,
+      "maximum_similarity" : 0.23809523809523808,
+      "matched_token_number" : 10
+    },
+    "SortAlgo1_4-SortAlgo3_5" : {
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
+    },
+    "SortAlgo1_4-SortAlgo3_6" : {
+      "minimal_similarity" : 0.34545454545454546,
+      "maximum_similarity" : 0.4523809523809524,
+      "matched_token_number" : 19
+    },
+    "SortAlgo1_5-SortAlgo3_6" : {
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
+    },
+    "SortAlgo1_5-SortAlgo3_5" : {
+      "minimal_similarity" : 0.5357142857142857,
+      "maximum_similarity" : 0.6976744186046512,
+      "matched_token_number" : 30
+    },
+    "SortAlgo1_6-SortAlgo3_5" : {
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
+    },
+    "SortAlgo-SortAlgo4d3" : {
+      "minimal_similarity" : 0.6595744680851063,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
+    },
+    "SortAlgo1_6-SortAlgo3_6" : {
+      "minimal_similarity" : 0.5454545454545454,
+      "maximum_similarity" : 0.7142857142857143,
+      "matched_token_number" : 30
+    },
+    "SortAlgo-SortAlgo4d2" : {
+      "minimal_similarity" : 0.6326530612244898,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
+    },
+    "SortAlgo-SortAlgo4d1" : {
+      "minimal_similarity" : 0.6458333333333334,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
+    },
+    "SortAlgo1_4-SortAlgo3" : {
+      "minimal_similarity" : 0.35185185185185186,
+      "maximum_similarity" : 0.4523809523809524,
+      "matched_token_number" : 19
+    },
+    "SortAlgo3-SortAlgo3_5" : {
+      "minimal_similarity" : 0.16071428571428573,
+      "maximum_similarity" : 0.16666666666666666,
+      "matched_token_number" : 9
+    },
+    "SortAlgo1_4-SortAlgo4" : {
+      "minimal_similarity" : 0.7619047619047619,
+      "maximum_similarity" : 0.7619047619047619,
+      "matched_token_number" : 32
+    },
+    "SortAlgo3-SortAlgo3_6" : {
+      "minimal_similarity" : 0.5818181818181818,
+      "maximum_similarity" : 0.5925925925925926,
+      "matched_token_number" : 32
+    },
+    "SortAlgo1_4-SortAlgo2" : {
+      "minimal_similarity" : 0.5476190476190477,
+      "maximum_similarity" : 0.5609756097560976,
+      "matched_token_number" : 23
+    },
+    "SortAlgo1_4-SortAlgo7" : {
+      "minimal_similarity" : 0.30357142857142855,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
+    },
+    "SortAlgo1_4-SortAlgo5" : {
+      "minimal_similarity" : 0.23255813953488372,
+      "maximum_similarity" : 0.23809523809523808,
+      "matched_token_number" : 10
+    },
+    "SortAlgo2-SortAlgo3_5" : {
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
+    },
+    "SortAlgo1_4-SortAlgo6" : {
+      "minimal_similarity" : 0.4166666666666667,
+      "maximum_similarity" : 0.47619047619047616,
+      "matched_token_number" : 20
+    },
     "SortAlgo2-SortAlgo3_6" : {
-      "minimal_similarity" : 0.3291139240506329,
-      "maximum_similarity" : 0.4406779661016949,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.34545454545454546,
+      "maximum_similarity" : 0.4634146341463415,
+      "matched_token_number" : 19
     },
     "SortAlgo1-SortAlgo3_6" : {
-      "minimal_similarity" : 0.3291139240506329,
-      "maximum_similarity" : 0.4406779661016949,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.34545454545454546,
+      "maximum_similarity" : 0.4634146341463415,
+      "matched_token_number" : 19
     },
     "SortAlgo1-SortAlgo3_5" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo-SortAlgo1_2" : {
-      "minimal_similarity" : 0.7283950617283951,
+      "minimal_similarity" : 0.7454545454545455,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo1_3-SortAlgo3_5" : {
-      "minimal_similarity" : 0.11538461538461539,
-      "maximum_similarity" : 0.12162162162162163,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo1_2-SortAlgo3_5" : {
-      "minimal_similarity" : 0.1111111111111111,
-      "maximum_similarity" : 0.12162162162162163,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo1_2-SortAlgo3_6" : {
-      "minimal_similarity" : 0.32098765432098764,
-      "maximum_similarity" : 0.3291139240506329,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.34545454545454546,
+      "maximum_similarity" : 0.34545454545454546,
+      "matched_token_number" : 19
     },
     "SortAlgo-SortAlgo1_6" : {
-      "minimal_similarity" : 0.5806451612903226,
-      "maximum_similarity" : 0.6101694915254238,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.5952380952380952,
+      "maximum_similarity" : 0.6097560975609756,
+      "matched_token_number" : 25
     },
     "SortAlgo-SortAlgo1_5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
     },
     "SortAlgo-SortAlgo1_4" : {
-      "minimal_similarity" : 0.7096774193548387,
-      "maximum_similarity" : 0.7457627118644068,
-      "matched_token_number" : 44
+      "minimal_similarity" : 0.5476190476190477,
+      "maximum_similarity" : 0.5609756097560976,
+      "matched_token_number" : 23
     },
     "SortAlgo-SortAlgo1_3" : {
-      "minimal_similarity" : 0.5512820512820513,
-      "maximum_similarity" : 0.7288135593220338,
-      "matched_token_number" : 43
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.7073170731707317,
+      "matched_token_number" : 29
     },
     "SortAlgo1_6-SortAlgo4d1" : {
-      "minimal_similarity" : 0.3787878787878788,
-      "maximum_similarity" : 0.4032258064516129,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3541666666666667,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
     },
     "SortAlgo4d2-SortAlgo7" : {
-      "minimal_similarity" : 0.34210526315789475,
-      "maximum_similarity" : 0.3880597014925373,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.17857142857142858,
+      "maximum_similarity" : 0.20408163265306123,
+      "matched_token_number" : 10
     },
     "SortAlgo1_6-SortAlgo4d2" : {
-      "minimal_similarity" : 0.373134328358209,
-      "maximum_similarity" : 0.4032258064516129,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3469387755102041,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
     },
     "SortAlgo4d2-SortAlgo5" : {
       "minimal_similarity" : 0.0,
@@ -1175,59 +1175,59 @@
       "matched_token_number" : 0
     },
     "SortAlgo4d2-SortAlgo6" : {
-      "minimal_similarity" : 0.35714285714285715,
-      "maximum_similarity" : 0.373134328358209,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3469387755102041,
+      "maximum_similarity" : 0.3541666666666667,
+      "matched_token_number" : 17
     },
     "SortAlgo1_6-SortAlgo4d3" : {
-      "minimal_similarity" : 0.38461538461538464,
-      "maximum_similarity" : 0.4032258064516129,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3617021276595745,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
     },
     "SortAlgo1_5-SortAlgo2_5" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 43
     },
     "SortAlgo2-SortAlgo3" : {
-      "minimal_similarity" : 0.581081081081081,
-      "maximum_similarity" : 0.7288135593220338,
-      "matched_token_number" : 43
+      "minimal_similarity" : 0.5370370370370371,
+      "maximum_similarity" : 0.7073170731707317,
+      "matched_token_number" : 29
     },
     "SortAlgo1_2-SortAlgo4d1" : {
-      "minimal_similarity" : 0.5802469135802469,
-      "maximum_similarity" : 0.7121212121212122,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.5636363636363636,
+      "maximum_similarity" : 0.6458333333333334,
+      "matched_token_number" : 31
     },
     "SortAlgo1_3-SortAlgo4d3" : {
-      "minimal_similarity" : 0.5512820512820513,
-      "maximum_similarity" : 0.6615384615384615,
-      "matched_token_number" : 43
-    },
-    "SortAlgo2-SortAlgo4" : {
-      "minimal_similarity" : 0.7258064516129032,
-      "maximum_similarity" : 0.7627118644067796,
-      "matched_token_number" : 45
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.6170212765957447,
+      "matched_token_number" : 29
     },
     "SortAlgo1_2-SortAlgo4d2" : {
-      "minimal_similarity" : 0.5802469135802469,
-      "maximum_similarity" : 0.7014925373134329,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.5636363636363636,
+      "maximum_similarity" : 0.6326530612244898,
+      "matched_token_number" : 31
+    },
+    "SortAlgo2-SortAlgo4" : {
+      "minimal_similarity" : 0.5714285714285714,
+      "maximum_similarity" : 0.5853658536585366,
+      "matched_token_number" : 24
     },
     "SortAlgo1_3-SortAlgo4d2" : {
-      "minimal_similarity" : 0.5512820512820513,
-      "maximum_similarity" : 0.6417910447761194,
-      "matched_token_number" : 43
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.5918367346938775,
+      "matched_token_number" : 29
     },
     "SortAlgo1_6-SortAlgo2_5" : {
-      "minimal_similarity" : 0.22580645161290322,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2619047619047619,
+      "matched_token_number" : 11
     },
     "SortAlgo1_4-SortAlgo4d1" : {
-      "minimal_similarity" : 0.5454545454545454,
-      "maximum_similarity" : 0.5806451612903226,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.3541666666666667,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
     },
     "SortAlgo1_5-SortAlgo4d3" : {
       "minimal_similarity" : 0.0,
@@ -1235,9 +1235,9 @@
       "matched_token_number" : 0
     },
     "SortAlgo1_4-SortAlgo4d2" : {
-      "minimal_similarity" : 0.5373134328358209,
-      "maximum_similarity" : 0.5806451612903226,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.3469387755102041,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
     },
     "SortAlgo1_5-SortAlgo4d2" : {
       "minimal_similarity" : 0.0,
@@ -1245,9 +1245,9 @@
       "matched_token_number" : 0
     },
     "SortAlgo1_4-SortAlgo4d3" : {
-      "minimal_similarity" : 0.5538461538461539,
-      "maximum_similarity" : 0.5806451612903226,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.3617021276595745,
+      "maximum_similarity" : 0.40476190476190477,
+      "matched_token_number" : 17
     },
     "SortAlgo1_5-SortAlgo4d1" : {
       "minimal_similarity" : 0.0,
@@ -1255,84 +1255,84 @@
       "matched_token_number" : 0
     },
     "SortAlgo4d2-SortAlgo4d3" : {
-      "minimal_similarity" : 0.9402985074626866,
-      "maximum_similarity" : 0.9692307692307692,
-      "matched_token_number" : 63
+      "minimal_similarity" : 0.9183673469387755,
+      "maximum_similarity" : 0.9574468085106383,
+      "matched_token_number" : 45
     },
     "SortAlgo2-SortAlgo7" : {
-      "minimal_similarity" : 0.4868421052631579,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6785714285714286,
+      "maximum_similarity" : 0.926829268292683,
+      "matched_token_number" : 38
     },
     "SortAlgo4d1-SortAlgo4d2" : {
-      "minimal_similarity" : 0.9850746268656716,
+      "minimal_similarity" : 0.9795918367346939,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 66
+      "matched_token_number" : 48
     },
     "SortAlgo1_2-SortAlgo4d3" : {
-      "minimal_similarity" : 0.5802469135802469,
-      "maximum_similarity" : 0.7230769230769231,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.5636363636363636,
+      "maximum_similarity" : 0.6595744680851063,
+      "matched_token_number" : 31
     },
     "SortAlgo1_3-SortAlgo4d1" : {
-      "minimal_similarity" : 0.5512820512820513,
-      "maximum_similarity" : 0.6515151515151515,
-      "matched_token_number" : 43
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.6041666666666666,
+      "matched_token_number" : 29
     },
     "SortAlgo2-SortAlgo5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
     },
     "SortAlgo4d1-SortAlgo4d3" : {
-      "minimal_similarity" : 0.9545454545454546,
-      "maximum_similarity" : 0.9692307692307692,
-      "matched_token_number" : 63
+      "minimal_similarity" : 0.9375,
+      "maximum_similarity" : 0.9574468085106383,
+      "matched_token_number" : 45
     },
     "SortAlgo2-SortAlgo6" : {
-      "minimal_similarity" : 0.44285714285714284,
-      "maximum_similarity" : 0.5254237288135594,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.4375,
+      "maximum_similarity" : 0.5121951219512195,
+      "matched_token_number" : 21
     },
     "SortAlgo1_6-SortAlgo7" : {
-      "minimal_similarity" : 0.40789473684210525,
-      "maximum_similarity" : 0.5,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.25,
+      "maximum_similarity" : 0.3333333333333333,
+      "matched_token_number" : 14
     },
     "SortAlgo3_6-SortAlgo6" : {
-      "minimal_similarity" : 0.7341772151898734,
-      "maximum_similarity" : 0.8285714285714286,
-      "matched_token_number" : 58
+      "minimal_similarity" : 0.7272727272727273,
+      "maximum_similarity" : 0.8333333333333334,
+      "matched_token_number" : 40
     },
     "SortAlgo2_5-SortAlgo3_5" : {
-      "minimal_similarity" : 0.5945945945945946,
-      "maximum_similarity" : 0.7457627118644068,
-      "matched_token_number" : 44
+      "minimal_similarity" : 0.5357142857142857,
+      "maximum_similarity" : 0.6976744186046512,
+      "matched_token_number" : 30
     },
     "SortAlgo3_6-SortAlgo5" : {
-      "minimal_similarity" : 0.11392405063291139,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo2_5-SortAlgo3_6" : {
-      "minimal_similarity" : 0.11392405063291139,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo3_6-SortAlgo7" : {
-      "minimal_similarity" : 0.20253164556962025,
-      "maximum_similarity" : 0.21052631578947367,
-      "matched_token_number" : 16
+      "minimal_similarity" : 0.19642857142857142,
+      "maximum_similarity" : 0.2,
+      "matched_token_number" : 11
     },
     "SortAlgo4d3-SortAlgo6" : {
-      "minimal_similarity" : 0.35714285714285715,
-      "maximum_similarity" : 0.38461538461538464,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3541666666666667,
+      "maximum_similarity" : 0.3617021276595745,
+      "matched_token_number" : 17
     },
     "SortAlgo4d3-SortAlgo7" : {
-      "minimal_similarity" : 0.34210526315789475,
-      "maximum_similarity" : 0.4,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.17857142857142858,
+      "maximum_similarity" : 0.2127659574468085,
+      "matched_token_number" : 10
     },
     "SortAlgo4d3-SortAlgo5" : {
       "minimal_similarity" : 0.0,
@@ -1340,224 +1340,224 @@
       "matched_token_number" : 0
     },
     "SortAlgo1_4-SortAlgo2_5" : {
-      "minimal_similarity" : 0.20967741935483872,
-      "maximum_similarity" : 0.22033898305084745,
-      "matched_token_number" : 13
+      "minimal_similarity" : 0.23255813953488372,
+      "maximum_similarity" : 0.23809523809523808,
+      "matched_token_number" : 10
     },
     "SortAlgo1-SortAlgo4" : {
-      "minimal_similarity" : 0.7258064516129032,
-      "maximum_similarity" : 0.7627118644067796,
-      "matched_token_number" : 45
+      "minimal_similarity" : 0.5714285714285714,
+      "maximum_similarity" : 0.5853658536585366,
+      "matched_token_number" : 24
     },
     "SortAlgo1-SortAlgo5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
     },
     "SortAlgo1-SortAlgo2" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo3_6-SortAlgo4" : {
-      "minimal_similarity" : 0.25316455696202533,
-      "maximum_similarity" : 0.3225806451612903,
-      "matched_token_number" : 20
+      "minimal_similarity" : 0.2545454545454545,
+      "maximum_similarity" : 0.3333333333333333,
+      "matched_token_number" : 14
     },
     "SortAlgo1-SortAlgo3" : {
-      "minimal_similarity" : 0.581081081081081,
-      "maximum_similarity" : 0.7288135593220338,
-      "matched_token_number" : 43
+      "minimal_similarity" : 0.5370370370370371,
+      "maximum_similarity" : 0.7073170731707317,
+      "matched_token_number" : 29
     },
     "SortAlgo1_3-SortAlgo2_5" : {
-      "minimal_similarity" : 0.11538461538461539,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo1_6-SortAlgo2" : {
-      "minimal_similarity" : 0.5806451612903226,
-      "maximum_similarity" : 0.6101694915254238,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.5952380952380952,
+      "maximum_similarity" : 0.6097560975609756,
+      "matched_token_number" : 25
     },
     "SortAlgo1-SortAlgo6" : {
-      "minimal_similarity" : 0.44285714285714284,
-      "maximum_similarity" : 0.5254237288135594,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.4375,
+      "maximum_similarity" : 0.5121951219512195,
+      "matched_token_number" : 21
     },
     "SortAlgo1-SortAlgo7" : {
-      "minimal_similarity" : 0.4868421052631579,
-      "maximum_similarity" : 0.6271186440677966,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.6785714285714286,
+      "maximum_similarity" : 0.926829268292683,
+      "matched_token_number" : 38
     },
     "SortAlgo1_2-SortAlgo2_5" : {
-      "minimal_similarity" : 0.1728395061728395,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2,
+      "maximum_similarity" : 0.2558139534883721,
+      "matched_token_number" : 11
     },
     "SortAlgo1_6-SortAlgo6" : {
-      "minimal_similarity" : 0.8142857142857143,
-      "maximum_similarity" : 0.9193548387096774,
-      "matched_token_number" : 57
+      "minimal_similarity" : 0.7916666666666666,
+      "maximum_similarity" : 0.9047619047619048,
+      "matched_token_number" : 38
     },
     "SortAlgo-SortAlgo2_5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
     },
     "SortAlgo1_6-SortAlgo5" : {
-      "minimal_similarity" : 0.22580645161290322,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2619047619047619,
+      "matched_token_number" : 11
     },
     "SortAlgo1_6-SortAlgo4" : {
-      "minimal_similarity" : 0.5483870967741935,
-      "maximum_similarity" : 0.5483870967741935,
-      "matched_token_number" : 34
+      "minimal_similarity" : 0.5714285714285714,
+      "maximum_similarity" : 0.5714285714285714,
+      "matched_token_number" : 24
     },
     "SortAlgo1_6-SortAlgo3" : {
-      "minimal_similarity" : 0.35135135135135137,
-      "maximum_similarity" : 0.41935483870967744,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.35185185185185186,
+      "maximum_similarity" : 0.4523809523809524,
+      "matched_token_number" : 19
     },
     "SortAlgo1_5-SortAlgo6" : {
-      "minimal_similarity" : 0.12857142857142856,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo2_5-SortAlgo7" : {
-      "minimal_similarity" : 0.17105263157894737,
-      "maximum_similarity" : 0.22033898305084745,
-      "matched_token_number" : 13
+      "minimal_similarity" : 0.17857142857142858,
+      "maximum_similarity" : 0.23255813953488372,
+      "matched_token_number" : 10
     },
     "SortAlgo1_5-SortAlgo7" : {
-      "minimal_similarity" : 0.17105263157894737,
-      "maximum_similarity" : 0.22033898305084745,
-      "matched_token_number" : 13
+      "minimal_similarity" : 0.17857142857142858,
+      "maximum_similarity" : 0.23255813953488372,
+      "matched_token_number" : 10
     },
     "SortAlgo1-SortAlgo4d3" : {
-      "minimal_similarity" : 0.7230769230769231,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.6595744680851063,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo1_5-SortAlgo4" : {
-      "minimal_similarity" : 0.22580645161290322,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2619047619047619,
+      "matched_token_number" : 11
     },
     "SortAlgo1_5-SortAlgo5" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 43
     },
     "SortAlgo1-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7014925373134329,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.6326530612244898,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo1-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7121212121212122,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.6458333333333334,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo1_5-SortAlgo2" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
     },
     "SortAlgo3_5-SortAlgo6" : {
-      "minimal_similarity" : 0.16216216216216217,
-      "maximum_similarity" : 0.17142857142857143,
-      "matched_token_number" : 12
-    },
-    "SortAlgo1_5-SortAlgo3" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.15254237288135594,
+      "minimal_similarity" : 0.16071428571428573,
+      "maximum_similarity" : 0.1875,
       "matched_token_number" : 9
     },
     "SortAlgo3_5-SortAlgo7" : {
-      "minimal_similarity" : 0.11842105263157894,
-      "maximum_similarity" : 0.12162162162162163,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
+    },
+    "SortAlgo1_5-SortAlgo3" : {
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo3-SortAlgo4d1" : {
-      "minimal_similarity" : 0.5675675675675675,
-      "maximum_similarity" : 0.6363636363636364,
-      "matched_token_number" : 42
+      "minimal_similarity" : 0.5185185185185185,
+      "maximum_similarity" : 0.5833333333333334,
+      "matched_token_number" : 28
     },
     "SortAlgo3-SortAlgo4d3" : {
-      "minimal_similarity" : 0.5675675675675675,
-      "maximum_similarity" : 0.6461538461538462,
-      "matched_token_number" : 42
+      "minimal_similarity" : 0.5185185185185185,
+      "maximum_similarity" : 0.5957446808510638,
+      "matched_token_number" : 28
     },
     "SortAlgo3-SortAlgo4d2" : {
-      "minimal_similarity" : 0.5675675675675675,
-      "maximum_similarity" : 0.6268656716417911,
-      "matched_token_number" : 42
+      "minimal_similarity" : 0.5185185185185185,
+      "maximum_similarity" : 0.5714285714285714,
+      "matched_token_number" : 28
     },
     "SortAlgo2-SortAlgo4d3" : {
-      "minimal_similarity" : 0.7230769230769231,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.6595744680851063,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo2-SortAlgo4d1" : {
-      "minimal_similarity" : 0.7121212121212122,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.6458333333333334,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo2-SortAlgo4d2" : {
-      "minimal_similarity" : 0.7014925373134329,
-      "maximum_similarity" : 0.7966101694915254,
-      "matched_token_number" : 47
+      "minimal_similarity" : 0.6326530612244898,
+      "maximum_similarity" : 0.7560975609756098,
+      "matched_token_number" : 31
     },
     "SortAlgo1_5-SortAlgo1_6" : {
-      "minimal_similarity" : 0.22580645161290322,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
-    },
-    "SortAlgo4d1-SortAlgo7" : {
-      "minimal_similarity" : 0.34210526315789475,
-      "maximum_similarity" : 0.3939393939393939,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2619047619047619,
+      "matched_token_number" : 11
     },
     "SortAlgo3_6-SortAlgo4d2" : {
-      "minimal_similarity" : 0.31645569620253167,
-      "maximum_similarity" : 0.373134328358209,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3090909090909091,
+      "maximum_similarity" : 0.3469387755102041,
+      "matched_token_number" : 17
+    },
+    "SortAlgo4d1-SortAlgo7" : {
+      "minimal_similarity" : 0.17857142857142858,
+      "maximum_similarity" : 0.20833333333333334,
+      "matched_token_number" : 10
     },
     "SortAlgo4d1-SortAlgo6" : {
-      "minimal_similarity" : 0.35714285714285715,
-      "maximum_similarity" : 0.3787878787878788,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3541666666666667,
+      "maximum_similarity" : 0.3541666666666667,
+      "matched_token_number" : 17
     },
     "SortAlgo3_6-SortAlgo4d1" : {
-      "minimal_similarity" : 0.31645569620253167,
-      "maximum_similarity" : 0.3787878787878788,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3090909090909091,
+      "maximum_similarity" : 0.3541666666666667,
+      "matched_token_number" : 17
     },
     "SortAlgo4-SortAlgo4d1" : {
-      "minimal_similarity" : 0.4696969696969697,
-      "maximum_similarity" : 0.5,
-      "matched_token_number" : 31
-    },
-    "SortAlgo4-SortAlgo4d2" : {
-      "minimal_similarity" : 0.4626865671641791,
-      "maximum_similarity" : 0.5,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.2708333333333333,
+      "maximum_similarity" : 0.30952380952380953,
+      "matched_token_number" : 13
     },
     "SortAlgo3_6-SortAlgo4d3" : {
-      "minimal_similarity" : 0.31645569620253167,
-      "maximum_similarity" : 0.38461538461538464,
-      "matched_token_number" : 25
+      "minimal_similarity" : 0.3090909090909091,
+      "maximum_similarity" : 0.3617021276595745,
+      "matched_token_number" : 17
+    },
+    "SortAlgo4-SortAlgo4d2" : {
+      "minimal_similarity" : 0.2653061224489796,
+      "maximum_similarity" : 0.30952380952380953,
+      "matched_token_number" : 13
     },
     "SortAlgo4-SortAlgo4d3" : {
-      "minimal_similarity" : 0.47692307692307695,
-      "maximum_similarity" : 0.5,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.2765957446808511,
+      "maximum_similarity" : 0.30952380952380953,
+      "matched_token_number" : 13
     },
     "SortAlgo3_5-SortAlgo4" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.14516129032258066,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo3_5-SortAlgo4d2" : {
       "minimal_similarity" : 0.0,
@@ -1570,9 +1570,9 @@
       "matched_token_number" : 0
     },
     "SortAlgo3_5-SortAlgo5" : {
-      "minimal_similarity" : 0.5945945945945946,
-      "maximum_similarity" : 0.7457627118644068,
-      "matched_token_number" : 44
+      "minimal_similarity" : 0.5357142857142857,
+      "maximum_similarity" : 0.6976744186046512,
+      "matched_token_number" : 30
     },
     "SortAlgo3_5-SortAlgo4d3" : {
       "minimal_similarity" : 0.0,
@@ -1580,14 +1580,14 @@
       "matched_token_number" : 0
     },
     "SortAlgo2_5-SortAlgo4" : {
-      "minimal_similarity" : 0.22580645161290322,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2619047619047619,
+      "matched_token_number" : 11
     },
     "SortAlgo2_5-SortAlgo3" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo3_5-SortAlgo4d1" : {
       "minimal_similarity" : 0.0,
@@ -1595,44 +1595,44 @@
       "matched_token_number" : 0
     },
     "SortAlgo2_5-SortAlgo6" : {
-      "minimal_similarity" : 0.12857142857142856,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo2_5-SortAlgo5" : {
       "minimal_similarity" : 1.0,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
-    },
-    "SortAlgo1-SortAlgo1_3" : {
-      "minimal_similarity" : 0.5512820512820513,
-      "maximum_similarity" : 0.7288135593220338,
       "matched_token_number" : 43
     },
+    "SortAlgo1-SortAlgo1_3" : {
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.7073170731707317,
+      "matched_token_number" : 29
+    },
     "SortAlgo1-SortAlgo1_2" : {
-      "minimal_similarity" : 0.7283950617283951,
+      "minimal_similarity" : 0.7454545454545455,
       "maximum_similarity" : 1.0,
-      "matched_token_number" : 59
+      "matched_token_number" : 41
     },
     "SortAlgo1-SortAlgo1_6" : {
-      "minimal_similarity" : 0.5806451612903226,
-      "maximum_similarity" : 0.6101694915254238,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.5952380952380952,
+      "maximum_similarity" : 0.6097560975609756,
+      "matched_token_number" : 25
     },
     "SortAlgo1-SortAlgo1_5" : {
-      "minimal_similarity" : 0.23728813559322035,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2558139534883721,
+      "maximum_similarity" : 0.2682926829268293,
+      "matched_token_number" : 11
     },
     "SortAlgo1-SortAlgo1_4" : {
-      "minimal_similarity" : 0.7096774193548387,
-      "maximum_similarity" : 0.7457627118644068,
-      "matched_token_number" : 44
+      "minimal_similarity" : 0.5476190476190477,
+      "maximum_similarity" : 0.5609756097560976,
+      "matched_token_number" : 23
     },
     "SortAlgo3-SortAlgo7" : {
-      "minimal_similarity" : 0.35526315789473684,
-      "maximum_similarity" : 0.36486486486486486,
-      "matched_token_number" : 27
+      "minimal_similarity" : 0.19642857142857142,
+      "maximum_similarity" : 0.2037037037037037,
+      "matched_token_number" : 11
     },
     "SortAlgo2_5-SortAlgo4d1" : {
       "minimal_similarity" : 0.0,
@@ -1640,9 +1640,9 @@
       "matched_token_number" : 0
     },
     "SortAlgo3-SortAlgo6" : {
-      "minimal_similarity" : 0.527027027027027,
-      "maximum_similarity" : 0.5571428571428572,
-      "matched_token_number" : 39
+      "minimal_similarity" : 0.5370370370370371,
+      "maximum_similarity" : 0.6041666666666666,
+      "matched_token_number" : 29
     },
     "SortAlgo2_5-SortAlgo4d2" : {
       "minimal_similarity" : 0.0,
@@ -1650,34 +1650,34 @@
       "matched_token_number" : 0
     },
     "SortAlgo1_4-SortAlgo1_5" : {
-      "minimal_similarity" : 0.20967741935483872,
-      "maximum_similarity" : 0.22033898305084745,
-      "matched_token_number" : 13
+      "minimal_similarity" : 0.23255813953488372,
+      "maximum_similarity" : 0.23809523809523808,
+      "matched_token_number" : 10
     },
     "SortAlgo3-SortAlgo5" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo1_4-SortAlgo1_6" : {
-      "minimal_similarity" : 0.532258064516129,
-      "maximum_similarity" : 0.532258064516129,
-      "matched_token_number" : 33
+      "minimal_similarity" : 0.5476190476190477,
+      "maximum_similarity" : 0.5476190476190477,
+      "matched_token_number" : 23
     },
     "SortAlgo3-SortAlgo4" : {
-      "minimal_similarity" : 0.4189189189189189,
-      "maximum_similarity" : 0.5,
-      "matched_token_number" : 31
+      "minimal_similarity" : 0.25925925925925924,
+      "maximum_similarity" : 0.3333333333333333,
+      "matched_token_number" : 14
     },
     "SortAlgo1_3-SortAlgo1_5" : {
-      "minimal_similarity" : 0.11538461538461539,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo1_3-SortAlgo1_4" : {
-      "minimal_similarity" : 0.47435897435897434,
-      "maximum_similarity" : 0.5967741935483871,
-      "matched_token_number" : 37
+      "minimal_similarity" : 0.46551724137931033,
+      "maximum_similarity" : 0.6428571428571429,
+      "matched_token_number" : 27
     },
     "SortAlgo2_5-SortAlgo4d3" : {
       "minimal_similarity" : 0.0,
@@ -1685,39 +1685,39 @@
       "matched_token_number" : 0
     },
     "SortAlgo1_3-SortAlgo1_6" : {
-      "minimal_similarity" : 0.3333333333333333,
-      "maximum_similarity" : 0.41935483870967744,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.3103448275862069,
+      "maximum_similarity" : 0.42857142857142855,
+      "matched_token_number" : 18
     },
     "SortAlgo-SortAlgo3_6" : {
-      "minimal_similarity" : 0.3291139240506329,
-      "maximum_similarity" : 0.4406779661016949,
-      "matched_token_number" : 26
+      "minimal_similarity" : 0.34545454545454546,
+      "maximum_similarity" : 0.4634146341463415,
+      "matched_token_number" : 19
     },
     "SortAlgo1_2-SortAlgo1_5" : {
-      "minimal_similarity" : 0.1728395061728395,
-      "maximum_similarity" : 0.23728813559322035,
-      "matched_token_number" : 14
+      "minimal_similarity" : 0.2,
+      "maximum_similarity" : 0.2558139534883721,
+      "matched_token_number" : 11
     },
     "SortAlgo1_2-SortAlgo1_6" : {
-      "minimal_similarity" : 0.4444444444444444,
-      "maximum_similarity" : 0.5806451612903226,
-      "matched_token_number" : 36
+      "minimal_similarity" : 0.45454545454545453,
+      "maximum_similarity" : 0.5952380952380952,
+      "matched_token_number" : 25
     },
     "SortAlgo-SortAlgo3_5" : {
-      "minimal_similarity" : 0.12162162162162163,
-      "maximum_similarity" : 0.15254237288135594,
-      "matched_token_number" : 9
+      "minimal_similarity" : 0.0,
+      "maximum_similarity" : 0.0,
+      "matched_token_number" : 0
     },
     "SortAlgo1_2-SortAlgo1_3" : {
-      "minimal_similarity" : 0.5308641975308642,
-      "maximum_similarity" : 0.5512820512820513,
-      "matched_token_number" : 43
+      "minimal_similarity" : 0.5,
+      "maximum_similarity" : 0.5272727272727272,
+      "matched_token_number" : 29
     },
     "SortAlgo1_2-SortAlgo1_4" : {
-      "minimal_similarity" : 0.5555555555555556,
-      "maximum_similarity" : 0.7258064516129032,
-      "matched_token_number" : 45
+      "minimal_similarity" : 0.41818181818181815,
+      "maximum_similarity" : 0.5476190476190477,
+      "matched_token_number" : 23
     }
   }
 } ]

--- a/language-api/pom.xml
+++ b/language-api/pom.xml
@@ -8,6 +8,8 @@
         <version>${revision}</version>
     </parent>
     <artifactId>language-api</artifactId>
+    <name>JPlag Language API</name>
+    <description>Language API for JPlag language modules</description>
     <dependencies>
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>

--- a/language-api/src/main/java/de/jplag/Token.java
+++ b/language-api/src/main/java/de/jplag/Token.java
@@ -88,4 +88,9 @@ public class Token {
     public TokenType getType() {
         return type;
     }
+
+    @Override
+    public String toString() {
+        return type.toString();
+    }
 }

--- a/languages/java/src/main/java/de/jplag/java/JavaTokenType.java
+++ b/languages/java/src/main/java/de/jplag/java/JavaTokenType.java
@@ -43,8 +43,6 @@ public enum JavaTokenType implements TokenType {
     J_INTERFACE_END("}INTERF"), // check
     J_CONSTR_BEGIN("CONSTR{"), //
     J_CONSTR_END("}CONSTR"), //
-    J_INIT_BEGIN("INIT{"), // check
-    J_INIT_END("}INIT"), // check
     J_VOID("VOID"), //
     J_ARRAY_INIT_BEGIN("ARRINIT{"), // check
     J_ARRAY_INIT_END("}ARRINIT"), // check

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -10,7 +10,6 @@ import de.jplag.ParsingException;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssertTree;
 import com.sun.source.tree.AssignmentTree;
-import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.BreakTree;
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.CatchTree;
@@ -90,16 +89,6 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Object, Object> {
      */
     private void addToken(JavaTokenType tokenType, long start, long end) {
         parser.add(tokenType, file, map.getLineNumber(start), map.getColumnNumber(start), (end - start));
-    }
-
-    @Override
-    public Object visitBlock(BlockTree node, Object p) {
-        long start = positions.getStartPosition(ast, node);
-        long end = positions.getEndPosition(ast, node) - 1;
-        addToken(JavaTokenType.J_INIT_BEGIN, start, 1);
-        Object result = super.visitBlock(node, p);
-        addToken(JavaTokenType.J_INIT_END, end, 1);
-        return result;
     }
 
     @Override

--- a/languages/java/src/test/java/de/jplag/java/JavaBlockTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaBlockTest.java
@@ -8,9 +8,13 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,8 +23,8 @@ import de.jplag.Token;
 import de.jplag.TokenType;
 
 class JavaBlockTest {
-    private static final String LOG_MESSAGE = "Tokens of {}: {}";
     private static final Path BASE_PATH = Path.of("src", "test", "resources", "java");
+    private static final String LOG_MESSAGE = "Tokens of {}: {}";
 
     private final Logger logger = LoggerFactory.getLogger(JavaBlockTest.class);
 
@@ -34,10 +38,12 @@ class JavaBlockTest {
         assertTrue(baseDirectory.exists(), "Could not find base directory!");
     }
 
-    @Test
-    void testParsingTestClass() throws ParsingException {
-        List<TokenType> tokenTypes1 = parseFile("IfWithBraces.java");
-        List<TokenType> tokenTypes2 = parseFile("IfWithoutBraces.java");
+    @ParameterizedTest
+    @MethodSource("provideClassPairs")
+    @DisplayName("Test pairs of classes with explicit vs. implicit blocks.")
+    void testJavaClassPair(String fileName1, String fileName2) throws ParsingException {
+        List<TokenType> tokenTypes1 = parseFile(fileName1);
+        List<TokenType> tokenTypes2 = parseFile(fileName2);
         assertEquals(tokenTypes1.size(), tokenTypes2.size());
         assertIterableEquals(tokenTypes1, tokenTypes2);
     }
@@ -47,6 +53,11 @@ class JavaBlockTest {
         List<TokenType> tokenTypes = parsedTokens.stream().map(Token::getType).toList();
         logger.info(LOG_MESSAGE, fileName, tokenTypes);
         return tokenTypes;
+    }
+
+    private static Stream<Arguments> provideClassPairs() {
+        return Stream.of(Arguments.of("IfWithBraces.java", "IfWithoutBraces.java"), // just if conditions
+                Arguments.of("Verbose.java", "Compact.java")); // complex case with different blocks
     }
 
 }

--- a/languages/java/src/test/java/de/jplag/java/JavaBlockTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaBlockTest.java
@@ -1,6 +1,5 @@
 package de.jplag.java;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -22,6 +21,9 @@ import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenType;
 
+/**
+ * Test cases regarding the extraction from implicit vs. explicit blocks in Java code.
+ */
 class JavaBlockTest {
     private static final Path BASE_PATH = Path.of("src", "test", "resources", "java");
     private static final String LOG_MESSAGE = "Tokens of {}: {}";
@@ -42,19 +44,19 @@ class JavaBlockTest {
     @MethodSource("provideClassPairs")
     @DisplayName("Test pairs of classes with explicit vs. implicit blocks.")
     void testJavaClassPair(String fileName1, String fileName2) throws ParsingException {
-        List<TokenType> tokenTypes1 = parseFile(fileName1);
-        List<TokenType> tokenTypes2 = parseFile(fileName2);
-        assertEquals(tokenTypes1.size(), tokenTypes2.size());
-        assertIterableEquals(tokenTypes1, tokenTypes2);
+        assertIterableEquals(parseJavaFile(fileName1), parseJavaFile(fileName2));
     }
 
-    private List<TokenType> parseFile(String fileName) throws ParsingException {
+    private List<TokenType> parseJavaFile(String fileName) throws ParsingException {
         List<Token> parsedTokens = language.parse(Set.of(new File(baseDirectory, fileName)));
         List<TokenType> tokenTypes = parsedTokens.stream().map(Token::getType).toList();
         logger.info(LOG_MESSAGE, fileName, tokenTypes);
         return tokenTypes;
     }
 
+    /**
+     * Argument source for the test case {@link testJavaClassPair(String, String)).
+     */
     private static Stream<Arguments> provideClassPairs() {
         return Stream.of(Arguments.of("IfWithBraces.java", "IfWithoutBraces.java"), // just if conditions
                 Arguments.of("Verbose.java", "Compact.java")); // complex case with different blocks

--- a/languages/java/src/test/java/de/jplag/java/JavaBlockTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaBlockTest.java
@@ -1,0 +1,52 @@
+package de.jplag.java;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.jplag.ParsingException;
+import de.jplag.Token;
+import de.jplag.TokenType;
+
+class JavaBlockTest {
+    private static final String LOG_MESSAGE = "Tokens of {}: {}";
+    private static final Path BASE_PATH = Path.of("src", "test", "resources", "java");
+
+    private final Logger logger = LoggerFactory.getLogger(JavaBlockTest.class);
+
+    private de.jplag.Language language;
+    private File baseDirectory;
+
+    @BeforeEach
+    public void setUp() {
+        language = new Language();
+        baseDirectory = BASE_PATH.toFile();
+        assertTrue(baseDirectory.exists(), "Could not find base directory!");
+    }
+
+    @Test
+    void testParsingTestClass() throws ParsingException {
+        List<TokenType> tokenTypes1 = parseFile("IfWithBraces.java");
+        List<TokenType> tokenTypes2 = parseFile("IfWithoutBraces.java");
+        assertEquals(tokenTypes1.size(), tokenTypes2.size());
+        assertIterableEquals(tokenTypes1, tokenTypes2);
+    }
+
+    private List<TokenType> parseFile(String fileName) throws ParsingException {
+        List<Token> parsedTokens = language.parse(Set.of(new File(baseDirectory, fileName)));
+        List<TokenType> tokenTypes = parsedTokens.stream().map(Token::getType).toList();
+        logger.info(LOG_MESSAGE, fileName, tokenTypes);
+        return tokenTypes;
+    }
+
+}

--- a/languages/java/src/test/resources/java/Compact.java
+++ b/languages/java/src/test/resources/java/Compact.java
@@ -1,0 +1,24 @@
+package java;
+
+import java.util.ArrayList;
+
+public class Compact {
+    static int tryCount(ArrayList<Integer> a, int n) {
+        if (a.isEmpty())
+            return Integer.MAX_VALUE;
+
+        int count = 0;
+
+        for (int i = 0; i + 1 < a.size(); i++)
+            if (a.get(i) + 1 != (int) a.get(i + 1))
+                count++;
+
+        if (a.get(0) != 0)
+            count++;
+
+        if (a.get(a.size() - 1) != n - 1)
+            count++;
+
+        return count;
+    }
+}

--- a/languages/java/src/test/resources/java/IfWithBraces.java
+++ b/languages/java/src/test/resources/java/IfWithBraces.java
@@ -6,8 +6,10 @@ public class IfWithBraces {
     public static void main(String[] args) {
         if (args == null) {
             throw new IllegalArgumentException();
-        } else {
+        } else if (args.length > 1) {
             System.out.println(Arrays.toString(args));
+        } else {
+            System.out.println(args[0]);
         }
     }
 }

--- a/languages/java/src/test/resources/java/IfWithBraces.java
+++ b/languages/java/src/test/resources/java/IfWithBraces.java
@@ -1,0 +1,13 @@
+package java;
+
+import java.util.Arrays;
+
+public class IfWithBraces {
+    public static void main(String[] args) {
+        if (args == null) {
+            throw new IllegalArgumentException();
+        } else {
+            System.out.println(Arrays.toString(args));
+        }
+    }
+}

--- a/languages/java/src/test/resources/java/IfWithoutBraces.java
+++ b/languages/java/src/test/resources/java/IfWithoutBraces.java
@@ -6,7 +6,9 @@ public class IfWithoutBraces {
     public static void main(String[] args) {
         if (args == null)
             throw new IllegalArgumentException();
-        else
+        else if (args.length > 1)
             System.out.println(Arrays.toString(args));
+        else
+            System.out.println(args[0]);
     }
 }

--- a/languages/java/src/test/resources/java/IfWithoutBraces.java
+++ b/languages/java/src/test/resources/java/IfWithoutBraces.java
@@ -1,0 +1,12 @@
+package java;
+
+import java.util.Arrays;
+
+public class IfWithoutBraces {
+    public static void main(String[] args) {
+        if (args == null)
+            throw new IllegalArgumentException();
+        else
+            System.out.println(Arrays.toString(args));
+    }
+}

--- a/languages/java/src/test/resources/java/Verbose.java
+++ b/languages/java/src/test/resources/java/Verbose.java
@@ -1,0 +1,28 @@
+package java;
+
+import java.util.ArrayList;
+
+public class Verbose {
+    static int tryCount(ArrayList<Integer> l, int n) {
+        if (l.size() == 0) {
+            return Integer.MAX_VALUE;
+        }
+
+        int count = 0;
+
+        for (int i = 0; i + 1 < l.size(); i++) {
+            if (l.get(i) + 1 != l.get(i + 1)) {
+                count++;
+            }
+        }
+        if (l.get(0) != 0) {
+            count++;
+        }
+
+        if (l.get(l.size() - 1) != n - 1) {
+            count++;
+        }
+
+        return count;
+    }
+}


### PR DESCRIPTION
Adapts the Java language module to no longer extract the block tokens `}INIT` and `INIT{`. Begin and end tokens are still extracted for control structures such as `if`, `else`, and `for`. As a consequence, the following two source codes will produce the same tokens:

```java
if(condition) {
    foo();
} else {
    bar():
}
```

```java
if(condition)
    foo();
else
    bar():
```

I added two test cases to the Java language module for this behavior.

As the underlying changes in this PR affect the token extraction for Java code, the test cases needed to be adapted. As a few test files were now too short (fewer tokens --> matches below MMT) I also adapted some test resources. The E2E test values were also updated.

This PR addresses #373.