### PR TITLE
Update version to 4.4.0-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <emf.ecore.xmi.version>2.18.0</emf.ecore.xmi.version>
 
         <!-- The Revision of JPlag -->
-        <revision>4.3.0-SNAPSHOT</revision>
+        <revision>4.4.0-SNAPSHOT</revision>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
While the next release may be a major one, we set the development version to 4.4.0-SNAPSHOT for now.