### PR TITLE
Increase development version to 4.4.0-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <emf.ecore.xmi.version>2.18.0</emf.ecore.xmi.version>
 
         <!-- The Revision of JPlag -->
-        <revision>4.3.0</revision>
+        <revision>4.4.0-SNAPSHOT</revision>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Increase the development version of JPlag to 4.4.0-SNAPSHOT.
However, the next release may be a major one.