### PR TITLE
Print the number of tokens when it’s too little

### DIFF
--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -122,7 +122,8 @@ public class SubmissionSet {
         if (!baseCode.parse(options.debugParser())) {
             throw new BasecodeException("Could not successfully parse basecode submission!");
         } else if (baseCode.getNumberOfTokens() < options.minimumTokenMatch()) {
-            throw new BasecodeException("Basecode submission contains fewer tokens than minimum match length allows!");
+            throw new BasecodeException(String.format("Basecode submission contains %d token(s), which is less than the minimum match length (%d)!",
+                    baseCode.getNumberOfTokens(), options.minimumTokenMatch()));
         }
         logger.trace("Basecode submission parsed!");
         long duration = System.currentTimeMillis() - startTime;
@@ -153,7 +154,8 @@ public class SubmissionSet {
             }
 
             if (submission.getTokenList() != null && submission.getNumberOfTokens() < options.minimumTokenMatch()) {
-                logger.error("Submission {} contains fewer tokens than minimum match length allows!", currentSubmissionName);
+                logger.error("Submission {} contains {} token(s), which is less than the minimum match length ({})!", currentSubmissionName,
+                        submission.getNumberOfTokens(), options.minimumTokenMatch());
                 submission.setTokenList(null);
                 tooShort++;
                 ok = false;


### PR DESCRIPTION
When trying to prepare a sample submission for [TMS](https://gitlab.com/tms-elte), I was hit by the minimum token count: the submission was rejected due to not containing the required number of tokens; however, the output stated neither the number of tokens found nor the number of tokens required. So I added them to the output, and I share the code in the hope that it will be useful for others as well.

<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
