### PR TITLE
Improve the end-to-end tests by adding summary tests

### DIFF
--- a/core/src/main/java/de/jplag/options/SimilarityMetric.java
+++ b/core/src/main/java/de/jplag/options/SimilarityMetric.java
@@ -5,14 +5,16 @@ import java.util.function.ToDoubleFunction;
 import de.jplag.JPlagComparison;
 
 public enum SimilarityMetric implements ToDoubleFunction<JPlagComparison> {
-    AVG(JPlagComparison::similarity),
-    MIN(JPlagComparison::minimalSimilarity),
-    MAX(JPlagComparison::maximalSimilarity),
-    INTERSECTION(it -> (double) it.getNumberOfMatchedTokens());
+    AVG("average similarity", JPlagComparison::similarity),
+    MIN("minimum similarity", JPlagComparison::minimalSimilarity),
+    MAX("maximal similarity", JPlagComparison::maximalSimilarity),
+    INTERSECTION("matched tokens", it -> (double) it.getNumberOfMatchedTokens());
 
     private final ToDoubleFunction<JPlagComparison> similarityFunction;
+    private final String description;
 
-    SimilarityMetric(ToDoubleFunction<JPlagComparison> similarityFunction) {
+    SimilarityMetric(String description, ToDoubleFunction<JPlagComparison> similarityFunction) {
+        this.description = description;
         this.similarityFunction = similarityFunction;
     }
 
@@ -23,5 +25,10 @@ public enum SimilarityMetric implements ToDoubleFunction<JPlagComparison> {
     @Override
     public double applyAsDouble(JPlagComparison comparison) {
         return similarityFunction.applyAsDouble(comparison);
+    }
+
+    @Override
+    public String toString() {
+        return description;
     }
 }

--- a/endtoend-testing/README.md
+++ b/endtoend-testing/README.md
@@ -5,7 +5,7 @@ With the help of elaborated plagiarism, which has been worked out from suggestio
 
 ## References
 These elaborations provide basic ideas on how a modification of the plagiarized source code can look or be adapted.
-These code adaptations refer to a wide range of changes, from
+These code adaptations refer to various changes, from
 adding/removing comments to architectural changes in the deliverables.
 
 The following elaborations were used to be able to create the plagiarisms with the broadest coverage:
@@ -47,13 +47,13 @@ More detailed information about the creation as well as about the subject of the
 ## JPlag - End-To-End TestSuite Structure
 The construction of an end-to-end test is done with the help of the JPlag API. 
 The tests are generated dynamically according to the existing test data and allow the creation of end-to-end tests for all supported languages of JPlag without making any changes to the code.
-The helper loads the existing test data from the designated directory and creates dynamic tests for the individual directories. It is possible to create different test classes for the different languages.
+The helper loads the existing test data from the designated directory and creates dynamic tests for the individual directories. It is possible to create different test classes for the other languages.
 
-To distinguish which domain of the recognition changes have occurred, fine granular test cases are used. These are composed of the changes already mentioned above. The plagiarism is compared with the original delivery; thus, it is possible to detect and test small sections of the recognition. 
+To distinguish which domain of the recognition changes have occurred, fine granular test cases are used. These are composed of the changes already mentioned above. The plagiarism is compared with the original delivery; thus, detecting and testing small sections of the recognition is possible. 
 
 The comparative values were discussed and tested. The following results of the JPlag scan are used for the comparison:
-1. minimal similarity as `float`
-2. maximum similarity as `float`
+1. minimal similarity as `double`
+2. maximum similarity as `double`
 3. matched token number as `int`
 
 The comparative values were discussed and elaborated in the issue [End-to-end testing - "comparative values"](https://github.com/jplag/JPlag/issues/548 "End-to-end testing - \"comparative values\""). 
@@ -65,12 +65,12 @@ This was done by storing the data in a *.json file which is read at the beginnin
 
 ### JSON Result Structure
 
-The structures of the Json file can be traced using the individual record classes, which can be found under `de.jplag.endtoend.model`.
+The structures of the JSON file can be traced using the individual record classes, which can be found under `de.jplag.endtoend.model`.
 The outer structure of the JSON file is recorded in the `ResultDescription` record. 
 The record contains a map of several options and the corresponding results. 
 The internal structure consists of several `Option` records, each containing information about the test run's current configuration. 
 Thus the results can be kept apart from the other configurations. 
-The test results for the specified options are also specified in the object. This consists of the `ExpectedResult` record, which contains the results of the detection.
+The test results for the specified options are also specified in the object. This consists of the `ExpectedResult` record, which contains the detection results.
 
 Here the hierarchy is as follows:
 
@@ -81,8 +81,8 @@ Here the hierarchy is as follows:
   },
   "tests":{
     "languageIdentifier":{
-      "minimal_similarity":"float",
-      "maximum_similarity":"float",
+      "minimal_similarity":"double",
+      "maximum_similarity":"double",
       "matched_token_number":"int"
     },
   "/..."
@@ -94,8 +94,8 @@ Here the hierarchy is as follows:
   },
   "tests":{
     "languageIdentifier":{
-      "minimal_similarity":"float",
-      "maximum_similarity":"float",
+      "minimal_similarity":"double",
+      "maximum_similarity":"double",
       "matched_token_number":"int"
     },
     "/..."
@@ -110,7 +110,7 @@ Here the hierarchy is as follows:
 This section explains how to create new end-to-end tests in the existing test suite. 
 ### Creating The Plagiarism
 Before you add a new language to the end-to-end tests, I would like to point out that the quality of the tests depends dreadfully on the plagiarism techniques you choose, which were explained in section [Steps Towards Plagiarism](#steps-towards-plagiarism).
-If you need more information about the creation of plans for this purpose, you can also read the elaborations that can be found under [References](#references).
+If you need more information about creating plans for this purpose, you can also read the elaborations that can be found under [References](#references).
 The more various changes you apply, the more accurate the end-to-end tests for the language will be.
 
 In the following, an example is shown, which is in the JavaEndToEnd tests and is used.
@@ -181,7 +181,7 @@ public record ExpectedResult(
 }
 ```
 
-- To be able to include the new value in the tests, they must be added to the `EndToEndSuiteTest` as a comparison operation at the package `de.jplag.endtoend`. The `runJPlagTestSuite()` function provided for this purpose must be extended to include the new comparison value. To do this, create the comparison as shown in the code example below.
+- To include the new value in the tests, they must be added to the `EndToEndSuiteTest` as a comparison operation at the package `de.jplag.endtoend`. The `runJPlagTestSuite()` function provided for this purpose must be extended to include the new comparison value. To do this, create the comparison as shown in the code example below.
 
 ```JAVA
 //...
@@ -193,12 +193,12 @@ public record ExpectedResult(
 ```
 
 - Once the tests run the first time, they will fail due to the missing values in the old JSON result file used for the test cases. The old results must then be replaced with new ones. 
-For this purpose, the last section of the chapter [Copying Plagiarism To The Resources](#copying-plagiarism-to-the-resources) can be used as help. 
+For this purpose, the last section of the chapter [Copying Plagiarism To The Resources](#copying-plagiarism-to-the-resources) can help. 
 
-###  Extending JPlar Test Run Options
+###  Extending JPlag Test Run Options
 The end-to-end tests support the possible scan options of the JPlag API. Currently, `minimumTokenMatch` is used in the end-to-end tests. These values are also stored in the JSON as configuration to keep the test cases at the options apart. Likewise, also changes in the logic of the different options are to be determined to be able.
 
-- To extend new options to the end-to-end tests, they have to be added to the record object `Options` in the package `de.jplag.endtoend.model`. Here it is sufficient to add the values in the record and to enter the JSON name as `@JsonProperty("json_name")`.
+- To extend new options to the end-to-end tests, they must be added to the record object `Options` in the package `de.jplag.endtoend.model`. Here it is sufficient to add the values in the record and to enter the JSON name as `@JsonProperty("json_name")`.
 
 ```JAVA
 public record Options(
@@ -216,7 +216,7 @@ public record Options(
     }
 ```
 
-- If you want to create individual test cases by testing the options only on a specific set of dates, a new test case must be created for this purpose. The transfer parameter options can be adjusted and specified for the new test cases. This can then be tested with the function `runTests`. 
+- If you want to create individual test cases by testing the options only on a specific dataset, a new test case must be created for this purpose. The transfer parameter options can be adjusted and specified for the new test cases. This can then be tested with the function `runTests`. 
  ```JAVA 
  runTests(directoryName, option, currentLanguageIdentifier, testCase, currentResultDescription);
 ```

--- a/endtoend-testing/src/main/java/de/jplag/endtoend/helper/DeltaSummaryStatistics.java
+++ b/endtoend-testing/src/main/java/de/jplag/endtoend/helper/DeltaSummaryStatistics.java
@@ -1,0 +1,62 @@
+package de.jplag.endtoend.helper;
+
+import java.util.DoubleSummaryStatistics;
+
+/**
+ * Summary statistics when evaluating the delta between two double values. This class manages two
+ * {@link DoubleSummaryStatistics} and delegates the delta of the accepted values to the statistics depending on the
+ * sign of the delta. In contrast to normal {@link DoubleSummaryStatistics}, negative and positive deltas do not cancel
+ * each other out in the average value, as two separate statistics are managed. A delta of zero is not stored.
+ */
+public class DeltaSummaryStatistics {
+    private final DoubleSummaryStatistics positive;
+    private final DoubleSummaryStatistics negative;
+
+    /**
+     * Creates the delta summary statistics.
+     */
+    public DeltaSummaryStatistics() {
+        positive = new FormattedDoubleSummaryStatistics();
+        negative = new FormattedDoubleSummaryStatistics();
+    }
+
+    /**
+     * Calculates the delta of the two double values and delegates it to the statistics depending on the sign of the delta.
+     * A delta of zero is not stored.
+     * @param first is the first double value.
+     * @param second is the second double value.
+     */
+    public void accept(double first, double second) {
+        double delta = first - second;
+        if (delta > 0) {
+            positive.accept(delta);
+        } else if (delta < 0) {
+            negative.accept(-delta); // delta is absolute
+        }
+    }
+
+    /**
+     * @return the {@link DoubleSummaryStatistics} of the positive delta values.
+     */
+    public DoubleSummaryStatistics getPositiveStatistics() {
+        return positive;
+    }
+
+    /**
+     * @return the {@link DoubleSummaryStatistics} of the negaitve delta values.
+     */
+    public DoubleSummaryStatistics getNegativeStatistics() {
+        return negative;
+    }
+
+    /**
+     * Customized implementation of {@link DoubleSummaryStatistics} with a customized textual representation.
+     */
+    private class FormattedDoubleSummaryStatistics extends DoubleSummaryStatistics {
+        @Override
+        public String toString() {
+            return String.format("count=%d, average=%,.4f, min=%,.4f, max=%,.4f", getCount(), getAverage(), getMin(), getMax());
+        }
+    }
+
+}

--- a/endtoend-testing/src/main/java/de/jplag/endtoend/helper/DeltaSummaryStatistics.java
+++ b/endtoend-testing/src/main/java/de/jplag/endtoend/helper/DeltaSummaryStatistics.java
@@ -55,7 +55,7 @@ public class DeltaSummaryStatistics {
     private class FormattedDoubleSummaryStatistics extends DoubleSummaryStatistics {
         @Override
         public String toString() {
-            return String.format("count=%d, average=%,.4f, min=%,.4f, max=%,.4f", getCount(), getAverage(), getMin(), getMax());
+            return String.format("count=%d, average=%.4f, min=%.4f, max=%.4f", getCount(), getAverage(), getMin(), getMax());
         }
     }
 

--- a/endtoend-testing/src/main/java/de/jplag/endtoend/model/ExpectedResult.java
+++ b/endtoend-testing/src/main/java/de/jplag/endtoend/model/ExpectedResult.java
@@ -1,5 +1,7 @@
 package de.jplag.endtoend.model;
 
+import de.jplag.options.SimilarityMetric;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -9,4 +11,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public record ExpectedResult(@JsonProperty("minimal_similarity") double resultSimilarityMinimum,
         @JsonProperty("maximum_similarity") double resultSimilarityMaximum, @JsonProperty("matched_token_number") int resultMatchedTokenNumber) {
+
+    /**
+     * Returns the value of a similarity metric for this result.
+     * @param metric is the specified similarity metric.
+     * @return the similarity value as a double value.
+     */
+    public double getSimilarityForMetric(SimilarityMetric metric) {
+        return switch (metric) {
+            case AVG -> (resultSimilarityMinimum() + resultSimilarityMaximum()) / 2.0;
+            case MIN -> resultSimilarityMinimum();
+            case MAX -> resultSimilarityMaximum();
+            case INTERSECTION -> resultMatchedTokenNumber();
+            default -> throw new IllegalArgumentException("Metric not supported!");
+        };
+    }
+
 }

--- a/endtoend-testing/src/test/java/de/jplag/endtoend/EndToEndSuiteTest.java
+++ b/endtoend-testing/src/test/java/de/jplag/endtoend/EndToEndSuiteTest.java
@@ -1,16 +1,21 @@
 package de.jplag.endtoend;
 
+import static de.jplag.options.SimilarityMetric.INTERSECTION;
+import static de.jplag.options.SimilarityMetric.MAX;
+import static de.jplag.options.SimilarityMetric.MIN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.DoubleSummaryStatistics;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -24,19 +29,21 @@ import de.jplag.JPlagResult;
 import de.jplag.Language;
 import de.jplag.cli.LanguageLoader;
 import de.jplag.endtoend.constants.TestDirectoryConstants;
+import de.jplag.endtoend.helper.DeltaSummaryStatistics;
 import de.jplag.endtoend.helper.FileHelper;
 import de.jplag.endtoend.helper.TestSuiteHelper;
 import de.jplag.endtoend.model.ExpectedResult;
 import de.jplag.endtoend.model.ResultDescription;
 import de.jplag.exceptions.ExitException;
 import de.jplag.options.JPlagOptions;
+import de.jplag.options.SimilarityMetric;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * Main test class for end-to-end testing in all language. The test cases aim to detect changes in the detection of
- * plagiarism in the Java language and to be able to roughly categorize them. The plagiarism is compared with the
- * original class. The results are compared with the results from previous tests and changes are detected.
+ * Main test suite for end-to-end testing over all languages. The test suite aims to detect changes regarding the
+ * detection quality of JPlag. Artificial plagiarisms are compared with the original code. The results are compared with
+ * previous ones stored in the resource folder.
  */
 class EndToEndSuiteTest {
     private static final double EPSILON = 1E-8;
@@ -47,26 +54,39 @@ class EndToEndSuiteTest {
      * @throws IOException is thrown for all problems that may occur while parsing the json file.
      */
     @TestFactory
-    Collection<DynamicContainer> dynamicOverAllTest() throws IOException, ExitException {
-        File resultsDirectory = TestDirectoryConstants.BASE_PATH_TO_RESULT_JSON.toFile();
-        File[] languageDirectories = resultsDirectory.listFiles(File::isDirectory);
-        List<DynamicContainer> allTests = new LinkedList<>();
+    Collection<DynamicContainer> endToEndTestFactory() throws ExitException {
+        File resultDirectory = TestDirectoryConstants.BASE_PATH_TO_RESULT_JSON.toFile();
+        List<File> languageDirectories = Arrays.asList(resultDirectory.listFiles(File::isDirectory));
+        List<DynamicContainer> allTests = new ArrayList<>();
         for (File languageDirectory : languageDirectories) {
-            Language language = LanguageLoader.getLanguage(languageDirectory.getName()).orElseThrow();
-            File[] resultJsons = languageDirectory.listFiles(file -> !file.isDirectory() && file.getName().endsWith(".json"));
-            List<DynamicContainer> languageTests = new LinkedList<>();
-            for (File resultJson : resultJsons) {
-                List<DynamicContainer> testContainers = new LinkedList<>();
-                ResultDescription[] results = new ObjectMapper().readValue(resultJson, ResultDescription[].class);
-                for (var result : results) {
-                    var testCases = generateTestsForResultDescription(resultJson, result, language);
-                    testContainers.add(DynamicContainer.dynamicContainer("MTM: " + result.options().minimumTokenMatch(), testCases));
-                }
-                languageTests.add(DynamicContainer.dynamicContainer(FileHelper.getFileNameWithoutFileExtension(resultJson), testContainers));
-            }
-            allTests.add(DynamicContainer.dynamicContainer(language.getIdentifier(), languageTests));
+            allTests.add(generateTestForLanguage(languageDirectory));
         }
         return allTests;
+    }
+
+    private DynamicContainer generateTestForLanguage(File languageDirectory) throws ExitException {
+        Language language = LanguageLoader.getLanguage(languageDirectory.getName()).orElseThrow();
+        File[] resultJsons = languageDirectory.listFiles(file -> !file.isDirectory() && file.getName().endsWith(".json"));
+        List<DynamicContainer> languageTests = new LinkedList<>();
+        for (File resultJson : resultJsons) { // for each data set
+            languageTests.add(generateTestsForDataSet(language, resultJson));
+        }
+        return DynamicContainer.dynamicContainer(language.getIdentifier(), languageTests);
+    }
+
+    private DynamicContainer generateTestsForDataSet(Language language, File resultJson) throws ExitException {
+        List<DynamicContainer> testContainers = new LinkedList<>();
+        ResultDescription[] results;
+        try {
+            results = new ObjectMapper().readValue(resultJson, ResultDescription[].class);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Could not load expected values.", exception);
+        }
+        for (var result : results) { // for each configuration
+            var testCases = generateTestsForResultDescription(resultJson, result, language);
+            testContainers.add(DynamicContainer.dynamicContainer("MTM: " + result.options().minimumTokenMatch(), testCases));
+        }
+        return DynamicContainer.dynamicContainer(FileHelper.getFileNameWithoutFileExtension(resultJson), testContainers);
     }
 
     /**
@@ -83,15 +103,17 @@ class EndToEndSuiteTest {
         JPlagOptions jplagOptions = new JPlagOptions(language, Set.of(submissionDirectory), Set.of())
                 .withMinimumTokenMatch(result.options().minimumTokenMatch());
         JPlagResult jplagResult = new JPlag(jplagOptions).run();
-        Map<String, JPlagComparison> jPlagComparisons = jplagResult.getAllComparisons().stream()
-                .collect(Collectors.toMap(it -> TestSuiteHelper.getTestIdentifier(it), it -> it));
-        assertEquals(result.identifierToResultMap().size(), jPlagComparisons.size(), "different number of results and expected results");
+        var comparisons = jplagResult.getAllComparisons().stream().collect(Collectors.toMap(it -> TestSuiteHelper.getTestIdentifier(it), it -> it));
+        assertEquals(result.identifierToResultMap().size(), comparisons.size(), "different number of results and expected results");
 
-        return result.identifierToResultMap().keySet().stream().map(identifier -> {
-            JPlagComparison comparison = jPlagComparisons.get(identifier);
+        DeltaSummaryStatistics statistics = new DeltaSummaryStatistics();
+        var tests = new ArrayList<>(result.identifierToResultMap().keySet().stream().map(identifier -> {
+            JPlagComparison comparison = comparisons.get(identifier);
             ExpectedResult expectedResult = result.identifierToResultMap().get(identifier);
-            return generateTest(identifier, expectedResult, comparison);
-        }).toList();
+            return generateTest(identifier, expectedResult, comparison, statistics);
+        }).toList());
+        tests.addAll(evaluateDeviationOfSimilarity(statistics));
+        return tests;
     }
 
     /**
@@ -100,30 +122,23 @@ class EndToEndSuiteTest {
      * @param expectedResult contains all expected result values.
      * @param result is the comparison object generated from running JPlag.
      */
-    private DynamicTest generateTest(String name, ExpectedResult expectedResult, JPlagComparison result) {
+    private DynamicTest generateTest(String name, ExpectedResult expectedResult, JPlagComparison result, DeltaSummaryStatistics statistics) {
         return DynamicTest.dynamicTest(name, () -> {
             assertNotNull(result, "No comparison result could be found");
-
-            List<String> validationErrors = new ArrayList<>();
-            if (areDoublesDifferent(expectedResult.resultSimilarityMinimum(), result.minimalSimilarity())) {
-                validationErrors.add(formattedValidationError("minimal similarity", String.valueOf(expectedResult.resultSimilarityMinimum()),
-                        String.valueOf(result.minimalSimilarity())));
-            }
-            if (areDoublesDifferent(expectedResult.resultSimilarityMaximum(), result.maximalSimilarity())) {
-                validationErrors.add(formattedValidationError("maximal similarity", String.valueOf(expectedResult.resultSimilarityMaximum()),
-                        String.valueOf(result.maximalSimilarity())));
+            List<String> errors = new ArrayList<>();
+            for (SimilarityMetric metric : List.of(MIN, MAX)) {
+                double expected = expectedResult.getSimilarityForMetric(metric);
+                double actual = metric.applyAsDouble(result);
+                if (Math.abs(expected - actual) >= EPSILON) {
+                    errors.add(formattedValidationError(metric, expected, actual));
+                }
+                statistics.accept(actual, expected);
             }
             if (expectedResult.resultMatchedTokenNumber() != result.getNumberOfMatchedTokens()) {
-                validationErrors.add(formattedValidationError("number of matched tokens", String.valueOf(expectedResult.resultMatchedTokenNumber()),
-                        String.valueOf(result.getNumberOfMatchedTokens())));
+                errors.add(formattedValidationError(INTERSECTION, expectedResult.resultMatchedTokenNumber(), result.getNumberOfMatchedTokens()));
             }
-
-            assertTrue(validationErrors.isEmpty(), createValidationErrorOutput(validationErrors));
+            assertTrue(errors.isEmpty(), createValidationErrorOutput(name, errors));
         });
-    }
-
-    private boolean areDoublesDifferent(double d1, double d2) {
-        return Math.abs(d1 - d2) >= EPSILON;
     }
 
     /**
@@ -132,16 +147,29 @@ class EndToEndSuiteTest {
      * @param actualValue actual test value
      * @param expectedValue expected test value
      */
-    private String formattedValidationError(String valueName, String actualValue, String expectedValue) {
-        return valueName + " was " + actualValue + " but expected " + expectedValue;
+    private String formattedValidationError(SimilarityMetric metric, Number actualValue, Number expectedValue) {
+        return metric + " was " + String.valueOf(actualValue) + " but expected " + String.valueOf(expectedValue);
     }
 
     /**
      * Creates the display info from the passed failed test results
      * @return formatted text for the failed comparative values of the current test
      */
-    private String createValidationErrorOutput(List<String> validationErrors) {
-        return "There were " + validationErrors.size() + " validation error(s):" + System.lineSeparator()
+    private String createValidationErrorOutput(String name, List<String> validationErrors) {
+        return name + ": There were " + validationErrors.size() + " validation error(s):" + System.lineSeparator()
                 + String.join(System.lineSeparator(), validationErrors);
+    }
+
+    private List<DynamicTest> evaluateDeviationOfSimilarity(DeltaSummaryStatistics deltaStatistics) {
+        return List.of(deviationOfSimilarityTest("positive", deltaStatistics.getPositiveStatistics()),
+                deviationOfSimilarityTest("negative", deltaStatistics.getNegativeStatistics()));
+    }
+
+    private DynamicTest deviationOfSimilarityTest(String textualSign, DoubleSummaryStatistics statistics) {
+        return DynamicTest.dynamicTest("OVERVIEW: " + textualSign + " similarity deviation", () -> {
+            if (Math.abs(statistics.getAverage()) > EPSILON) {
+                fail(textualSign + " deviation over all AVG similarity values:" + System.lineSeparator() + statistics.toString());
+            }
+        });
     }
 }


### PR DESCRIPTION
This PR adds summary tests to the e2e test suite, thus allowing one to quickly glance at the test result and understand the impact of the changes on all tests in total. The information is presented like this:

```java
org.opentest4j.AssertionFailedError: positive deviation over all AVG similarity values:
	count=42, average=0.0260, min=0.0008, max=0.0833

org.opentest4j.AssertionFailedError: negative deviation over all AVG similarity values:
	count=284, average=0.0906, min=0.0012, max=0.2681
```

This PR also cleans up some code that is touched and improves JavaDoc comments.