### PR TITLE
Fix comparison view not working in local mode

### DIFF
--- a/core/src/main/java/de/jplag/reporting/FilePathUtil.java
+++ b/core/src/main/java/de/jplag/reporting/FilePathUtil.java
@@ -8,6 +8,17 @@ import de.jplag.Submission;
 
 public final class FilePathUtil {
 
+    private FilePathUtil() {
+        // private constructor to prevent instantiation
+    }
+
+    /**
+     * Returns the files path relative to the root folder of the submission ID
+     * @param file File that should be relativized
+     * @param submission Submission file belongs to
+     * @param submissionToIdFunction Function to map names to ids
+     * @return Relative path
+     */
     public static String getRelativeSubmissionPath(File file, Submission submission, Function<Submission, String> submissionToIdFunction) {
         if (file.toPath().equals(submission.getRoot().toPath())) {
             return Path.of(submissionToIdFunction.apply(submission), submissionToIdFunction.apply(submission)).toString();

--- a/core/src/main/java/de/jplag/reporting/FilePathUtil.java
+++ b/core/src/main/java/de/jplag/reporting/FilePathUtil.java
@@ -1,10 +1,10 @@
 package de.jplag.reporting;
 
-import de.jplag.Submission;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.util.function.Function;
+
+import de.jplag.Submission;
 
 public final class FilePathUtil {
 

--- a/core/src/main/java/de/jplag/reporting/FilePathUtil.java
+++ b/core/src/main/java/de/jplag/reporting/FilePathUtil.java
@@ -1,0 +1,18 @@
+package de.jplag.reporting;
+
+import de.jplag.Submission;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.function.Function;
+
+public final class FilePathUtil {
+
+    public static String getRelativeSubmissionPath(File file, Submission submission, Function<Submission, String> submissionToIdFunction) {
+        if (file.toPath().equals(submission.getRoot().toPath())) {
+            return Path.of(submissionToIdFunction.apply(submission), submissionToIdFunction.apply(submission)).toString();
+        }
+        return Path.of(submissionToIdFunction.apply(submission), submission.getRoot().toPath().relativize(file.toPath()).toString()).toString();
+    }
+
+}

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -1,7 +1,5 @@
 package de.jplag.reporting.jsonfactory;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -105,8 +103,8 @@ public class ComparisonReportWriter {
         Token endOfSecond = tokensSecond.stream().max(lineComparator).orElseThrow();
 
         return new Match(FilePathUtil.getRelativeSubmissionPath(startOfFirst.getFile(), comparison.firstSubmission(), submissionToIdFunction),
-                FilePathUtil.getRelativeSubmissionPath(startOfSecond.getFile(), comparison.secondSubmission(), submissionToIdFunction), startOfFirst.getLine(), endOfFirst.getLine(),
-                startOfSecond.getLine(), endOfSecond.getLine(), match.length());
+                FilePathUtil.getRelativeSubmissionPath(startOfSecond.getFile(), comparison.secondSubmission(), submissionToIdFunction),
+                startOfFirst.getLine(), endOfFirst.getLine(), startOfSecond.getLine(), endOfSecond.getLine(), match.length());
     }
 
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -13,6 +13,7 @@ import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
 import de.jplag.Submission;
 import de.jplag.Token;
+import de.jplag.reporting.FilePathUtil;
 import de.jplag.reporting.reportobject.model.ComparisonReport;
 import de.jplag.reporting.reportobject.model.Match;
 
@@ -103,16 +104,9 @@ public class ComparisonReportWriter {
         Token startOfSecond = tokensSecond.stream().min(lineComparator).orElseThrow();
         Token endOfSecond = tokensSecond.stream().max(lineComparator).orElseThrow();
 
-        return new Match(relativizedFilePath(startOfFirst.getFile(), comparison.firstSubmission()),
-                relativizedFilePath(startOfSecond.getFile(), comparison.secondSubmission()), startOfFirst.getLine(), endOfFirst.getLine(),
+        return new Match(FilePathUtil.getRelativeSubmissionPath(startOfFirst.getFile(), comparison.firstSubmission(), submissionToIdFunction),
+                FilePathUtil.getRelativeSubmissionPath(startOfSecond.getFile(), comparison.secondSubmission(), submissionToIdFunction), startOfFirst.getLine(), endOfFirst.getLine(),
                 startOfSecond.getLine(), endOfSecond.getLine(), match.length());
-    }
-
-    private String relativizedFilePath(File file, Submission submission) {
-        if (file.toPath().equals(submission.getRoot().toPath())) {
-            return Path.of(submissionToIdFunction.apply(submission), submissionToIdFunction.apply(submission)).toString();
-        }
-        return Path.of(submissionToIdFunction.apply(submission), submission.getRoot().toPath().relativize(file.toPath()).toString()).toString();
     }
 
 }

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -8,15 +8,12 @@ import static de.jplag.reporting.reportobject.mapper.SubmissionNameToIdMapper.bu
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import de.jplag.reporting.FilePathUtil;
-import de.jplag.reporting.reportobject.model.SubmissionFileIndex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,12 +22,14 @@ import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
 import de.jplag.Language;
 import de.jplag.Submission;
+import de.jplag.reporting.FilePathUtil;
 import de.jplag.reporting.jsonfactory.ComparisonReportWriter;
 import de.jplag.reporting.jsonfactory.ToDiskWriter;
 import de.jplag.reporting.reportobject.mapper.ClusteringResultMapper;
 import de.jplag.reporting.reportobject.mapper.MetricMapper;
 import de.jplag.reporting.reportobject.model.Metric;
 import de.jplag.reporting.reportobject.model.OverviewReport;
+import de.jplag.reporting.reportobject.model.SubmissionFileIndex;
 import de.jplag.reporting.reportobject.model.Version;
 
 /**
@@ -206,7 +205,6 @@ public class ReportObjectFactory {
         }
         fileWriter.saveAsJSON(fileIndex, path, SUBMISSION_FILE_INDEX_FILE_NAME);
     }
-
 
     private Set<Submission> getSubmissions(List<JPlagComparison> comparisons) {
         Set<Submission> submissions = comparisons.stream().map(JPlagComparison::firstSubmission).collect(Collectors.toSet());

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -200,7 +200,6 @@ public class ReportObjectFactory {
             for (File file : submission.getFiles()) {
                 filePaths.add(FilePathUtil.getRelativeSubmissionPath(file, submission, submissionToIdFunction));
             }
-            System.out.println(filePaths);
             fileIndex.fileIndexes().put(submissionNameToIdMap.get(submission.getName()), filePaths);
         }
         fileWriter.saveAsJSON(fileIndex, path, SUBMISSION_FILE_INDEX_FILE_NAME);

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -10,7 +10,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionFileIndex.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionFileIndex.java
@@ -1,10 +1,9 @@
 package de.jplag.reporting.reportobject.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 import java.util.Map;
 
-public record SubmissionFileIndex(
-        @JsonProperty("submission_file_indexes") Map<String, List<String>> fileIndexes
-) {}
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SubmissionFileIndex(@JsonProperty("submission_file_indexes") Map<String, List<String>> fileIndexes) {
+}

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionFileIndex.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionFileIndex.java
@@ -1,0 +1,10 @@
+package de.jplag.reporting.reportobject.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public record SubmissionFileIndex(
+        @JsonProperty("submission_file_indexes") Map<String, List<String>> fileIndexes
+) {}

--- a/docs/6.-Report-File-Generation.md
+++ b/docs/6.-Report-File-Generation.md
@@ -6,6 +6,7 @@
 ```
 result.zip
 │   overview.json
+|   submissionFileIndex.json
 │
 └───submissions
 │   └───submissionId1
@@ -37,6 +38,9 @@ The report zip contains
 - overview.json
 
   - The `overview.json` encapsulates the main information from a JPlagResult such as base directory path, language, min- and max-metric, etc. The `overview.json` provides data to the `OverviewView.vue` that is first displayed after the report is dropped into the viewer. Corresponds to the Java record `OverviewReport`.
+
+- submissionFileIndex.json
+  - The `submissionFileIndex.json` stores a list of all files in the submission for each submission id.
 
 - submissions
 

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -102,7 +102,7 @@ if (store().local) {
   const request = new XMLHttpRequest()
   request.open(
     'GET',
-    `/src/files/${store().getComparisonFileName(props.firstId, props.secondId)}`,
+    `/files/${store().getComparisonFileName(props.firstId, props.secondId)}`,
     false
   )
   request.send()
@@ -152,7 +152,7 @@ if (store().local) {
 
 function getSubmissionFileListFromLocal(submissionId: string): string[] {
   const request = new XMLHttpRequest()
-  request.open('GET', `../../src/files/submissionFileIndex.json`, false)
+  request.open('GET', `/files/submissionFileIndex.json`, false)
   request.send()
   if (request.status == 200) {
     return JSON.parse(request.response).submission_file_indexes[submissionId]
@@ -165,7 +165,7 @@ function loadSubmissionFilesFromLocal(submissionId: string) {
   const request = new XMLHttpRequest()
   const fileList = getSubmissionFileListFromLocal(submissionId)
   for (const file of fileList) {
-    request.open('GET', `../../src/files/files/${file.replace(/\\/, '/')}`, false)
+    request.open('GET', `/files/files/${file.replace(/\\/, '/')}`, false)
     request.send()
     if (request.status == 200) {
       store().saveSubmissionFile({

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -108,6 +108,8 @@ if (store().local) {
   request.send()
 
   if (request.status == 200) {
+    loadSubmissionFilesFromLocal(props.firstId)
+    loadSubmissionFilesFromLocal(props.secondId)
     try {
       comparison = ComparisonFactory.getComparison(JSON.parse(request.response))
     } catch (e) {
@@ -145,6 +147,35 @@ if (store().local) {
       }
     })
     store().clearStore()
+  }
+}
+
+function getSubmissionFileListFromLocal(submissionId: string): string[] {
+  const request = new XMLHttpRequest()
+  request.open('GET', `../../src/files/submissionFileIndex.json`, false)
+  request.send()
+  if (request.status == 200) {
+    return JSON.parse(request.response).submission_file_indexes[submissionId]
+  } else {
+    return []
+  }
+}
+
+function loadSubmissionFilesFromLocal(submissionId: string) {
+  const request = new XMLHttpRequest()
+  const fileList = getSubmissionFileListFromLocal(submissionId)
+  for (const file of fileList) {
+    request.open('GET', `../../src/files/files/${file.replace(/\\/, '/')}`, false)
+    request.send()
+    if (request.status == 200) {
+      store().saveSubmissionFile({
+        name: submissionId,
+        file: {
+          fileName: file,
+          data: request.response
+        }
+      })
+    }
   }
 }
 

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -35,7 +35,7 @@ class LoadError extends Error {}
 store().clearStore()
 const hasLocalFile = ref(false)
 // Checks whether local files exist
-fetch('/src/files/overview.json').then((response) => (hasLocalFile.value = response.status == 200))
+fetch('/files/overview.json').then((response) => (hasLocalFile.value = response.status == 200))
 
 // Loads file passed in query param, if any.
 const queryParams = useRoute().query

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -109,7 +109,7 @@ function getOverview() {
   //Gets the overview file based on the used mode (zip, local, single).
   if (store().local) {
     const request = new XMLHttpRequest()
-    request.open('GET', '/src/files/overview.json', false)
+    request.open('GET', '/files/overview.json', false)
     request.send()
 
     if (request.status == 200) {


### PR DESCRIPTION
The comparison view of the report viewer was broken when using local mode.
To fix this I added the file `submissionFileIndex.json` file, which stores a map of submission IDs to all their submitted files, which now gets read when opening the comparison view.
I also updated the wikis page about the report generation accordingly.