### PR TITLE
Correctly show matches when the token order is not line index order

### DIFF
--- a/core/src/main/java/de/jplag/Match.java
+++ b/core/src/main/java/de/jplag/Match.java
@@ -2,8 +2,8 @@ package de.jplag;
 
 /**
  * Represents two sections of two submissions that are similar.
- * @param startOfFirst is the starting token index in the first submission.
- * @param startOfSecond is the starting token index in the second submission.
+ * @param startOfFirst is the index of the first token of the match in the first submission.
+ * @param startOfSecond is the index of the first token of the match in the second submission.
  * @param length is the length of these similar sections (number of tokens).
  */
 public record Match(int startOfFirst, int startOfSecond, int length) {
@@ -27,5 +27,19 @@ public record Match(int startOfFirst, int startOfSecond, int length) {
         } else {
             return (startOfSecond - other.startOfSecond) < other.length;
         }
+    }
+
+    /**
+     * @return the token index of the last token of the match in the first submission.
+     */
+    public int endOfFirst() {
+        return startOfFirst + length - 1;
+    }
+
+    /**
+     * @return the token index of the last token of the match in the second submission.
+     */
+    public int endOfSecond() {
+        return startOfSecond + length - 1;
     }
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -2,6 +2,7 @@ package de.jplag.reporting.jsonfactory;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -92,12 +93,15 @@ public class ComparisonReportWriter {
     }
 
     private Match convertMatchToReportMatch(JPlagComparison comparison, de.jplag.Match match) {
-        List<Token> tokensFirst = comparison.firstSubmission().getTokenList();
-        List<Token> tokensSecond = comparison.secondSubmission().getTokenList();
-        Token startOfFirst = tokensFirst.get(match.startOfFirst());
-        Token endOfFirst = tokensFirst.get(match.startOfFirst() + match.length() - 1);
-        Token startOfSecond = tokensSecond.get(match.startOfSecond());
-        Token endOfSecond = tokensSecond.get(match.startOfSecond() + match.length() - 1);
+        List<Token> tokensFirst = comparison.firstSubmission().getTokenList().subList(match.startOfFirst(), match.endOfFirst() + 1);
+        List<Token> tokensSecond = comparison.secondSubmission().getTokenList().subList(match.startOfSecond(), match.endOfSecond() + 1);
+
+        Comparator<? super Token> lineComparator = (first, second) -> first.getLine() - second.getLine();
+
+        Token startOfFirst = tokensFirst.stream().min(lineComparator).orElseThrow();
+        Token endOfFirst = tokensFirst.stream().max(lineComparator).orElseThrow();
+        Token startOfSecond = tokensSecond.stream().min(lineComparator).orElseThrow();
+        Token endOfSecond = tokensSecond.stream().max(lineComparator).orElseThrow();
 
         return new Match(relativizedFilePath(startOfFirst.getFile(), comparison.firstSubmission()),
                 relativizedFilePath(startOfSecond.getFile(), comparison.secondSubmission()), startOfFirst.getLine(), endOfFirst.getLine(),


### PR DESCRIPTION
In some cases, the first and last tokens of a match are not the first or last elements of the match in the source code. This happens e.g. when:

- view files are used, as in the EMF language module
- the code is normalized before parsing for obfuscation detection
- in rare edge cases, even in normal language modules, e.g., regarding if/else/end-if/try/catch, etc.

In these cases, JPlag was not able to correctly display the matches in the report viewers. This PR fixes this by comparing the line indices of all tokens of a match.