### PR TITLE
Fix package-lock.json

### DIFF
--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -42,14 +42,9 @@
         "eslint": "^8.33.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-vue": "^8.7.1",
-<<<<<<< HEAD
-        "jest": "^29.3.1",
-        "jest-environment-jsdom": "^29.3.1",
-        "jest-transform-stub": "^2.0.0",
-=======
         "jest": "^29.4.0",
         "jest-environment-jsdom": "^29.4.2",
->>>>>>> upstream/develop
+        "jest-transform-stub": "^2.0.0",
         "lint-staged": "^13.1.0",
         "prettier": "^2.8.4",
         "ts-jest": "^29.0.5",


### PR DESCRIPTION
This PR fixes the `package-lock.json` file that was broken in #924. This should also reenable dependabot for the report viewer.