### PR TITLE
Improve readability of language test results

### DIFF
--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/FileTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/FileTestData.java
@@ -33,7 +33,7 @@ class FileTestData implements TestData {
 
     @Override
     public String describeTestSource() {
-        return "(File: " + this.file.getPath() + ")";
+        return "(File: " + this.file.getName() + ")";
     }
 
     @Override
@@ -53,6 +53,6 @@ class FileTestData implements TestData {
 
     @Override
     public String toString() {
-        return this.file.getPath();
+        return this.file.getName();
     }
 }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
@@ -98,6 +98,11 @@ public class TestDataCollector {
      * @param data The test data
      */
     public record TokenListTest(List<TokenType> tokens, TestData data) {
+
+        @Override
+        public String toString() {
+            return data.toString(); // readable test name
+        }
     }
 
     /**


### PR DESCRIPTION
This PR improves the readability of the language module test results:

- Display names are used for test categories
- Token sequences are compared via assertLinesMatch for improved readability in case of failures
- test files are displayed via their names instead of paths
- JUnit wording "expected" is used in favor of "required"