### PR TITLE
Improve test result visualization for the view file tests

### DIFF
--- a/languages/emf-metamodel/src/test/java/de/jplag/emf/AbstractEmfTest.java
+++ b/languages/emf-metamodel/src/test/java/de/jplag/emf/AbstractEmfTest.java
@@ -1,6 +1,6 @@
 package de.jplag.emf;
 
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -69,7 +69,7 @@ public abstract class AbstractEmfTest {
         assertTrue(viewFile.exists());
         assertTrue(expectedViewFile.exists());
         try {
-            assertIterableEquals(Files.readAllLines(expectedViewFile.toPath()), Files.readAllLines(viewFile.toPath()));
+            assertLinesMatch(Files.readAllLines(expectedViewFile.toPath()), Files.readAllLines(viewFile.toPath()));
         } catch (IOException exception) {
             fail(exception);
         }


### PR DESCRIPTION
Replaces `asstertIterableEquals` with `assertLinesMatch`, which leads to a diff style view for the whole file in many IDEs, thus showing not only the first mismatching line but all mismatching lines.

![image](https://github.com/jplag/JPlag/assets/4396919/6f5281db-9bf0-4af1-ac3b-1bc473c8305b)
