### PR TITLE
Fix supported C# version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In the following, a list of all supported languages with their supported languag
 |--------------------------------------------------------|--------:|-------------------|:----------------------------------------------------------------:|:---------:|
 | [Java](https://www.java.com)                           |      17 | java              |                              mature                              |   JavaC   |
 | [C++](https://isocpp.org)                              |      11 | cpp               |                              legacy                              |  JavaCC   |
-| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/)  |       8 | csharp            |                               beta                               |  ANTLR 4  |
+| [C#](https://docs.microsoft.com/en-us/dotnet/csharp/)  |       6 | csharp            |                               beta                               |  ANTLR 4  |
 | [Go](https://go.dev)                                   |    1.17 | golang            |                               beta                               |  ANTLR 4  |
 | [Kotlin](https://kotlinlang.org)                       |     1.3 | kotlin            |                               beta                               |  ANTLR 4  |
 | [Python](https://www.python.org)                       |     3.6 | python3           |                              legacy                              |  ANTLR 4  |

--- a/docs/2.-Supported-Languages.md
+++ b/docs/2.-Supported-Languages.md
@@ -5,7 +5,7 @@ Thus, each frontend has a state label:
 - `mature`: This module is tried and tested, as well as up to date with a current language version.
 - `beta`: This module is relatively new and up to date. However, it is not as well tested. **Feedback welcome!**
 - `alpha`: This module is very new and not yet finished. Use with caution! 
-- `legacy`: This module is old and may only support outdated language versions. It needs an update.
+- `legacy`: This module is from JPlag legacy (pre-v3.0.0) and may only support outdated language versions. It needs an update.
 - `unknown`: It is very much unclear in which state this module is.
 
 All language modules can be found [here](https://github.com/jplag/JPlag/tree/master/languages).


### PR DESCRIPTION
The C# Language class states it supports C# 6, the README previously stated C# 8 is supported. Expression-bodied not read-only properties ([supported as of C# 7.0](https://github.com/dotnet/docs/blob/c802a0c56bccdc87908365c0788b3c5ecacea2b3/docs/csharp/programming-guide/statements-expressions-operators/expression-bodied-members.md)) like this don’t parse:

```cs
public int foo { get => 4; }
```

which means the Language class is right and C# 8 isn’t fully supported. Since the latest version is 11, and the first unsupported version (C# 7) was released over six years ago, also reclassify C# support as “legacy”.

<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
