### PR TITLE
Adjust JPlag descriptions

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -46,7 +46,8 @@ public final class CLI {
 
     private static final String[] DESCRIPTIONS = {"Detecting Software Plagiarism", "Software-Archaeological Playground", "Since 1996",
             "Scientifically Published", "Maintained by SDQ", "RIP Structure and Table", "What else?", "You have been warned!", "Since Java 1.0",
-            "More Abstract than Tree", "Students Nightmare", "No, changing variable names does not work", "The tech is out there!"};
+            "More Abstract than Tree", "Students Nightmare", "No, changing variable names does not work", "The tech is out there!",
+            "Developed by plagiarism experts."};
 
     private final CommandLine commandLine;
     private final CliOptions options;


### PR DESCRIPTION
This PR adds another line to the random JPlag descriptions which states that JPlag is indeed developed by plagiarism experts who - beyond other forms of experience - also published in this domain.