### PR TITLE
Fix OS-specific issue in the emfatic test case

### DIFF
--- a/languages/emf-metamodel/src/test/java/de/jplag/emf/util/EmfaticModelViewTest.java
+++ b/languages/emf-metamodel/src/test/java/de/jplag/emf/util/EmfaticModelViewTest.java
@@ -44,11 +44,11 @@ class EmfaticModelViewTest extends AbstractEmfTest {
 
         // Compare expected vs. actual view file:
         File viewFile = new File(modelFile.getPath() + Language.VIEW_FILE_SUFFIX);
-        assertTrue(viewFile.exists());
         File expectedViewFile = BASE_PATH.resolveSibling(Path.of(EXPECTED_VIEW_FOLDER, viewFile.getName())).toFile();
+        assertTrue(viewFile.exists());
         assertTrue(expectedViewFile.exists());
         try {
-            assertEquals(Files.readString(expectedViewFile.toPath()), Files.readString(viewFile.toPath()));
+            assertEquals(Files.readAllLines(expectedViewFile.toPath()), Files.readAllLines(viewFile.toPath()));
         } catch (IOException exception) {
             fail(exception);
         }


### PR DESCRIPTION
The line separators led to falsely detected differences in the expected vs. actual file due to the os-specific encoding. Line separators are now no longer compared in the test case.