### PR TITLE
Quick fix display of missingComparison

### DIFF
--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -83,7 +83,7 @@
           :top-comparisons="topComps[selectedMetricIndex]"
         />
       </div>
-      <div v-if="missingComparisons!==0">
+      <div v-if="missingComparisons!==0 && !isNaN(missingComparisons)">
         <h3>Total comparisons: {{overview.totalComparisons}}, Shown comparisons: {{shownComparisons}}, Missing comparisons: {{missingComparisons}}. To see more, re-run JPlag with a higher maximum number argument.</h3>
       </div>
     </div>


### PR DESCRIPTION
If using older version of JPlag, the info of missing comparisons will not be shown correctly. This PR just let this info be shown when there are some missingComparisons and missingComparisons is a number. Because, when using older Jplag, there is no field(totalComparisons) in zip file, missingComparisons is NaN.