### PR TITLE
Extract APPLY token for function calls with literal arguments

### DIFF
--- a/languages/cpp2/src/main/java/de/jplag/cpp2/CPPTokenListener.java
+++ b/languages/cpp2/src/main/java/de/jplag/cpp2/CPPTokenListener.java
@@ -66,6 +66,7 @@ import de.jplag.cpp2.grammar.CPP14Parser.EnumeratorDefinitionContext;
 import de.jplag.cpp2.grammar.CPP14Parser.FunctionBodyContext;
 import de.jplag.cpp2.grammar.CPP14Parser.FunctionDefinitionContext;
 import de.jplag.cpp2.grammar.CPP14Parser.HandlerContext;
+import de.jplag.cpp2.grammar.CPP14Parser.InitDeclaratorContext;
 import de.jplag.cpp2.grammar.CPP14Parser.IterationStatementContext;
 import de.jplag.cpp2.grammar.CPP14Parser.JumpStatementContext;
 import de.jplag.cpp2.grammar.CPP14Parser.LabeledStatementContext;
@@ -335,6 +336,14 @@ public class CPPTokenListener extends CPP14ParserBaseListener {
      */
     private static boolean noPointerInFunctionCallContext(NoPointerDeclaratorContext context) {
         return context != null && (context.parametersAndQualifiers() != null || context.LeftParen() != null);
+    }
+
+    @Override
+    public void enterInitDeclarator(InitDeclaratorContext context) {
+        // method calls with literals as arguments
+        if (context.initializer() != null && context.initializer().LeftParen() != null) {
+            addEnter(APPLY, context.getStart());
+        }
     }
 
     @Override

--- a/languages/cpp2/src/test/java/de/jplag/cpp2/TokenExtractionTest.java
+++ b/languages/cpp2/src/test/java/de/jplag/cpp2/TokenExtractionTest.java
@@ -83,7 +83,7 @@ class TokenExtractionTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"this->myMethod(v)", "MyClass::myMethod(v)", "myMethod(v)", "m.myMethod(v)"})
+    @ValueSource(strings = {"this->myMethod(v)", "MyClass::myMethod(v)", "myMethod(v)", "m.myMethod(v)", "myMethod(1)", "myMethod(\"a\")"})
     void testFunctionCalls(String expression, @TempDir Path path) {
         TokenResult result = extractFromString(path, """
                 void a(string v) {


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
The new C++ language module didn't extract an APPLY token for function calls with only literals as arguments.