### PR TITLE
enchance/solve bad performance when clicking metric button

### DIFF
--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -21,6 +21,7 @@
         "vue-chart-3": "^3.1.8",
         "vue-draggable-next": "^2.1.1",
         "vue-router": "^4.1.6",
+        "vue-virtual-scroller": "^2.0.0-beta.8",
         "vue3-highlightjs": "^1.0.5",
         "vuex": "^4.0.2"
       },
@@ -13492,6 +13493,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -17568,6 +17574,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/vue-observe-visibility": {
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-flFbp/gs9pZniXR6fans8smv1kDScJ8RS7rEpMjhVabiKeq7Qz3D9+eGsypncjfIyyU84saU88XZ0zjbD6Gq/g==",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
+    "node_modules/vue-resize": {
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.6.tgz",
@@ -17603,6 +17625,19 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "node_modules/vue-virtual-scroller": {
+      "version": "2.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-2.0.0-beta.8.tgz",
+      "integrity": "sha512-b8/f5NQ5nIEBRTNi6GcPItE4s7kxNHw2AIHLtDp+2QvqdTjVN0FgONwX9cr53jWRgnu+HRLPaWDOR2JPI5MTfQ==",
+      "dependencies": {
+        "mitt": "^2.1.0",
+        "vue-observe-visibility": "^2.0.0-alpha.1",
+        "vue-resize": "^2.0.0-alpha.1"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
     },
     "node_modules/vue3-highlightjs": {
       "version": "1.0.5",
@@ -28475,6 +28510,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "mitt": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-2.1.0.tgz",
+      "integrity": "sha512-ILj2TpLiysu2wkBbWjAmww7TkZb65aiQO+DkVdUTBpBXq+MHYiETENkKFMtsJZX1Lf4pe4QOrTSjIfUwN5lRdg=="
+    },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -31512,6 +31552,18 @@
         }
       }
     },
+    "vue-observe-visibility": {
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-flFbp/gs9pZniXR6fans8smv1kDScJ8RS7rEpMjhVabiKeq7Qz3D9+eGsypncjfIyyU84saU88XZ0zjbD6Gq/g==",
+      "requires": {}
+    },
+    "vue-resize": {
+      "version": "2.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-2.0.0-alpha.1.tgz",
+      "integrity": "sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==",
+      "requires": {}
+    },
     "vue-router": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.1.6.tgz",
@@ -31543,6 +31595,16 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue-virtual-scroller": {
+      "version": "2.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-2.0.0-beta.8.tgz",
+      "integrity": "sha512-b8/f5NQ5nIEBRTNi6GcPItE4s7kxNHw2AIHLtDp+2QvqdTjVN0FgONwX9cr53jWRgnu+HRLPaWDOR2JPI5MTfQ==",
+      "requires": {
+        "mitt": "^2.1.0",
+        "vue-observe-visibility": "^2.0.0-alpha.1",
+        "vue-resize": "^2.0.0-alpha.1"
+      }
     },
     "vue3-highlightjs": {
       "version": "1.0.5",

--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -23,6 +23,7 @@
     "vue-chart-3": "^3.1.8",
     "vue-draggable-next": "^2.1.1",
     "vue-router": "^4.1.6",
+    "vue-virtual-scroller": "^2.0.0-beta.8",
     "vue3-highlightjs": "^1.0.5",
     "vuex": "^4.0.2"
   },

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -2,7 +2,7 @@
   Table which display all of the comparisons with their participating ids and similarity percentage for the selected metric.
 -->
 <template>
-  <table class="table">
+  <table>
     <tr class="head-row">
       <th>No.</th>
       <th>Submission 1</th>

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -13,6 +13,7 @@
   </table>
 
   <DynamicScroller
+      v-if="topComparisons.length>0"
       class="scroller"
       :items="topComparisons"
       :min-item-size="48"

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -2,7 +2,7 @@
   Table which display all of the comparisons with their participating ids and similarity percentage for the selected metric.
 -->
 <template>
-  <table>
+  <table class="table">
     <tr class="head-row">
       <th>No.</th>
       <th>Submission 1</th>
@@ -10,113 +10,225 @@
       <th>Submission 2</th>
       <th>Match %</th>
     </tr>
-    <tr
-      v-for="(comparison, index) in topComparisons"
-      :key="
-        comparison.firstSubmissionId +
-        comparison.secondSubmissionId +
-        comparison.similarity
-      "
-      class="selectable"
-    >
+  </table>
+
+  <RecycleScroller
+      style="height: 650px; overflow: auto;"
+      class="scroller"
+      :items="topComparisons"
+      :item-size="48"
+      key-field="id"
+      v-slot="{ item }"
+  >
+    <table class="table" style="width: 100%">
+      <tr v-if="item.id % 2 === 0" class="selectableEven">
       <td
         @click="
           navigateToComparisonView(
-            comparison.firstSubmissionId,
-            comparison.secondSubmissionId
+            item.firstSubmissionId,
+            item.secondSubmissionId
           )
         "
+        class="td1"
       >
-        {{ index + 1 }}.
+        {{ item.id }}.
       </td>
       <td
         @click="
           navigateToComparisonView(
-            comparison.firstSubmissionId,
-            comparison.secondSubmissionId
+            item.firstSubmissionId,
+            item.secondSubmissionId
           )
         "
         :class="{
-          'anonymous-style': isAnonymous(comparison.firstSubmissionId),
+          'anonymous-style': isAnonymous(item.firstSubmissionId),
         }"
+        class="td2"
       >
         {{
-          isAnonymous(comparison.firstSubmissionId)
+          isAnonymous(item.firstSubmissionId)
             ? "Hidden"
-            : displayName(comparison.firstSubmissionId)
+            : displayName(item.firstSubmissionId)
         }}
       </td>
       <td
         @click="
           navigateToComparisonView(
-            comparison.firstSubmissionId,
-            comparison.secondSubmissionId
+            item.firstSubmissionId,
+            item.secondSubmissionId
           )
         "
+        class="td3"
       >
         <img alt=">>" src="@/assets/double_arrow_black_18dp.svg" />
       </td>
       <td
         @click="
           navigateToComparisonView(
-            comparison.firstSubmissionId,
-            comparison.secondSubmissionId
+            item.firstSubmissionId,
+            item.secondSubmissionId
           )
         "
         :class="{
-          'anonymous-style': isAnonymous(comparison.secondSubmissionId),
+          'anonymous-style': isAnonymous(item.secondSubmissionId),
         }"
+        class="td4"
       >
         {{
-          isAnonymous(comparison.secondSubmissionId)
+          isAnonymous(item.secondSubmissionId)
             ? "Hidden"
-            : displayName(comparison.secondSubmissionId)
+            : displayName(item.secondSubmissionId)
         }}
       </td>
       <td
         @click="
           navigateToComparisonView(
-            comparison.firstSubmissionId,
-            comparison.secondSubmissionId
+            item.firstSubmissionId,
+            item.secondSubmissionId
           )
         "
+        class="td5"
       >
-        {{ formattedMatchPercentage(comparison.similarity) }}
+        {{ formattedMatchPercentage(item.similarity) }}
       </td>
-      <td>
+      <td style="width: 5%">
         <img
           v-if="
             isInCluster(
-              comparison.firstSubmissionId,
-              comparison.secondSubmissionId
+              item.firstSubmissionId,
+              item.secondSubmissionId
             )
           "
           alt=">>"
           src="@/assets/keyboard_double_arrow_down_black_18dp.svg"
-          @click="toggleDialog(index)"
+          @click="toggleDialog(item.id-1)"
         />
       </td>
       <GDialog
         v-if="
           isInCluster(
-            comparison.firstSubmissionId,
-            comparison.secondSubmissionId
+            item.firstSubmissionId,
+            item.secondSubmissionId
           )
         "
-        v-model="dialog[index]"
+        v-model="dialog[item.id-1]"
       >
         <ClustersList
           :clusters="
             getClustersFor(
-              comparison.firstSubmissionId,
-              comparison.secondSubmissionId
+              item.firstSubmissionId,
+              item.secondSubmissionId
             )
           "
-          :comparison="comparison"
+          :comparison="item"
         />
       </GDialog>
-    </tr>
-  </table>
+      </tr>
+      <tr v-else class="selectableOdd">
+        <td
+            @click="
+          navigateToComparisonView(
+            item.firstSubmissionId,
+            item.secondSubmissionId
+          )
+        "
+            class="td1"
+        >
+          {{ item.id }}.
+        </td>
+        <td
+            @click="
+          navigateToComparisonView(
+            item.firstSubmissionId,
+            item.secondSubmissionId
+          )
+        "
+            :class="{
+          'anonymous-style': isAnonymous(item.firstSubmissionId),
+        }"
+            class="td2"
+        >
+          {{
+            isAnonymous(item.firstSubmissionId)
+                ? "Hidden"
+                : displayName(item.firstSubmissionId)
+          }}
+        </td>
+        <td
+            @click="
+          navigateToComparisonView(
+            item.firstSubmissionId,
+            item.secondSubmissionId
+          )
+        "
+            class="td3"
+        >
+          <img alt=">>" src="@/assets/double_arrow_black_18dp.svg" />
+        </td>
+        <td
+            @click="
+          navigateToComparisonView(
+            item.firstSubmissionId,
+            item.secondSubmissionId
+          )
+        "
+            :class="{
+          'anonymous-style': isAnonymous(item.secondSubmissionId),
+        }"
+            class="td4"
+        >
+          {{
+            isAnonymous(item.secondSubmissionId)
+                ? "Hidden"
+                : displayName(item.secondSubmissionId)
+          }}
+        </td>
+        <td
+            @click="
+          navigateToComparisonView(
+            item.firstSubmissionId,
+            item.secondSubmissionId
+          )
+        "
+            class="td5"
+        >
+          {{ formattedMatchPercentage(item.similarity) }}
+        </td>
+        <td style="width: 5%">
+          <img
+              v-if="
+            isInCluster(
+              item.firstSubmissionId,
+              item.secondSubmissionId
+            )
+          "
+              alt=">>"
+              src="@/assets/keyboard_double_arrow_down_black_18dp.svg"
+              @click="toggleDialog(item.id-1)"
+          />
+        </td>
+        <GDialog
+            v-if="
+          isInCluster(
+            item.firstSubmissionId,
+            item.secondSubmissionId
+          )
+        "
+            v-model="dialog[item.id-1]"
+        >
+          <ClustersList
+              :clusters="
+            getClustersFor(
+              item.firstSubmissionId,
+              item.secondSubmissionId
+            )
+          "
+              :comparison="item"
+          />
+        </GDialog>
+      </tr>
+    </table>
+  </RecycleScroller>
 </template>
 
 <script lang="ts">
@@ -247,18 +359,11 @@ export default defineComponent({
 </script>
 
 <style scoped>
-table {
+.table {
+  table-layout: fixed;
   border-collapse: collapse;
   font-size: larger;
   text-align: center;
-}
-
-tr:nth-child(odd) {
-  background: var(--primary-color-light);
-}
-
-tr:nth-child(even) {
-  background: var(--secondary-color);
 }
 
 th {
@@ -268,10 +373,35 @@ th {
   color: var(--on-primary-color);
 }
 
-td {
+.td1 {
+  padding-right: 10%;
   padding-top: 3%;
   padding-bottom: 3%;
 }
+
+.td2 {
+  padding-right: 5%;
+   padding-top: 3%;
+   padding-bottom: 3%;
+ }
+
+.td3 {
+  padding-right: 5%;
+   padding-top: 3%;
+   padding-bottom: 3%;
+ }
+
+.td4 {
+  padding-right: 5%;
+   padding-top: 3%;
+   padding-bottom: 3%;
+ }
+
+.td5 {
+  padding-left: 6%;
+   padding-top: 3%;
+   padding-bottom: 3%;
+ }
 
 .anonymous-style {
   color: #777777;
@@ -282,8 +412,23 @@ td {
   background: var(--primary-color-light);
 }
 
-.selectable:hover {
-  background: var(--primary-color-dark);
+.selectableEven{
+  background: var(--primary-color-light);
+  cursor: pointer;
+}
+
+.selectableOdd{
+  background: var(--secondary-color);
+  cursor: pointer;
+}
+
+.selectableEven:hover {
+  background: var(--primary-color-dark) !important;
+  cursor: pointer;
+}
+
+.selectableOdd:hover {
+  background: var(--primary-color-dark) !important;
   cursor: pointer;
 }
 </style>

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -12,223 +12,129 @@
     </tr>
   </table>
 
-  <RecycleScroller
-      style="height: 650px; overflow: auto;"
+  <DynamicScroller
       class="scroller"
       :items="topComparisons"
-      :item-size="48"
-      key-field="id"
-      v-slot="{ item }"
+      :min-item-size="48"
   >
-    <table class="table" style="width: 100%">
-      <tr v-if="item.id % 2 === 0" class="selectableEven">
-      <td
-        @click="
-          navigateToComparisonView(
-            item.firstSubmissionId,
-            item.secondSubmissionId
-          )
-        "
-        class="td1"
+    <template v-slot="{ item, index, active }">
+      <DynamicScrollerItem
+          :item="item"
+          :active="active"
+          :size-dependencies="[
+          item.firstSubmissionId,
+          item.secondSubmissionId,
+        ]"
+          :data-index="index"
       >
-        {{ item.id }}.
-      </td>
-      <td
-        @click="
+        <table class="inside-table">
+          <tr :class="{'selectableEven': item.id % 2 === 0, 'selectableOdd': item.id % 2 !== 0}">
+            <td
+                @click="
           navigateToComparisonView(
             item.firstSubmissionId,
             item.secondSubmissionId
           )
         "
-        :class="{
+                class="td1"
+            >
+              {{ item.id }}.
+            </td>
+            <td
+                @click="
+          navigateToComparisonView(
+            item.firstSubmissionId,
+            item.secondSubmissionId
+          )
+        "
+                :class="{
           'anonymous-style': isAnonymous(item.firstSubmissionId),
         }"
-        class="td2"
-      >
-        {{
-          isAnonymous(item.firstSubmissionId)
-            ? "Hidden"
-            : displayName(item.firstSubmissionId)
-        }}
-      </td>
-      <td
-        @click="
+                class="td2"
+            >
+              {{
+                isAnonymous(item.firstSubmissionId)
+                    ? "Hidden"
+                    : displayName(item.firstSubmissionId)
+              }}
+            </td>
+            <td
+                @click="
           navigateToComparisonView(
             item.firstSubmissionId,
             item.secondSubmissionId
           )
         "
-        class="td3"
-      >
-        <img alt=">>" src="@/assets/double_arrow_black_18dp.svg" />
-      </td>
-      <td
-        @click="
+                class="td3"
+            >
+              <img alt=">>" src="@/assets/double_arrow_black_18dp.svg" />
+            </td>
+            <td
+                @click="
           navigateToComparisonView(
             item.firstSubmissionId,
             item.secondSubmissionId
           )
         "
-        :class="{
+                :class="{
           'anonymous-style': isAnonymous(item.secondSubmissionId),
         }"
-        class="td4"
-      >
-        {{
-          isAnonymous(item.secondSubmissionId)
-            ? "Hidden"
-            : displayName(item.secondSubmissionId)
-        }}
-      </td>
-      <td
-        @click="
+                class="td4"
+            >
+              {{
+                isAnonymous(item.secondSubmissionId)
+                    ? "Hidden"
+                    : displayName(item.secondSubmissionId)
+              }}
+            </td>
+            <td
+                @click="
           navigateToComparisonView(
             item.firstSubmissionId,
             item.secondSubmissionId
           )
         "
-        class="td5"
-      >
-        {{ formattedMatchPercentage(item.similarity) }}
-      </td>
-      <td style="width: 5%">
-        <img
-          v-if="
+                class="td5"
+            >
+              {{ formattedMatchPercentage(item.similarity) }}
+            </td>
+            <td class="td6">
+              <img
+                  v-if="
             isInCluster(
               item.firstSubmissionId,
               item.secondSubmissionId
             )
           "
-          alt=">>"
-          src="@/assets/keyboard_double_arrow_down_black_18dp.svg"
-          @click="toggleDialog(item.id-1)"
-        />
-      </td>
-      <GDialog
-        v-if="
+                  alt=">>"
+                  src="@/assets/keyboard_double_arrow_down_black_18dp.svg"
+                  @click="toggleDialog(item.id-1)"
+              />
+            </td>
+            <GDialog
+                v-if="
           isInCluster(
             item.firstSubmissionId,
             item.secondSubmissionId
           )
         "
-        v-model="dialog[item.id-1]"
-      >
-        <ClustersList
-          :clusters="
+                v-model="dialog[item.id-1]"
+            >
+              <ClustersList
+                  :clusters="
             getClustersFor(
               item.firstSubmissionId,
               item.secondSubmissionId
             )
           "
-          :comparison="item"
-        />
-      </GDialog>
-      </tr>
-      <tr v-else class="selectableOdd">
-        <td
-            @click="
-          navigateToComparisonView(
-            item.firstSubmissionId,
-            item.secondSubmissionId
-          )
-        "
-            class="td1"
-        >
-          {{ item.id }}.
-        </td>
-        <td
-            @click="
-          navigateToComparisonView(
-            item.firstSubmissionId,
-            item.secondSubmissionId
-          )
-        "
-            :class="{
-          'anonymous-style': isAnonymous(item.firstSubmissionId),
-        }"
-            class="td2"
-        >
-          {{
-            isAnonymous(item.firstSubmissionId)
-                ? "Hidden"
-                : displayName(item.firstSubmissionId)
-          }}
-        </td>
-        <td
-            @click="
-          navigateToComparisonView(
-            item.firstSubmissionId,
-            item.secondSubmissionId
-          )
-        "
-            class="td3"
-        >
-          <img alt=">>" src="@/assets/double_arrow_black_18dp.svg" />
-        </td>
-        <td
-            @click="
-          navigateToComparisonView(
-            item.firstSubmissionId,
-            item.secondSubmissionId
-          )
-        "
-            :class="{
-          'anonymous-style': isAnonymous(item.secondSubmissionId),
-        }"
-            class="td4"
-        >
-          {{
-            isAnonymous(item.secondSubmissionId)
-                ? "Hidden"
-                : displayName(item.secondSubmissionId)
-          }}
-        </td>
-        <td
-            @click="
-          navigateToComparisonView(
-            item.firstSubmissionId,
-            item.secondSubmissionId
-          )
-        "
-            class="td5"
-        >
-          {{ formattedMatchPercentage(item.similarity) }}
-        </td>
-        <td style="width: 5%">
-          <img
-              v-if="
-            isInCluster(
-              item.firstSubmissionId,
-              item.secondSubmissionId
-            )
-          "
-              alt=">>"
-              src="@/assets/keyboard_double_arrow_down_black_18dp.svg"
-              @click="toggleDialog(item.id-1)"
-          />
-        </td>
-        <GDialog
-            v-if="
-          isInCluster(
-            item.firstSubmissionId,
-            item.secondSubmissionId
-          )
-        "
-            v-model="dialog[item.id-1]"
-        >
-          <ClustersList
-              :clusters="
-            getClustersFor(
-              item.firstSubmissionId,
-              item.secondSubmissionId
-            )
-          "
-              :comparison="item"
-          />
-        </GDialog>
-      </tr>
-    </table>
-  </RecycleScroller>
+                  :comparison="item"
+              />
+            </GDialog>
+          </tr>
+        </table>
+      </DynamicScrollerItem>
+    </template>
+  </DynamicScroller>
 </template>
 
 <script lang="ts">
@@ -359,11 +265,19 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.table {
+.scroller{
+  height: 650px;
+}
+
+table {
   table-layout: fixed;
   border-collapse: collapse;
   font-size: larger;
   text-align: center;
+}
+
+.inside-table {
+  width: 100%;
 }
 
 th {
@@ -373,35 +287,36 @@ th {
   color: var(--on-primary-color);
 }
 
-.td1 {
-  padding-right: 10%;
+td {
   padding-top: 3%;
   padding-bottom: 3%;
 }
 
+.td1 {
+  width: 3%;
+}
+
 .td2 {
-  padding-right: 5%;
-   padding-top: 3%;
-   padding-bottom: 3%;
+  width: 18%;
+  padding-left: 5%;
  }
 
 .td3 {
-  padding-right: 5%;
-   padding-top: 3%;
-   padding-bottom: 3%;
+   width: 3%;
  }
 
 .td4 {
-  padding-right: 5%;
-   padding-top: 3%;
-   padding-bottom: 3%;
+   width: 18%;
+   padding-right: 5%;
  }
 
 .td5 {
-  padding-left: 6%;
-   padding-top: 3%;
-   padding-bottom: 3%;
+   width: 8%;
  }
+
+.td6 {
+  width: 2%;
+}
 
 .anonymous-style {
   color: #777777;

--- a/report-viewer/src/main.ts
+++ b/report-viewer/src/main.ts
@@ -2,9 +2,11 @@ import {createApp} from "vue";
 import App from "./App.vue";
 import router from "./router";
 import store from "./store/store"
+import VueVirtualScroller from "vue-virtual-scroller"
 import 'highlight.js/styles/vs.css'
 import 'gitart-vue-dialog/dist/style.css'
 import 'highlight.js/lib/common';
+import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
 
 
-createApp(App).use(router).use(store).mount("#app");
+createApp(App).use(router).use(store).use(VueVirtualScroller).mount("#app");

--- a/report-viewer/src/model/ComparisonListElement.ts
+++ b/report-viewer/src/model/ComparisonListElement.ts
@@ -3,6 +3,7 @@
  * For full comparison model see Comparison.ts
  */
 export type ComparisonListElement = {
+    id: number,
     firstSubmissionId: string,
     secondSubmissionId: string,
     similarity: number

--- a/report-viewer/src/model/factories/OverviewFactory.ts
+++ b/report-viewer/src/model/factories/OverviewFactory.ts
@@ -36,8 +36,9 @@ export class OverviewFactory {
       const comparisons = [] as Array<ComparisonListElement>;
 
       (metric.topComparisons as Array<Record<string, unknown>>).forEach(
-        (jsonComparison) => {
+        (jsonComparison,index) => {
           const comparison: ComparisonListElement = {
+            id: index + 1 as number,
             firstSubmissionId: jsonComparison.first_submission as string,
             secondSubmissionId: jsonComparison.second_submission as string,
             similarity: jsonComparison.similarity as number,

--- a/report-viewer/src/router/index.ts
+++ b/report-viewer/src/router/index.ts
@@ -1,8 +1,5 @@
 import "./public-path"
 import {createRouter, createWebHistory, RouteRecordRaw} from "vue-router";
-import OverviewView from "@/views/OverviewView.vue";
-import ComparisonView from "@/views/ComparisonView.vue";
-import FileUploadView from "@/views/FileUploadView.vue";
 
 /**
  * Router containing the navigation destinations.
@@ -11,17 +8,17 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: "/",
     name: "FileUploadView",
-    component: FileUploadView,
+    component: () => import('@/views/FileUploadView.vue'),
   },
   {
     path: "/overview",
     name: "OverviewView",
-    component: OverviewView,
+    component: () => import('@/views/OverviewView.vue'),
   },
   {
     path: "/comparison/:firstId/:secondId",
     name: "ComparisonView",
-    component: ComparisonView,
+    component: () => import('@/views/ComparisonView.vue'),
     props: true,
   },
 ];

--- a/report-viewer/src/vue-virtual-scroll.d.ts
+++ b/report-viewer/src/vue-virtual-scroll.d.ts
@@ -1,0 +1,21 @@
+// Type definitions for vue-virtual-scroller
+// Project: https://github.com/Akryum/vue-virtual-scroller/
+declare module "vue-virtual-scroller" {
+    import Vue, { ComponentOptions, PluginObject, Component } from "vue";
+    interface PluginOptions {
+        installComponents?: boolean;
+        componentsPrefix?: string;
+    }
+
+    const plugin: PluginObject<PluginOptions> & { version: string };
+
+    export const RecycleScroller: Component<any, any, any, any>;
+    export const DynamicScroller: Component<any, any, any, any>;
+    export const DynamicScrollerItem: Component<any, any, any, any>;
+
+    export function IdState(options?: {
+        idProp?: (vm: any) => any;
+    }): ComponentOptions<Vue> | typeof Vue;
+
+    export default plugin;
+}

--- a/report-viewer/src/vue-virtual-scroll.d.ts
+++ b/report-viewer/src/vue-virtual-scroll.d.ts
@@ -1,5 +1,6 @@
 // Type definitions for vue-virtual-scroller
 // Project: https://github.com/Akryum/vue-virtual-scroller/
+// Reference: https://github.com/Akryum/vue-virtual-scroller/issues/199
 declare module "vue-virtual-scroller" {
     import Vue, { ComponentOptions, PluginObject, Component } from "vue";
     interface PluginOptions {

--- a/report-viewer/tests/unit/model/Overview.spec.ts
+++ b/report-viewer/tests/unit/model/Overview.spec.ts
@@ -14,52 +14,61 @@ test('overview', () => {
         "distribution": [1, 0, 2, 0, 0, 0, 0, 3, 0, 4],
         "metricThreshold": 0,
         "comparisons": [
-            {
+            {   "id": 1,
                 "firstSubmissionId": "A",
                 "secondSubmissionId": "C",
                 "similarity": 0.9966329966329966
             },
             {
+                "id": 2,
                 "firstSubmissionId": "D",
                 "secondSubmissionId": "A",
                 "similarity": 0.7787255393878575
             },
             {
+                "id": 3,
                 "firstSubmissionId": "D",
                 "secondSubmissionId": "C",
                 "similarity": 0.7787255393878575
             },
             {
+                "id": 4,
                 "firstSubmissionId": "B",
                 "secondSubmissionId": "D",
                 "similarity": 0.2827868852459016
             },
             {
+                "id": 5,
                 "firstSubmissionId": "B",
                 "secondSubmissionId": "A",
                 "similarity": 0.2457689477557027
             },
             {
+                "id": 6,
                 "firstSubmissionId": "B",
                 "secondSubmissionId": "C",
                 "similarity": 0.2457689477557027
             },
             {
+                "id": 7,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "A",
                 "similarity": 0
             },
             {
+                "id": 8,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "D",
                 "similarity": 0
             },
             {
+                "id": 9,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "B",
                 "similarity": 0
             },
             {
+                "id": 10,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "C",
                 "similarity": 0
@@ -72,51 +81,61 @@ test('overview', () => {
         "metricThreshold": 0,
         "comparisons": [
             {
+                "id": 1,
                 "firstSubmissionId": "A",
                 "secondSubmissionId": "C",
                 "similarity": 0.9966329966329966
             },
             {
+                "id": 2,
                 "firstSubmissionId": "B",
                 "secondSubmissionId": "A",
                 "similarity": 0.9766081871345029
             },
             {
+                "id": 3,
                 "firstSubmissionId": "B",
                 "secondSubmissionId": "C",
                 "similarity": 0.9766081871345029
             },
             {
+                "id": 4,
                 "firstSubmissionId": "D",
                 "secondSubmissionId": "A",
                 "similarity": 0.9639751552795031
             },
             {
+                "id": 5,
                 "firstSubmissionId": "D",
                 "secondSubmissionId": "C",
                 "similarity": 0.9639751552795031
             },
             {
+                "id": 6,
                 "firstSubmissionId": "B",
                 "secondSubmissionId": "D",
                 "similarity": 0.8070175438596491
             },
             {
+                "id": 7,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "A",
                 "similarity": 0
             },
             {
+                "id": 8,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "D",
                 "similarity": 0
             },
             {
+                "id": 9,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "B",
                 "similarity": 0
             },
             {
+                "id": 10,
                 "firstSubmissionId": "E",
                 "secondSubmissionId": "C",
                 "similarity": 0


### PR DESCRIPTION
This PR fixed bad performance when clicking metric button. When there are more than thousand comparisons, it becomes very slow. The reason is that, web page needs to re-render thousand of DOM nodes (`<tr>`). Because all comparisons shows in the `ComparisonsTable `. It wastes too much time and mermory. I found it takes 1 second or even serval seconds to load page in Vue dev tool, when there are over 1K comparisons.  This problem should be considered at designing, but not too late.

Actually, there are two solutions;

1. ###  paging: 

show some parts of comparisons in one page. This solution dosen't fit our design. Because scrolling will be more suitable to see the coherence of similarity. From high to low.

2. ###  virtual scroll:  

Virtual scrolling enables a performant way to simulate all items being rendered by making the height of the container element the same as the height of a total number of elements to be rendered, and then only rendering the items in view. So performance is really good, even there are over 10K records. So I choose this way to improve the performance. But we need install this plugin `(vue-virtual-scroller@next)`.

I keep the layout of this `ComparisonsTable ` as before as possible. Because original table layout must be replaced when using this plugin.

Additionally, I also made the route lazy loaded.

