### PR TITLE
Improve error messages for the java language feature test

### DIFF
--- a/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -1,17 +1,14 @@
 package de.jplag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import de.jplag.exceptions.ExitException;
 
 public class NewJavaFeaturesTest extends TestBase {
-
-    private final Logger logger = LoggerFactory.getLogger(NewJavaFeaturesTest.class);
 
     private static final int EXPECTED_MATCHES = 6; // might change if you add files to the submissions
     private static final double EXPECTED_SIMILARITY = 0.96; // might change if you add files to the submissions
@@ -20,13 +17,16 @@ public class NewJavaFeaturesTest extends TestBase {
     private static final String EXCLUSION_FILE_NAME = "blacklist.txt";
     private static final String ROOT_DIRECTORY = "NewJavaFeatures";
     private static final String CHANGE_MESSAGE = "Number of %s changed! If intended, modify the test case!";
-    private static final String VERSION_MISMATCH_MESSAGE = "Using Java version %s instead of %s may skew the results";
+    private static final String VERSION_MISMATCH_MESSAGE = "Using Java version %s instead of %s may skew the results.";
     private static final String VERSION_MATCH_MESSAGE = "Java version matches, but results deviate from expected values";
     private static final String JAVA_VERSION_KEY = "java.version";
 
     @Test
     @DisplayName("test comparison of Java files with modern language features")
     public void testJavaFeatureDuplicates() throws ExitException {
+        // pre-condition
+        String actualJavaVersion = System.getProperty(JAVA_VERSION_KEY);
+        assumeTrue(actualJavaVersion.startsWith(EXPECTED_JAVA_VERSION), VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, EXPECTED_JAVA_VERSION));
 
         JPlagResult result = runJPlagWithExclusionFile(ROOT_DIRECTORY, EXCLUSION_FILE_NAME);
 
@@ -39,19 +39,7 @@ public class NewJavaFeaturesTest extends TestBase {
 
         // Check similarity and number of matches:
         var comparison = result.getAllComparisons().get(0);
-        String versionMessage = createJavaVersionMessage();
-        assertEquals(EXPECTED_SIMILARITY, comparison.similarity(), DELTA, versionMessage);
-        assertEquals(EXPECTED_MATCHES, comparison.matches().size(), versionMessage);
+        assertEquals(EXPECTED_SIMILARITY, comparison.similarity(), DELTA, VERSION_MATCH_MESSAGE);
+        assertEquals(EXPECTED_MATCHES, comparison.matches().size(), VERSION_MATCH_MESSAGE);
     }
-
-    private String createJavaVersionMessage() {
-        String actualJavaVersion = System.getProperty(JAVA_VERSION_KEY);
-        String message = VERSION_MATCH_MESSAGE;
-        if (!actualJavaVersion.startsWith(EXPECTED_JAVA_VERSION)) {
-            message = VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, EXPECTED_JAVA_VERSION);
-            logger.error(message);
-        }
-        return message;
-    }
-
 }

--- a/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -4,20 +4,30 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.jplag.exceptions.ExitException;
 
 public class NewJavaFeaturesTest extends TestBase {
+
+    private final Logger logger = LoggerFactory.getLogger(NewJavaFeaturesTest.class);
+
     private static final int EXPECTED_MATCHES = 6; // might change if you add files to the submissions
     private static final double EXPECTED_SIMILARITY = 0.96; // might change if you add files to the submissions
+    private static final String EXPECTED_JAVA_VERSION = "17"; // might change with newer JPlag versions
 
     private static final String EXCLUSION_FILE_NAME = "blacklist.txt";
     private static final String ROOT_DIRECTORY = "NewJavaFeatures";
     private static final String CHANGE_MESSAGE = "Number of %s changed! If intended, modify the test case!";
+    private static final String VERSION_MISMATCH_MESSAGE = "Using Java version %s instead of %s may skew the results";
+    private static final String VERSION_MATCH_MESSAGE = "Java version matches, but results deviate from expected values";
+    private static final String JAVA_VERSION_KEY = "java.version";
 
     @Test
     @DisplayName("test comparison of Java files with modern language features")
     public void testJavaFeatureDuplicates() throws ExitException {
+
         JPlagResult result = runJPlagWithExclusionFile(ROOT_DIRECTORY, EXCLUSION_FILE_NAME);
 
         // Ensure test input did not change:
@@ -29,8 +39,19 @@ public class NewJavaFeaturesTest extends TestBase {
 
         // Check similarity and number of matches:
         var comparison = result.getAllComparisons().get(0);
-        assertEquals(EXPECTED_SIMILARITY, comparison.similarity(), DELTA);
-        assertEquals(EXPECTED_MATCHES, comparison.matches().size());
+        String versionMessage = createJavaVersionMessage();
+        assertEquals(EXPECTED_SIMILARITY, comparison.similarity(), DELTA, versionMessage);
+        assertEquals(EXPECTED_MATCHES, comparison.matches().size(), versionMessage);
+    }
+
+    private String createJavaVersionMessage() {
+        String actualJavaVersion = System.getProperty(JAVA_VERSION_KEY);
+        String message = VERSION_MATCH_MESSAGE;
+        if (!actualJavaVersion.startsWith(EXPECTED_JAVA_VERSION)) {
+            message = VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, EXPECTED_JAVA_VERSION);
+            logger.error(message);
+        }
+        return message;
     }
 
 }

--- a/core/src/test/java/de/jplag/TestBase.java
+++ b/core/src/test/java/de/jplag/TestBase.java
@@ -8,6 +8,7 @@ import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import de.jplag.clustering.ClusteringOptions;
 import de.jplag.exceptions.ExitException;
 import de.jplag.java.JavaLanguage;
 import de.jplag.options.JPlagOptions;
@@ -105,7 +106,8 @@ public abstract class TestBase {
     protected JPlagOptions getOptions(List<String> newPaths, List<String> oldPaths, Function<JPlagOptions, JPlagOptions> customization) {
         var newFiles = newPaths.stream().map(File::new).collect(Collectors.toSet());
         var oldFiles = oldPaths.stream().map(File::new).collect(Collectors.toSet());
-        JPlagOptions options = new JPlagOptions(new JavaLanguage(), newFiles, oldFiles);
+        JPlagOptions options = new JPlagOptions(new JavaLanguage(), newFiles, oldFiles)
+                .withClusteringOptions(new ClusteringOptions().withEnabled(false));
         return customization.apply(options);
     }
 

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -26,16 +26,21 @@
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
+            <artifactId>language-api</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>language-testutils</artifactId>
             <version>${revision}</version>
         </dependency>
 
         <!-- Languages -->
-        <dependency>
-            <groupId>de.jplag</groupId>
-            <artifactId>language-api</artifactId>
-            <version>${revision}</version>
-        </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>text</artifactId>


### PR DESCRIPTION
When running the tests with a different Java version, this test may fail due to using a different version of JavaC in the Java language module. This is expected behavior, as it affects the tokenization. However, the messages were less than ideal.
This PR changes that by skipping the test when the Java version mismatches:

- Actual values deviate from expected ones, but Java version is correct **=> Changes to JPlag occurred, test fails**
- Actual values deviate from expected ones, and Java version is incorrect **=> Test is skipped*

_(also, this PR disables clustering for tests that do not need it)_