### PR TITLE
fix/match-highlighting-problem

### DIFF
--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -106,7 +106,7 @@ public class ComparisonReportWriter {
 
     private String relativizedFilePath(File file, Submission submission) {
         if (file.toPath().equals(submission.getRoot().toPath())) {
-            return Path.of(submissionToIdFunction.apply(submission), submission.getName()).toString();
+            return Path.of(submissionToIdFunction.apply(submission), submissionToIdFunction.apply(submission)).toString();
         }
         return Path.of(submissionToIdFunction.apply(submission), submission.getRoot().toPath().relativize(file.toPath()).toString()).toString();
     }

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -289,6 +289,7 @@ th {
 }
 
 td {
+  overflow-wrap: break-word;
   padding-top: 3%;
   padding-bottom: 3%;
 }


### PR DESCRIPTION
I fixed this problem. Now match highlighting is correct. The reason is, the file path should also be converted into ID. But i find another problem. The size of row is not adaptive. But for other example, it works. It needs investigation. I am busy right now, so if i have free time, i will take a look at it.

NOT ADAPTIVE: ![image](https://user-images.githubusercontent.com/43599217/225659065-88d568ed-60b9-4f54-9469-f3314ac1cb76.png)

ADAPTIVE: ![image](https://user-images.githubusercontent.com/43599217/225659461-a6e77e36-9324-4df6-b9bc-f8065141d05a.png)

