### PR TITLE
Added the option to initialize the parser lazily for AbstractAntlrLan…

### DIFF
--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrLanguage.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrLanguage.java
@@ -42,6 +42,10 @@ public abstract class AbstractAntlrLanguage implements Language {
         return this.parser.parse(files);
     }
 
+    /**
+     * Lazily creates the parser. Has to be implemented, if no parser is passed in the constructor.
+     * @return The newly initialized parser
+     */
     protected AbstractAntlrParserAdapter<?> initializeParser() {
         throw new UnsupportedOperationException(
                 String.format("The initializeParser method needs to be implemented for %s", this.getClass().getName()));

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrLanguage.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrLanguage.java
@@ -10,9 +10,12 @@ import de.jplag.Token;
 
 /**
  * Base class for Antlr languages. Handle the parse function from {@link Language}
+ * <p>
+ * You can either pass the parser to the super constructor, or implement the initializeParser method. That allows you to
+ * access class members, like language specific options.
  */
 public abstract class AbstractAntlrLanguage implements Language {
-    private final AbstractAntlrParserAdapter<?> parser;
+    private AbstractAntlrParserAdapter<?> parser;
 
     /**
      * New instance
@@ -22,8 +25,25 @@ public abstract class AbstractAntlrLanguage implements Language {
         this.parser = parser;
     }
 
+    /**
+     * New instance, without pre initialized parser. If you use this constructor, you need to override the initializeParser
+     * method.
+     */
+    protected AbstractAntlrLanguage() {
+        this.parser = null;
+    }
+
     @Override
     public List<Token> parse(Set<File> files) throws ParsingException {
+        if (this.parser == null) {
+            this.parser = this.initializeParser();
+        }
+
         return this.parser.parse(files);
+    }
+
+    protected AbstractAntlrParserAdapter<?> initializeParser() {
+        throw new UnsupportedOperationException(
+                String.format("The initializeParser method needs to be implemented for %s", this.getClass().getName()));
     }
 }

--- a/language-antlr-utils/src/test/java/de/jplag/antlr/LanguageTest.java
+++ b/language-antlr-utils/src/test/java/de/jplag/antlr/LanguageTest.java
@@ -1,0 +1,65 @@
+package de.jplag.antlr;
+
+import de.jplag.ParsingException;
+import de.jplag.antlr.testLanguage.TestLanguage;
+import de.jplag.antlr.testLanguage.TestParserAdapter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Some tests for the abstract antlr language
+ */
+class LanguageTest {
+    @Test
+    void testExceptionForNoDefinedParser() {
+        LanguageWithoutParser lang = new LanguageWithoutParser();
+        Set<File> emptySet = Set.of();
+        assertThrows(UnsupportedOperationException.class, () -> lang.parse(emptySet));
+    }
+
+    @Test
+    void testLanguageWithStaticParser() throws ParsingException {
+        TestLanguage lang = new TestLanguage();
+        Assertions.assertEquals(0, lang.parse(Set.of()).size());
+    }
+
+    @Test
+    void testLanguageWithLazyParser() throws ParsingException {
+        LanguageWithLazyParser lang = new LanguageWithLazyParser();
+        Assertions.assertEquals(0, lang.parse(Set.of()).size());
+    }
+
+    private static class LanguageWithoutParser extends AbstractAntlrLanguage {
+        @Override
+        public String[] suffixes() {
+            return new String[0];
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getIdentifier() {
+            return null;
+        }
+
+        @Override
+        public int minimumTokenMatch() {
+            return 0;
+        }
+    }
+
+    private static class LanguageWithLazyParser extends LanguageWithoutParser {
+        @Override
+        protected AbstractAntlrParserAdapter<?> initializeParser() {
+            return new TestParserAdapter();
+        }
+    }
+}

--- a/language-antlr-utils/src/test/java/de/jplag/antlr/LanguageTest.java
+++ b/language-antlr-utils/src/test/java/de/jplag/antlr/LanguageTest.java
@@ -1,15 +1,16 @@
 package de.jplag.antlr;
 
-import de.jplag.ParsingException;
-import de.jplag.antlr.testLanguage.TestLanguage;
-import de.jplag.antlr.testLanguage.TestParserAdapter;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import de.jplag.ParsingException;
+import de.jplag.antlr.testLanguage.TestLanguage;
+import de.jplag.antlr.testLanguage.TestParserAdapter;
 
 /**
  * Some tests for the abstract antlr language

--- a/language-antlr-utils/src/test/java/de/jplag/antlr/ParserTest.java
+++ b/language-antlr-utils/src/test/java/de/jplag/antlr/ParserTest.java
@@ -2,7 +2,7 @@ package de.jplag.antlr;
 
 import static de.jplag.antlr.testLanguage.TestTokenType.*;
 
-import de.jplag.antlr.testLanguage.TestLangauge;
+import de.jplag.antlr.testLanguage.TestLanguage;
 import de.jplag.antlr.testLanguage.TestTokenType;
 import de.jplag.testutils.LanguageModuleTest;
 import de.jplag.testutils.datacollector.TestDataCollector;
@@ -10,7 +10,7 @@ import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
 
 public class ParserTest extends LanguageModuleTest {
     public ParserTest() {
-        super(new TestLangauge(), TestTokenType.class);
+        super(new TestLanguage(), TestTokenType.class);
     }
 
     @Override

--- a/language-antlr-utils/src/test/java/de/jplag/antlr/testLanguage/TestLanguage.java
+++ b/language-antlr-utils/src/test/java/de/jplag/antlr/testLanguage/TestLanguage.java
@@ -2,11 +2,11 @@ package de.jplag.antlr.testLanguage;
 
 import de.jplag.antlr.AbstractAntlrLanguage;
 
-public class TestLangauge extends AbstractAntlrLanguage {
+public class TestLanguage extends AbstractAntlrLanguage {
     /**
      * New instance
      */
-    public TestLangauge() {
+    public TestLanguage() {
         super(new TestParserAdapter());
     }
 


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

For language-antlr-utils - AbstractAntlrLanguage:
Added the option to initialize the parser later in a separate method, to allow passing more data to the parser. To do that, you need to implement the initializeParser method and pass nothing to the super constructor.