### PR TITLE
Improve log readability and parse error reporting

### DIFF
--- a/cli/src/main/java/de/jplag/cli/logger/CollectedLogger.java
+++ b/cli/src/main/java/de/jplag/cli/logger/CollectedLogger.java
@@ -73,8 +73,6 @@ public final class CollectedLogger extends MarkerIgnoringBase {
         // Append date-time
         builder.append(dateFormat.format(timeOfError == null ? new Date() : timeOfError)).append(' ');
 
-        // Append current thread name
-        builder.append('[').append(Thread.currentThread().getName()).append("] ");
         // Append current Level
         builder.append('[').append(renderLevel(level)).append(']').append(' ');
 

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -1,5 +1,7 @@
 package de.jplag;
 
+import java.io.File;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import org.slf4j.Logger;
@@ -72,6 +74,19 @@ public class JPlag {
         if (logger.isInfoEnabled())
             logger.info("Total time for comparing submissions: {}", TimeUtil.formatDuration(result.getDuration()));
         result.setClusteringResult(ClusteringFactory.getClusterings(result.getAllComparisons(), options.clusteringOptions()));
+
+        logSkippedSubmissions(submissionSet, options);
+
         return result;
+    }
+
+    private static void logSkippedSubmissions(SubmissionSet submissionSet, JPlagOptions options) {
+        if (submissionSet.getInvalidSubmissions().size() > 0) {
+            List<Submission> skipSet = submissionSet.getInvalidSubmissions();
+            logger.warn("{} submissions were skipped (see errors above): {}", skipSet.size(), skipSet.stream().map(Submission::getName).toList());
+            if (options.debugParser()) {
+                logger.warn("Erroneous submissions were copied to {}", new File("errors").getAbsolutePath());
+            }
+        }
     }
 }

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -81,8 +81,8 @@ public class JPlag {
     }
 
     private static void logSkippedSubmissions(SubmissionSet submissionSet, JPlagOptions options) {
-        if (submissionSet.getInvalidSubmissions().size() > 0) {
-            List<Submission> skipSet = submissionSet.getInvalidSubmissions();
+        List<Submission> skipSet = submissionSet.getInvalidSubmissions();
+        if (!skipSet.isEmpty()) {
             logger.warn("{} submissions were skipped (see errors above): {}", skipSet.size(), skipSet.stream().map(Submission::getName).toList());
             if (options.debugParser()) {
                 logger.warn("Erroneous submissions were copied to {}", new File("errors").getAbsolutePath());

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -81,11 +81,11 @@ public class JPlag {
     }
 
     private static void logSkippedSubmissions(SubmissionSet submissionSet, JPlagOptions options) {
-        List<Submission> skipSet = submissionSet.getInvalidSubmissions();
-        if (!skipSet.isEmpty()) {
-            logger.warn("{} submissions were skipped (see errors above): {}", skipSet.size(), skipSet.stream().map(Submission::getName).toList());
+        List<Submission> skippedSubmissions = submissionSet.getInvalidSubmissions();
+        if (!skippedSubmissions.isEmpty()) {
+            logger.warn("{} submissions were skipped (see errors above): {}", skippedSubmissions.size(), skippedSubmissions);
             if (options.debugParser()) {
-                logger.warn("Erroneous submissions were copied to {}", new File("errors").getAbsolutePath());
+                logger.warn("Erroneous submissions were copied to {}", new File(JPlagOptions.ERROR_FOLDER).getAbsolutePath());
             }
         }
     }

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -16,17 +16,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.jplag.normalization.TokenStringNormalizer;
+import de.jplag.options.JPlagOptions;
 
 /**
  * Represents a single submission. A submission can contain multiple files.
  */
 public class Submission implements Comparable<Submission> {
     private static final Logger logger = LoggerFactory.getLogger(Submission.class);
-
-    /**
-     * Directory name for storing submission files with parse errors if so requested.
-     */
-    private static final String ERROR_FOLDER = "errors";
 
     /**
      * Identification of the submission (often a directory or file name).
@@ -226,7 +222,7 @@ public class Submission implements Comparable<Submission> {
     }
 
     private static File createErrorDirectory(String... subdirectoryNames) {
-        File subdirectory = Path.of(ERROR_FOLDER, subdirectoryNames).toFile();
+        File subdirectory = Path.of(JPlagOptions.ERROR_FOLDER, subdirectoryNames).toFile();
         if (!subdirectory.exists()) {
             subdirectory.mkdirs();
         }

--- a/core/src/main/java/de/jplag/TimeUtil.java
+++ b/core/src/main/java/de/jplag/TimeUtil.java
@@ -1,5 +1,7 @@
 package de.jplag;
 
+import java.time.Duration;
+
 public final class TimeUtil {
 
     private TimeUtil() {
@@ -12,10 +14,8 @@ public final class TimeUtil {
      * @return Readable representation of the time interval.
      */
     public static String formatDuration(long durationInMilliseconds) {
-        int timeInSeconds = (int) (durationInMilliseconds / 1000);
-        String hours = (timeInSeconds / 3600 > 0) ? (timeInSeconds / 3600) + " h " : "";
-        String minutes = (timeInSeconds / 60 > 0) ? ((timeInSeconds / 60) % 60) + " min " : "";
-        String seconds = (timeInSeconds % 60) + " sec";
-        return hours + minutes + seconds;
+        Duration duration = Duration.ofMillis(durationInMilliseconds);
+        return String.format("%dh %02dmin %02ds %03dms", duration.toHours(), duration.toMinutesPart(), duration.toSecondsPart(),
+                duration.toMillisPart());
     }
 }

--- a/core/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/core/src/main/java/de/jplag/options/JPlagOptions.java
@@ -54,6 +54,7 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, Set<Fil
     public static final int SHOW_ALL_COMPARISONS = 0;
     public static final SimilarityMetric DEFAULT_SIMILARITY_METRIC = SimilarityMetric.AVG;
     public static final Charset CHARSET = StandardCharsets.UTF_8;
+    public static final String ERROR_FOLDER = "errors";
 
     private static final Logger logger = LoggerFactory.getLogger(JPlagOptions.class);
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -43,6 +43,8 @@ import de.jplag.reporting.reportobject.model.Version;
  * to the disk.
  */
 public class ReportObjectFactory {
+    private static final String DIRECTORY_ERROR = "Could not create directory {} for report viewer generation";
+
     private static final Logger logger = LoggerFactory.getLogger(ReportObjectFactory.class);
 
     private static final ToDiskWriter fileWriter = new ToDiskWriter();
@@ -76,7 +78,7 @@ public class ReportObjectFactory {
             logger.info("Zipping report files...");
             zipAndDelete(path);
         } catch (IOException e) {
-            logger.error("Could not create directory " + path + " for report viewer generation", e);
+            logger.error(DIRECTORY_ERROR, e, path);
         }
 
     }
@@ -130,7 +132,7 @@ public class ReportObjectFactory {
         try {
             return createDirectory(submissionsPath.getPath(), submissionToIdFunction.apply(submission), file, submissionRoot);
         } catch (IOException e) {
-            logger.error("Could not create directory " + path + " for report viewer generation", e);
+            logger.error(DIRECTORY_ERROR, e, path);
             return null;
         }
     }
@@ -139,7 +141,7 @@ public class ReportObjectFactory {
         try {
             return createDirectory(submissionsPath.getPath(), submissionToIdFunction.apply(submission));
         } catch (IOException e) {
-            logger.error("Could not create directory " + path + " for report viewer generation", e);
+            logger.error(DIRECTORY_ERROR, e, path);
             return null;
         }
     }
@@ -148,7 +150,7 @@ public class ReportObjectFactory {
         try {
             return createDirectory(path, SUBMISSIONS_FOLDER);
         } catch (IOException e) {
-            logger.error("Could not create directory " + path + " for report viewer generation", e);
+            logger.error(DIRECTORY_ERROR, e, path);
             return null;
         }
     }

--- a/core/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
+++ b/core/src/main/java/de/jplag/strategy/AbstractComparisonStrategy.java
@@ -15,7 +15,7 @@ import de.jplag.options.JPlagOptions;
 
 public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+    private final Logger logger = LoggerFactory.getLogger(ComparisonStrategy.class);
 
     private final GreedyStringTiling greedyStringTiling;
 
@@ -24,7 +24,6 @@ public abstract class AbstractComparisonStrategy implements ComparisonStrategy {
     protected AbstractComparisonStrategy(JPlagOptions options, GreedyStringTiling greedyStringTiling) {
         this.greedyStringTiling = greedyStringTiling;
         this.options = options;
-        logger.info("Start comparing...");
     }
 
     /**


### PR DESCRIPTION
Logging improvements:
- Removes the thread id from the log message (causes a lot of noise during the parallel comparison)
- When submissions cannot be parsed, warn the user at the end of the JPlag run (as previous errors tend to be missed due to the large log)
- When the debug mode is used, also state where the erroneous submissions are copied to
- Improve formatting of logged durations
- Do not expose internal comparison strategy via log (as it is just more visual noise)
- Remove superfluous "start comparing" message