### PR TITLE
Bump Typescript to Version 5.0.4

### DIFF
--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -38,7 +38,7 @@
         "lint-staged": "^13.2.1",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.4",
-        "typescript": "~4.8.4",
+        "typescript": "^5.0.4",
         "vite": "^4.1.4",
         "vitest": "^0.29.1",
         "vue-tsc": "^1.2.0"
@@ -5422,16 +5422,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/ufo": {

--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -45,7 +45,7 @@
     "lint-staged": "^13.2.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.4",
-    "typescript": "~4.8.4",
+    "typescript": "^5.0.4",
     "vite": "^4.1.4",
     "vitest": "^0.29.1",
     "vue-tsc": "^1.2.0"


### PR DESCRIPTION
This PR updates Typescript to its latest release

In addition previously typescripts version was referenced as `"typescript": "~4.8.4",` in the package.json. This lead to dependabot not correctly updating to the newest version. This is also fixed now