### PR TITLE
Add option to build without base url path

### DIFF
--- a/.github/workflows/report-viewer.yml
+++ b/.github/workflows/report-viewer.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: report-viewer
         run: |
           npm install
-          npm run build
+          npm run build-prod
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.4.2

--- a/report-viewer/README.md
+++ b/report-viewer/README.md
@@ -6,7 +6,7 @@ Before the first run execute:
 
 - Install necessary dependencies by running `npm install` in the /report-viewer folder.
 - Start the application by running the `npm run dev` command in the /report-viewer folder.
-- The report viewer is now accessible in your browser under http://localhost:8080/JPlag/
+- The report viewer is now accessible in your browser under http://localhost:8080/
 
 ## Project setup
 ```

--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -9,6 +9,7 @@
     "test:unit": "vitest",
     "test:e2e": "playwright test",
     "build-only": "vite build",
+    "build-prod": "run-p type-check && vite build --mode prod",
     "build-dev": "run-p type-check && vite build --mode dev",
     "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",

--- a/report-viewer/vite.config.ts
+++ b/report-viewer/vite.config.ts
@@ -6,6 +6,15 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig((userConfig: UserConfig) => {
+  let base = '/'
+  switch (userConfig.mode) {
+    case 'dev':
+      base = '/JPlag-Dev/'
+      break
+    case 'prod':
+      base = '/JPlag/'
+      break
+  }
   return {
     plugins: [vue()],
     resolve: {
@@ -13,6 +22,6 @@ export default defineConfig((userConfig: UserConfig) => {
         '@': fileURLToPath(new URL('./src', import.meta.url))
       }
     },
-    base: userConfig.mode != 'dev' ? '/JPlag/' : '/JPlag-Dev/'
+    base: base
   }
 })


### PR DESCRIPTION
Currently when building the report viewer there will always be a base path (e.g. localhoost:8080/Jplag/). This can become an issue when wanting to hosting to host it locally (for example through http-server). 

There is now  a new build command `npm run build-prod` to build for the main-branch.
The old build command `npm run build` now builds without a base path.