### PR TITLE
Fix pre commit in report viewer

### DIFF
--- a/report-viewer/.lintstagedrc.json
+++ b/report-viewer/.lintstagedrc.json
@@ -1,10 +1,10 @@
 {
   "*.ts": [
-    "prettier --write",
-    "eslint"
+    "npx prettier --write",
+    "npx eslint"
   ],
   "*.vue": [
-    "prettier --write",
-    "eslint"
+    "npx prettier --write",
+    "npx eslint"
   ]
 }


### PR DESCRIPTION
In the lintstaged config the commands where called whitout the `npx` prefix. 
This workes if eslint and prettier are both installed globally or when an intelliJ based IDE (e.g. WebStorm) is used. In other IDEs or Editors like VS Code not having npx written there lead to errors.