### PR TITLE
Fix wrongly enforced code style

### DIFF
--- a/cli/src/main/java/de/jplag/cli/logger/Triple.java
+++ b/cli/src/main/java/de/jplag/cli/logger/Triple.java
@@ -1,4 +1,4 @@
 package de.jplag.cli.logger;
 
-public record Triple<A, B, C> (A first, B second, C third) {
+public record Triple<A, B, C>(A first, B second, C third) {
 }

--- a/languages/cpp2/src/main/java/de/jplag/cpp2/CPPTokenListener.java
+++ b/languages/cpp2/src/main/java/de/jplag/cpp2/CPPTokenListener.java
@@ -445,7 +445,7 @@ public class CPPTokenListener extends CPP14ParserBaseListener {
      * @param endToken the token extracted for this rule in {@code exit*} contexts
      * @param <T> the input type
      */
-    private record Extraction<T> (Predicate<T> extractionTest, TokenType startToken, TokenType endToken) {
+    private record Extraction<T>(Predicate<T> extractionTest, TokenType startToken, TokenType endToken) {
 
         /**
          * Creates an Extraction rule that matches if the value returned by the given function is non-null.

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EmfaticModelView.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EmfaticModelView.java
@@ -141,7 +141,7 @@ public final class EmfaticModelView extends AbstractModelView {
      * Checks if a token is representing a end of a block, e.g. a closing bracket.
      */
     private boolean isEndToken(Token token) {
-        return token.getType()instanceof MetamodelTokenType type && type.isEndToken();
+        return token.getType() instanceof MetamodelTokenType type && type.isEndToken();
     }
 
     /**


### PR DESCRIPTION
Fix issues that spotless previously enforced erroneously due to incompatibilities with new java syntax.
Due to #974, spotless was updated and now correctly detects the violations.