### PR TITLE
Prevent random exceptions when Emfatic is unable to provide a textual model view for EMF

### DIFF
--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -248,7 +248,7 @@ public class Submission implements Comparable<Submission> {
         try {
             tokenList = language.parse(new HashSet<>(files));
         } catch (ParsingException e) {
-            logger.warn("Failed to parse submission {} with error {}", this, e);
+            logger.warn("Failed to parse submission {} with error {}", this, e.getMessage(), e);
             tokenList = null;
             hasErrors = true;
             if (debugParser) {

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
@@ -82,8 +82,9 @@ public class EcoreParser extends AbstractParser {
      * @param file is the path for the view file to be created.
      * @param modelResource is the resource containing the metamodel.
      * @return the view implementation.
+     * @throws ParsingException if view could not be created due to an invalid model.
      */
-    protected AbstractModelView createView(File file, Resource modelResource) {
+    protected AbstractModelView createView(File file, Resource modelResource) throws ParsingException {
         return new EmfaticModelView(file, modelResource);
     }
 

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EmfaticModelView.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/util/EmfaticModelView.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil.Copier;
 import org.eclipse.emf.emfatic.core.generator.emfatic.Writer;
 
+import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.TokenTrace;
 import de.jplag.emf.MetamodelToken;
@@ -44,8 +45,9 @@ public final class EmfaticModelView extends AbstractModelView {
      * Creates an Emfatic view for a metamodel.
      * @param file is the path for the view file to be created.
      * @param modelResource is the resource containing the metamodel.
+     * @throws ParsingException if Emfatic crashes.
      */
-    public EmfaticModelView(File file, Resource modelResource) {
+    public EmfaticModelView(File file, Resource modelResource) throws ParsingException {
         super(file);
         elementToLine = new HashMap<>();
         lines = generateEmfaticCode(viewBuilder, modelResource);
@@ -93,11 +95,16 @@ public final class EmfaticModelView extends AbstractModelView {
 
     /**
      * Generates Emfatic code from a model resource and splits it into lines with a string builder.
+     * @throws ParsingException if the Emfatic writer fails.
      */
-    private final List<String> generateEmfaticCode(StringBuilder builder, Resource modelResource) {
+    private final List<String> generateEmfaticCode(StringBuilder builder, Resource modelResource) throws ParsingException {
         Writer writer = new Writer();
-        String code = writer.write(modelResource, null, null);
-        builder.append(code);
+        try {
+            String code = writer.write(modelResource, null, null);
+            builder.append(code);
+        } catch (Exception exception) { // Emfatic does not properly handle errors, thus throws random exceptions.
+            throw new ParsingException(file, "Emfatic view could not be generated!", exception);
+        }
         return builder.toString().lines().toList();
     }
 

--- a/languages/emf-metamodel/src/test/java/de/jplag/emf/util/EmfaticModelViewTest.java
+++ b/languages/emf-metamodel/src/test/java/de/jplag/emf/util/EmfaticModelViewTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import de.jplag.ParsingException;
 import de.jplag.emf.AbstractEmfTest;
 import de.jplag.emf.Language;
 
@@ -23,7 +24,7 @@ class EmfaticModelViewTest extends AbstractEmfTest {
     @ParameterizedTest
     @DisplayName("Test content of emfatic view files of example metamodels")
     @MethodSource("provideModelNames")
-    void testEmfaticViewFiles(String modelName) {
+    void testEmfaticViewFiles(String modelName) throws ParsingException {
         // Load model:
         File modelFile = new File(baseDirectory, modelName);
         Resource modelResource = loadAndVerifyModel(modelFile);


### PR DESCRIPTION
Emfatic has no proper error handling. Thus it just throws random unchecked exceptions if it does not like the input model.
However, JPlag can recover from this situation via a parsing exception by skipping this submission. Thus this PR implements an **ugly** workaround to deal with Emfatic.