### PR TITLE
Adjusted behavior, default values and naming of MergingParameters

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -23,7 +23,7 @@ import de.jplag.cli.logger.CollectedLoggerFactory;
 import de.jplag.clustering.ClusteringOptions;
 import de.jplag.clustering.Preprocessing;
 import de.jplag.exceptions.ExitException;
-import de.jplag.merging.MergingParameters;
+import de.jplag.merging.MergingOptions;
 import de.jplag.options.JPlagOptions;
 import de.jplag.options.LanguageOption;
 import de.jplag.options.LanguageOptions;
@@ -166,12 +166,12 @@ public final class CLI {
         }
 
         ClusteringOptions clusteringOptions = getClusteringOptions(this.options);
-        MergingParameters mergingParameters = getMergingParameters(this.options);
+        MergingOptions mergingOptions = getMergingOptions(this.options);
 
         JPlagOptions jPlagOptions = new JPlagOptions(loadLanguage(parseResult), this.options.minTokenMatch, submissionDirectories,
                 oldSubmissionDirectories, null, this.options.advanced.subdirectory, suffixes, this.options.advanced.exclusionFileName,
                 JPlagOptions.DEFAULT_SIMILARITY_METRIC, this.options.advanced.similarityThreshold, this.options.shownComparisons, clusteringOptions,
-                this.options.advanced.debug, mergingParameters);
+                this.options.advanced.debug, mergingOptions);
 
         String baseCodePath = this.options.baseCode;
         File baseCodeDirectory = baseCodePath == null ? null : new File(baseCodePath);
@@ -230,8 +230,8 @@ public final class CLI {
         return clusteringOptions;
     }
 
-    private static MergingParameters getMergingParameters(CliOptions options) {
-        return new MergingParameters(options.merging.enabled, options.merging.neighborLength, options.merging.gapSize);
+    private static MergingOptions getMergingOptions(CliOptions options) {
+        return new MergingOptions(options.merging.enabled, options.merging.neighborLength, options.merging.gapSize);
     }
 
     private String generateDescription() {

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -231,7 +231,7 @@ public final class CLI {
     }
 
     private static MergingOptions getMergingOptions(CliOptions options) {
-        return new MergingOptions(options.merging.enabled, options.merging.neighborLength, options.merging.gapSize);
+        return new MergingOptions(options.merging.enabled, options.merging.minimumNeighborLength, options.merging.maximumGapSize);
     }
 
     private String generateDescription() {

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -231,7 +231,7 @@ public final class CLI {
     }
 
     private static MergingParameters getMergingParameters(CliOptions options) {
-        return new MergingParameters(options.merging.enabled, options.merging.mergeBuffer, options.merging.gapSize);
+        return new MergingParameters(options.merging.enabled, options.merging.neighborLength, options.merging.gapSize);
     }
 
     private String generateDescription() {

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -231,7 +231,7 @@ public final class CLI {
     }
 
     private static MergingParameters getMergingParameters(CliOptions options) {
-        return new MergingParameters(options.merging.enabled, options.merging.mergeBuffer, options.merging.seperatingThreshold);
+        return new MergingParameters(options.merging.enabled, options.merging.mergeBuffer, options.merging.gapSize);
     }
 
     private String generateDescription() {

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -59,7 +59,7 @@ public class CliOptions implements Runnable {
     @ArgGroup(validate = false, heading = "Clustering%n")
     public Clustering clustering = new Clustering();
 
-    @ArgGroup(validate = false, heading = "Match Merging defense that merges neighboring matches to increase the similarity between plagiarisms:%n")
+    @ArgGroup(validate = false, heading = "Merging of neighboring matches to increase the similarity of concealed plagiarism:%n")
     public Merging merging = new Merging();
 
     /**
@@ -116,7 +116,7 @@ public class CliOptions implements Runnable {
         @Option(names = {"--match-merging"}, description = "Enables match merging (default: false)%n")
         public boolean enabled;
 
-        @Option(names = {"--neighbor-length"}, description = "Defines how low the length of a match can be, to be considered (default: 2)%n")
+        @Option(names = {"--neighbor-length"}, description = "Defines how short a match can be, to be considered (default: 2)%n")
         public int neighborLength;
 
         @Option(names = {"--gap-size"}, description = "Defines how many token there can be between two neighboring matches (default: 6)%n")

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -116,11 +116,11 @@ public class CliOptions implements Runnable {
         @Option(names = {"--match-merging"}, description = "Enables match merging (default: false)%n")
         public boolean enabled;
 
-        @Option(names = {"--merge-buffer"}, description = "Defines how low the length of a match can be, to be considered (default: 0)%n")
+        @Option(names = {"--merge-buffer"}, description = "Defines how low the length of a match can be, to be considered (default: 2)%n")
         public int mergeBuffer;
 
         @Option(names = {
-                "--seperating-threshold"}, description = "Defines how many token there can be between two neighboring matches (default: 0)%n")
+                "--seperating-threshold"}, description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
         public int seperatingThreshold;
 
     }

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -117,10 +117,10 @@ public class CliOptions implements Runnable {
         public boolean enabled;
 
         @Option(names = {"--neighbor-length"}, description = "Defines how short a match can be, to be considered (default: 2)%n")
-        public int neighborLength;
+        public int minimumNeighborLength;
 
         @Option(names = {"--gap-size"}, description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
-        public int gapSize;
+        public int maximumGapSize;
 
     }
 

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -119,9 +119,8 @@ public class CliOptions implements Runnable {
         @Option(names = {"--merge-buffer"}, description = "Defines how low the length of a match can be, to be considered (default: 2)%n")
         public int mergeBuffer;
 
-        @Option(names = {
-                "--seperating-threshold"}, description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
-        public int seperatingThreshold;
+        @Option(names = {"--gap-size"}, description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
+        public int gapSize;
 
     }
 

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -59,7 +59,7 @@ public class CliOptions implements Runnable {
     @ArgGroup(validate = false, heading = "Clustering%n")
     public Clustering clustering = new Clustering();
 
-    @ArgGroup(validate = false, heading = "Match Merging defense mechanism against obfuscation that merges neighboring matches based on these parameters:%n")
+    @ArgGroup(validate = false, heading = "Match Merging defense that merges neighboring matches to increase the similarity between plagiarisms:%n")
     public Merging merging = new Merging();
 
     /**
@@ -116,8 +116,7 @@ public class CliOptions implements Runnable {
         @Option(names = {"--match-merging"}, description = "Enables match merging (default: false)%n")
         public boolean enabled;
 
-        @Option(names = {
-                "--merge-buffer"}, description = "Defines how much lower the length of a match can be than the minimum match length (default: 0)%n")
+        @Option(names = {"--merge-buffer"}, description = "Defines how low the length of a match can be, to be considered (default: 0)%n")
         public int mergeBuffer;
 
         @Option(names = {

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -116,8 +116,8 @@ public class CliOptions implements Runnable {
         @Option(names = {"--match-merging"}, description = "Enables match merging (default: false)%n")
         public boolean enabled;
 
-        @Option(names = {"--merge-buffer"}, description = "Defines how low the length of a match can be, to be considered (default: 2)%n")
-        public int mergeBuffer;
+        @Option(names = {"--neighbor-length"}, description = "Defines how low the length of a match can be, to be considered (default: 2)%n")
+        public int neighborLength;
 
         @Option(names = {"--gap-size"}, description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
         public int gapSize;

--- a/core/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/GreedyStringTiling.java
@@ -22,7 +22,7 @@ import de.jplag.options.JPlagOptions;
 public class GreedyStringTiling {
 
     private final int minimumMatchLength;
-    private final int mergeBuffer;
+    private final int neighborLength;
     private JPlagOptions options;
     private ConcurrentMap<TokenType, Integer> tokenTypeValues;
     private final Map<Submission, Set<Token>> baseCodeMarkings = new IdentityHashMap<>();
@@ -32,9 +32,9 @@ public class GreedyStringTiling {
 
     public GreedyStringTiling(JPlagOptions options) {
         this.options = options;
-        // Ensures 1 <= mergeBuffer <= minimumTokenMatch
-        this.mergeBuffer = Math.min(Math.max(options.mergingParameters().mergeBuffer(), 1), options.minimumTokenMatch());
-        this.minimumMatchLength = options.mergingParameters().enabled() ? this.mergeBuffer : options.minimumTokenMatch();
+        // Ensures 1 <= neighborLength <= minimumTokenMatch
+        this.neighborLength = Math.min(Math.max(options.mergingParameters().neighborLength(), 1), options.minimumTokenMatch());
+        this.minimumMatchLength = options.mergingParameters().enabled() ? this.neighborLength : options.minimumTokenMatch();
         this.tokenTypeValues = new ConcurrentHashMap<>();
         this.tokenTypeValues.put(SharedTokenType.FILE_END, 0);
     }

--- a/core/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/GreedyStringTiling.java
@@ -23,6 +23,7 @@ public class GreedyStringTiling {
 
     private final int minimumMatchLength;
     private final int mergeBuffer;
+    private JPlagOptions options;
     private ConcurrentMap<TokenType, Integer> tokenTypeValues;
     private final Map<Submission, Set<Token>> baseCodeMarkings = new IdentityHashMap<>();
 
@@ -30,8 +31,9 @@ public class GreedyStringTiling {
     private final Map<Submission, SubsequenceHashLookupTable> cachedHashLookupTables = new IdentityHashMap<>();
 
     public GreedyStringTiling(JPlagOptions options) {
-        this.mergeBuffer = options.mergingParameters().mergeBuffer();
-        this.minimumMatchLength = Math.max(options.minimumTokenMatch() - this.mergeBuffer, 1);
+        this.options = options;
+        this.mergeBuffer = Math.min(Math.max(options.mergingParameters().mergeBuffer(), 1), options.minimumTokenMatch());
+        this.minimumMatchLength = options.mergingParameters().enabled() ? this.mergeBuffer : options.minimumTokenMatch();
         this.tokenTypeValues = new ConcurrentHashMap<>();
         this.tokenTypeValues.put(SharedTokenType.FILE_END, 0);
     }
@@ -133,7 +135,7 @@ public class GreedyStringTiling {
                 }
             }
             for (Match match : iterationMatches) {
-                if (match.length() < minimumMatchLength + mergeBuffer) {
+                if (match.length() < options.minimumTokenMatch()) {
                     addMatchIfNotOverlapping(ignoredMatches, match);
                 } else {
                     addMatchIfNotOverlapping(globalMatches, match);

--- a/core/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/GreedyStringTiling.java
@@ -22,7 +22,7 @@ import de.jplag.options.JPlagOptions;
 public class GreedyStringTiling {
 
     private final int minimumMatchLength;
-    private final int neighborLength;
+    private final int minimumNeighborLength;
     private JPlagOptions options;
     private ConcurrentMap<TokenType, Integer> tokenTypeValues;
     private final Map<Submission, Set<Token>> baseCodeMarkings = new IdentityHashMap<>();
@@ -33,8 +33,8 @@ public class GreedyStringTiling {
     public GreedyStringTiling(JPlagOptions options) {
         this.options = options;
         // Ensures 1 <= neighborLength <= minimumTokenMatch
-        this.neighborLength = Math.min(Math.max(options.mergingOptions().neighborLength(), 1), options.minimumTokenMatch());
-        this.minimumMatchLength = options.mergingOptions().enabled() ? this.neighborLength : options.minimumTokenMatch();
+        this.minimumNeighborLength = Math.min(Math.max(options.mergingOptions().minimumNeighborLength(), 1), options.minimumTokenMatch());
+        this.minimumMatchLength = options.mergingOptions().enabled() ? this.minimumNeighborLength : options.minimumTokenMatch();
         this.tokenTypeValues = new ConcurrentHashMap<>();
         this.tokenTypeValues.put(SharedTokenType.FILE_END, 0);
     }

--- a/core/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/GreedyStringTiling.java
@@ -33,8 +33,8 @@ public class GreedyStringTiling {
     public GreedyStringTiling(JPlagOptions options) {
         this.options = options;
         // Ensures 1 <= neighborLength <= minimumTokenMatch
-        this.neighborLength = Math.min(Math.max(options.mergingParameters().neighborLength(), 1), options.minimumTokenMatch());
-        this.minimumMatchLength = options.mergingParameters().enabled() ? this.neighborLength : options.minimumTokenMatch();
+        this.neighborLength = Math.min(Math.max(options.mergingOptions().neighborLength(), 1), options.minimumTokenMatch());
+        this.minimumMatchLength = options.mergingOptions().enabled() ? this.neighborLength : options.minimumTokenMatch();
         this.tokenTypeValues = new ConcurrentHashMap<>();
         this.tokenTypeValues.put(SharedTokenType.FILE_END, 0);
     }

--- a/core/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/GreedyStringTiling.java
@@ -32,6 +32,7 @@ public class GreedyStringTiling {
 
     public GreedyStringTiling(JPlagOptions options) {
         this.options = options;
+        // Ensures 1 <= mergeBuffer <= minimumTokenMatch
         this.mergeBuffer = Math.min(Math.max(options.mergingParameters().mergeBuffer(), 1), options.minimumTokenMatch());
         this.minimumMatchLength = options.mergingParameters().enabled() ? this.mergeBuffer : options.minimumTokenMatch();
         this.tokenTypeValues = new ConcurrentHashMap<>();

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -74,7 +74,7 @@ public class JPlag {
         JPlagResult result = comparisonStrategy.compareSubmissions(submissionSet);
 
         // Use Match Merging against obfuscation
-        if (options.mergingParameters().enabled()) {
+        if (options.mergingOptions().enabled()) {
             result = new MatchMerging(options).mergeMatchesOf(result);
         }
 

--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -19,7 +19,7 @@ import de.jplag.options.JPlagOptions;
  * and right and neighboring matches as upper and lower. When neighboring matches get merged they become one and the
  * tokens separating them get removed from the submission clone. NeighborLength describes how short a match can be and
  * GapSize describes how many tokens can be between two neighboring matches. Both are set in {@link JPlagOptions} as
- * {@link MergingParameters} and default to (2,6).
+ * {@link MergingOptions} and default to (2,6).
  */
 public class MatchMerging {
     private JPlagOptions options;
@@ -34,7 +34,7 @@ public class MatchMerging {
 
     /**
      * Runs the internal match merging pipeline. It computes neighboring matches, merges them based on
-     * {@link MergingParameters} and removes remaining too short matches afterwards.
+     * {@link MergingOptions} and removes remaining too short matches afterwards.
      * @param result is the initially computed result object
      * @return JPlagResult containing the merged matches
      */
@@ -97,7 +97,7 @@ public class MatchMerging {
             int tokensBetweenRight = lowerNeighbor.startOfSecond() - upperNeighbor.endOfSecond() - 1;
             double averageTokensBetweenMatches = (tokenBetweenLeft + tokensBetweenRight) / 2.0;
             // Checking length is not necessary as GST already checked length while computing matches
-            if (averageTokensBetweenMatches <= options.mergingParameters().gapSize()
+            if (averageTokensBetweenMatches <= options.mergingOptions().gapSize()
                     && !mergeOverlapsFiles(leftSubmission, rightSubmission, upperNeighbor, tokenBetweenLeft, tokensBetweenRight)) {
                 globalMatches.remove(upperNeighbor);
                 globalMatches.remove(lowerNeighbor);

--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -19,7 +19,7 @@ import de.jplag.options.JPlagOptions;
  * to as left and right and neighboring matches as upper and lower. When neighboring matches get merged they become one
  * and the tokens separating them get removed from the submission clone. MergeBuffer describes how short a match can be
  * and SeperatingThreshold describes how many tokens can be between two neighboring matches. Both are set in
- * {@link JPlagOptions} as {@link MergingParameters} and default to (0,0).
+ * {@link JPlagOptions} as {@link MergingParameters} and default to (2,6).
  */
 public class MatchMerging {
     private JPlagOptions options;

--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -13,13 +13,13 @@ import de.jplag.Token;
 import de.jplag.options.JPlagOptions;
 
 /**
- * This class implements a match merging algorithm which serves as defense mechanism against obfuscation attacks. Based
- * on configurable parameters MergeBuffer and SeperatingThreshold, it alters prior results from pairwise submission
- * comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred to as left
- * and right and neighboring matches as upper and lower. When neighboring matches get merged they become one and the
- * tokens separating them get removed from the submission clone. MergeBuffer describes how shorter a match can be than
- * the Minimum Token Match. SeperatingThreshold describes how many tokens can be between two neighboring matches. Both
- * are set in {@link JPlagOptions} as {@link MergingParameters} and default to 0 (which deactivates merging).
+ * This class implements a match merging algorithm which serves as a defense mechanism against obfuscation attacks.
+ * Based on configurable parameters MergeBuffer and SeperatingThreshold, it alters prior results from pairwise
+ * submission comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred
+ * to as left and right and neighboring matches as upper and lower. When neighboring matches get merged they become one
+ * and the tokens separating them get removed from the submission clone. MergeBuffer describes how short a match can be
+ * and SeperatingThreshold describes how many tokens can be between two neighboring matches. Both are set in
+ * {@link JPlagOptions} as {@link MergingParameters} and default to (0,0).
  */
 public class MatchMerging {
     private JPlagOptions options;

--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -14,12 +14,12 @@ import de.jplag.options.JPlagOptions;
 
 /**
  * This class implements a match merging algorithm which serves as a defense mechanism against obfuscation attacks.
- * Based on configurable parameters NeighborLength and GapSize, it alters prior results from pairwise submission
- * comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred to as left
- * and right and neighboring matches as upper and lower. When neighboring matches get merged they become one and the
- * tokens separating them get removed from the submission clone. NeighborLength describes how short a match can be and
- * GapSize describes how many tokens can be between two neighboring matches. Both are set in {@link JPlagOptions} as
- * {@link MergingOptions} and default to (2,6).
+ * Based on configurable parameters MinimumNeighborLength and MaximumGapSize, it alters prior results from pairwise
+ * submission comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred
+ * to as left and right and neighboring matches as upper and lower. When neighboring matches get merged they become one
+ * and the tokens separating them get removed from the submission clone. MinimumNeighborLength describes how short a
+ * match can be and MaximumGapSize describes how many tokens can be between two neighboring matches. Both are set in
+ * {@link JPlagOptions} as {@link MergingOptions} and default to (2,6).
  */
 public class MatchMerging {
     private JPlagOptions options;
@@ -97,7 +97,7 @@ public class MatchMerging {
             int tokensBetweenRight = lowerNeighbor.startOfSecond() - upperNeighbor.endOfSecond() - 1;
             double averageTokensBetweenMatches = (tokenBetweenLeft + tokensBetweenRight) / 2.0;
             // Checking length is not necessary as GST already checked length while computing matches
-            if (averageTokensBetweenMatches <= options.mergingOptions().gapSize()
+            if (averageTokensBetweenMatches <= options.mergingOptions().maximumGapSize()
                     && !mergeOverlapsFiles(leftSubmission, rightSubmission, upperNeighbor, tokenBetweenLeft, tokensBetweenRight)) {
                 globalMatches.remove(upperNeighbor);
                 globalMatches.remove(lowerNeighbor);

--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -14,10 +14,10 @@ import de.jplag.options.JPlagOptions;
 
 /**
  * This class implements a match merging algorithm which serves as a defense mechanism against obfuscation attacks.
- * Based on configurable parameters MergeBuffer and GapSize, it alters prior results from pairwise submission
+ * Based on configurable parameters NeighborLength and GapSize, it alters prior results from pairwise submission
  * comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred to as left
  * and right and neighboring matches as upper and lower. When neighboring matches get merged they become one and the
- * tokens separating them get removed from the submission clone. MergeBuffer describes how short a match can be and
+ * tokens separating them get removed from the submission clone. NeighborLength describes how short a match can be and
  * GapSize describes how many tokens can be between two neighboring matches. Both are set in {@link JPlagOptions} as
  * {@link MergingParameters} and default to (2,6).
  */

--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -14,12 +14,12 @@ import de.jplag.options.JPlagOptions;
 
 /**
  * This class implements a match merging algorithm which serves as a defense mechanism against obfuscation attacks.
- * Based on configurable parameters MergeBuffer and SeperatingThreshold, it alters prior results from pairwise
- * submission comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred
- * to as left and right and neighboring matches as upper and lower. When neighboring matches get merged they become one
- * and the tokens separating them get removed from the submission clone. MergeBuffer describes how short a match can be
- * and SeperatingThreshold describes how many tokens can be between two neighboring matches. Both are set in
- * {@link JPlagOptions} as {@link MergingParameters} and default to (2,6).
+ * Based on configurable parameters MergeBuffer and GapSize, it alters prior results from pairwise submission
+ * comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred to as left
+ * and right and neighboring matches as upper and lower. When neighboring matches get merged they become one and the
+ * tokens separating them get removed from the submission clone. MergeBuffer describes how short a match can be and
+ * GapSize describes how many tokens can be between two neighboring matches. Both are set in {@link JPlagOptions} as
+ * {@link MergingParameters} and default to (2,6).
  */
 public class MatchMerging {
     private JPlagOptions options;
@@ -97,7 +97,7 @@ public class MatchMerging {
             int tokensBetweenRight = lowerNeighbor.startOfSecond() - upperNeighbor.endOfSecond() - 1;
             double averageTokensBetweenMatches = (tokenBetweenLeft + tokensBetweenRight) / 2.0;
             // Checking length is not necessary as GST already checked length while computing matches
-            if (averageTokensBetweenMatches <= options.mergingParameters().seperatingThreshold()
+            if (averageTokensBetweenMatches <= options.mergingParameters().gapSize()
                     && !mergeOverlapsFiles(leftSubmission, rightSubmission, upperNeighbor, tokenBetweenLeft, tokensBetweenRight)) {
                 globalMatches.remove(upperNeighbor);
                 globalMatches.remove(lowerNeighbor);

--- a/core/src/main/java/de/jplag/merging/MergingOptions.java
+++ b/core/src/main/java/de/jplag/merging/MergingOptions.java
@@ -5,40 +5,40 @@ package de.jplag.merging;
  * @param neighborLength describes how short a match can be, to be considered (Defaults to 2).
  * @param gapSize describes how many tokens can be between to neighboring matches (Defaults to 6).
  */
-public record MergingParameters(boolean enabled, int neighborLength, int gapSize) {
+public record MergingOptions(boolean enabled, int neighborLength, int gapSize) {
 
     /**
-     * The default values of MergingParameters are false for the enable-switch, which deactivate MatchMerging, while
+     * The default values of MergingOptions are false for the enable-switch, which deactivate MatchMerging, while
      * neighborLength and gapSize default to (2,6), which in testing yielded the best results.
      */
-    public MergingParameters() {
+    public MergingOptions() {
         this(false, 2, 6);
     }
 
     /**
      * Builder pattern method for setting enabled
      * @param enabled containing the new value
-     * @return MergingParameters with specified enabled
+     * @return MergingOptions with specified enabled
      */
-    public MergingParameters withEnabled(boolean enabled) {
-        return new MergingParameters(enabled, neighborLength, gapSize);
+    public MergingOptions withEnabled(boolean enabled) {
+        return new MergingOptions(enabled, neighborLength, gapSize);
     }
 
     /**
      * Builder pattern method for setting neighborLength
      * @param neighborLength containing the new value
-     * @return MergingParameters with specified neighborLength
+     * @return MergingOptions with specified neighborLength
      */
-    public MergingParameters withNeighborLength(int neighborLength) {
-        return new MergingParameters(enabled, neighborLength, gapSize);
+    public MergingOptions withNeighborLength(int neighborLength) {
+        return new MergingOptions(enabled, neighborLength, gapSize);
     }
 
     /**
      * Builder pattern method for setting gapSize
      * @param gapSize containing the new value
-     * @return MergingParameters with specified gapSize
+     * @return MergingOptions with specified gapSize
      */
-    public MergingParameters withGapSize(int gapSize) {
-        return new MergingParameters(enabled, neighborLength, gapSize);
+    public MergingOptions withGapSize(int gapSize) {
+        return new MergingOptions(enabled, neighborLength, gapSize);
     }
 }

--- a/core/src/main/java/de/jplag/merging/MergingOptions.java
+++ b/core/src/main/java/de/jplag/merging/MergingOptions.java
@@ -2,14 +2,14 @@ package de.jplag.merging;
 
 /**
  * Collection of parameters that describe how a match merging should be performed.
- * @param neighborLength describes how short a match can be, to be considered (Defaults to 2).
- * @param gapSize describes how many tokens can be between to neighboring matches (Defaults to 6).
+ * @param minimumNeighborLength describes how short a match can be, to be considered (Defaults to 2).
+ * @param maximumGapSize describes how many tokens can be between to neighboring matches (Defaults to 6).
  */
-public record MergingOptions(boolean enabled, int neighborLength, int gapSize) {
+public record MergingOptions(boolean enabled, int minimumNeighborLength, int maximumGapSize) {
 
     /**
      * The default values of MergingOptions are false for the enable-switch, which deactivate MatchMerging, while
-     * neighborLength and gapSize default to (2,6), which in testing yielded the best results.
+     * minimumNeighborLength and maximumGapSize default to (2,6), which in testing yielded the best results.
      */
     public MergingOptions() {
         this(false, 2, 6);
@@ -21,24 +21,24 @@ public record MergingOptions(boolean enabled, int neighborLength, int gapSize) {
      * @return MergingOptions with specified enabled
      */
     public MergingOptions withEnabled(boolean enabled) {
-        return new MergingOptions(enabled, neighborLength, gapSize);
+        return new MergingOptions(enabled, minimumNeighborLength, maximumGapSize);
     }
 
     /**
-     * Builder pattern method for setting neighborLength
-     * @param neighborLength containing the new value
-     * @return MergingOptions with specified neighborLength
+     * Builder pattern method for setting minimumNeighborLength
+     * @param minimumNeighborLength containing the new value
+     * @return MergingOptions with specified minimumNeighborLength
      */
-    public MergingOptions withNeighborLength(int neighborLength) {
-        return new MergingOptions(enabled, neighborLength, gapSize);
+    public MergingOptions withMinimumNeighborLength(int minimumNeighborLength) {
+        return new MergingOptions(enabled, minimumNeighborLength, maximumGapSize);
     }
 
     /**
-     * Builder pattern method for setting gapSize
-     * @param gapSize containing the new value
-     * @return MergingOptions with specified gapSize
+     * Builder pattern method for setting maximumGapSize
+     * @param maximumGapSize containing the new value
+     * @return MergingOptions with specified maximumGapSize
      */
-    public MergingOptions withGapSize(int gapSize) {
-        return new MergingOptions(enabled, neighborLength, gapSize);
+    public MergingOptions withMaximumGapSize(int maximumGapSize) {
+        return new MergingOptions(enabled, minimumNeighborLength, maximumGapSize);
     }
 }

--- a/core/src/main/java/de/jplag/merging/MergingParameters.java
+++ b/core/src/main/java/de/jplag/merging/MergingParameters.java
@@ -2,17 +2,17 @@ package de.jplag.merging;
 
 /**
  * Collection of parameters that describe how a match merging should be performed.
- * @param mergeBuffer describes how short a match can be, to be considered (Defaults to 0).
- * @param seperatingThreshold describes how many tokens can be between to neighboring matches (Defaults to 0).
+ * @param mergeBuffer describes how short a match can be, to be considered (Defaults to 2).
+ * @param seperatingThreshold describes how many tokens can be between to neighboring matches (Defaults to 6).
  */
 public record MergingParameters(boolean enabled, int mergeBuffer, int seperatingThreshold) {
 
     /**
      * The default values of MergingParameters are false for the enable-switch, which deactivate MatchMerging, while
-     * mergeBuffer and seperatingThreshold default to (0,0), which in testing yielded the best results.
+     * mergeBuffer and seperatingThreshold default to (2,6), which in testing yielded the best results.
      */
     public MergingParameters() {
-        this(false, 0, 0);
+        this(false, 2, 6);
     }
 
     /**

--- a/core/src/main/java/de/jplag/merging/MergingParameters.java
+++ b/core/src/main/java/de/jplag/merging/MergingParameters.java
@@ -3,13 +3,13 @@ package de.jplag.merging;
 /**
  * Collection of parameters that describe how a match merging should be performed.
  * @param mergeBuffer describes how short a match can be, to be considered (Defaults to 2).
- * @param seperatingThreshold describes how many tokens can be between to neighboring matches (Defaults to 6).
+ * @param gapSize describes how many tokens can be between to neighboring matches (Defaults to 6).
  */
-public record MergingParameters(boolean enabled, int mergeBuffer, int seperatingThreshold) {
+public record MergingParameters(boolean enabled, int mergeBuffer, int gapSize) {
 
     /**
      * The default values of MergingParameters are false for the enable-switch, which deactivate MatchMerging, while
-     * mergeBuffer and seperatingThreshold default to (2,6), which in testing yielded the best results.
+     * mergeBuffer and gapSize default to (2,6), which in testing yielded the best results.
      */
     public MergingParameters() {
         this(false, 2, 6);
@@ -21,7 +21,7 @@ public record MergingParameters(boolean enabled, int mergeBuffer, int seperating
      * @return MergingParameters with specified enabled
      */
     public MergingParameters withEnabled(boolean enabled) {
-        return new MergingParameters(enabled, mergeBuffer, seperatingThreshold);
+        return new MergingParameters(enabled, mergeBuffer, gapSize);
     }
 
     /**
@@ -30,15 +30,15 @@ public record MergingParameters(boolean enabled, int mergeBuffer, int seperating
      * @return MergingParameters with specified mergeBuffer
      */
     public MergingParameters withMergeBuffer(int mergeBuffer) {
-        return new MergingParameters(enabled, mergeBuffer, seperatingThreshold);
+        return new MergingParameters(enabled, mergeBuffer, gapSize);
     }
 
     /**
-     * Builder pattern method for setting seperatingThreshold
-     * @param seperatingThreshold containing the new value
-     * @return MergingParameters with specified seperatingThreshold
+     * Builder pattern method for setting gapSize
+     * @param gapSize containing the new value
+     * @return MergingParameters with specified gapSize
      */
-    public MergingParameters withSeperatingThreshold(int seperatingThreshold) {
-        return new MergingParameters(enabled, mergeBuffer, seperatingThreshold);
+    public MergingParameters withGapSize(int gapSize) {
+        return new MergingParameters(enabled, mergeBuffer, gapSize);
     }
 }

--- a/core/src/main/java/de/jplag/merging/MergingParameters.java
+++ b/core/src/main/java/de/jplag/merging/MergingParameters.java
@@ -2,14 +2,14 @@ package de.jplag.merging;
 
 /**
  * Collection of parameters that describe how a match merging should be performed.
- * @param mergeBuffer describes how shorter a match can be than the Minimum Token Match (Defaults to 0).
+ * @param mergeBuffer describes how short a match can be, to be considered (Defaults to 0).
  * @param seperatingThreshold describes how many tokens can be between to neighboring matches (Defaults to 0).
  */
 public record MergingParameters(boolean enabled, int mergeBuffer, int seperatingThreshold) {
 
     /**
-     * The default values of MergingParameters are false for the enable-switch and 0 for both mergeBuffer and
-     * seperatingThreshold. These completely deactivate MatchMerging.
+     * The default values of MergingParameters are false for the enable-switch, which deactivate MatchMerging, while
+     * mergeBuffer and seperatingThreshold default to (0,0), which in testing yielded the best results.
      */
     public MergingParameters() {
         this(false, 0, 0);

--- a/core/src/main/java/de/jplag/merging/MergingParameters.java
+++ b/core/src/main/java/de/jplag/merging/MergingParameters.java
@@ -2,14 +2,14 @@ package de.jplag.merging;
 
 /**
  * Collection of parameters that describe how a match merging should be performed.
- * @param mergeBuffer describes how short a match can be, to be considered (Defaults to 2).
+ * @param neighborLength describes how short a match can be, to be considered (Defaults to 2).
  * @param gapSize describes how many tokens can be between to neighboring matches (Defaults to 6).
  */
-public record MergingParameters(boolean enabled, int mergeBuffer, int gapSize) {
+public record MergingParameters(boolean enabled, int neighborLength, int gapSize) {
 
     /**
      * The default values of MergingParameters are false for the enable-switch, which deactivate MatchMerging, while
-     * mergeBuffer and gapSize default to (2,6), which in testing yielded the best results.
+     * neighborLength and gapSize default to (2,6), which in testing yielded the best results.
      */
     public MergingParameters() {
         this(false, 2, 6);
@@ -21,16 +21,16 @@ public record MergingParameters(boolean enabled, int mergeBuffer, int gapSize) {
      * @return MergingParameters with specified enabled
      */
     public MergingParameters withEnabled(boolean enabled) {
-        return new MergingParameters(enabled, mergeBuffer, gapSize);
+        return new MergingParameters(enabled, neighborLength, gapSize);
     }
 
     /**
-     * Builder pattern method for setting mergeBuffer
-     * @param mergeBuffer containing the new value
-     * @return MergingParameters with specified mergeBuffer
+     * Builder pattern method for setting neighborLength
+     * @param neighborLength containing the new value
+     * @return MergingParameters with specified neighborLength
      */
-    public MergingParameters withMergeBuffer(int mergeBuffer) {
-        return new MergingParameters(enabled, mergeBuffer, gapSize);
+    public MergingParameters withNeighborLength(int neighborLength) {
+        return new MergingParameters(enabled, neighborLength, gapSize);
     }
 
     /**
@@ -39,6 +39,6 @@ public record MergingParameters(boolean enabled, int mergeBuffer, int gapSize) {
      * @return MergingParameters with specified gapSize
      */
     public MergingParameters withGapSize(int gapSize) {
-        return new MergingParameters(enabled, mergeBuffer, gapSize);
+        return new MergingParameters(enabled, neighborLength, gapSize);
     }
 }

--- a/core/src/main/java/de/jplag/merging/Neighbor.java
+++ b/core/src/main/java/de/jplag/merging/Neighbor.java
@@ -2,9 +2,9 @@ package de.jplag.merging;
 
 import de.jplag.Match;
 
-/*
- * This class realizes a pair of neighboring matches, named upperMatch and lowerMatch Two matches are considered
- * neighbors, if they begin directly after one another in the left submission and in the right submission
+/**
+ * This class realizes a pair of neighboring matches, named upperMatch and lowerMatch. Two matches are considered
+ * neighbors, if they begin directly after one another in the left submission and in the right submission.
  */
 public record Neighbor(Match upperMatch, Match lowerMatch) {
 }

--- a/core/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/core/src/main/java/de/jplag/options/JPlagOptions.java
@@ -19,7 +19,7 @@ import de.jplag.JPlag;
 import de.jplag.Language;
 import de.jplag.clustering.ClusteringOptions;
 import de.jplag.exceptions.BasecodeException;
-import de.jplag.merging.MergingParameters;
+import de.jplag.merging.MergingOptions;
 import de.jplag.util.FileUtils;
 
 /**
@@ -48,7 +48,7 @@ import de.jplag.util.FileUtils;
 public record JPlagOptions(Language language, Integer minimumTokenMatch, Set<File> submissionDirectories, Set<File> oldSubmissionDirectories,
         File baseCodeSubmissionDirectory, String subdirectoryName, List<String> fileSuffixes, String exclusionFileName,
         SimilarityMetric similarityMetric, double similarityThreshold, int maximumNumberOfComparisons, ClusteringOptions clusteringOptions,
-        boolean debugParser, MergingParameters mergingParameters) {
+        boolean debugParser, MergingOptions mergingOptions) {
 
     public static final double DEFAULT_SIMILARITY_THRESHOLD = 0;
     public static final int DEFAULT_SHOWN_COMPARISONS = 100;
@@ -61,13 +61,13 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, Set<Fil
 
     public JPlagOptions(Language language, Set<File> submissionDirectories, Set<File> oldSubmissionDirectories) {
         this(language, null, submissionDirectories, oldSubmissionDirectories, null, null, null, null, DEFAULT_SIMILARITY_METRIC,
-                DEFAULT_SIMILARITY_THRESHOLD, DEFAULT_SHOWN_COMPARISONS, new ClusteringOptions(), false, new MergingParameters());
+                DEFAULT_SIMILARITY_THRESHOLD, DEFAULT_SHOWN_COMPARISONS, new ClusteringOptions(), false, new MergingOptions());
     }
 
     public JPlagOptions(Language language, Integer minimumTokenMatch, Set<File> submissionDirectories, Set<File> oldSubmissionDirectories,
             File baseCodeSubmissionDirectory, String subdirectoryName, List<String> fileSuffixes, String exclusionFileName,
             SimilarityMetric similarityMetric, double similarityThreshold, int maximumNumberOfComparisons, ClusteringOptions clusteringOptions,
-            boolean debugParser, MergingParameters mergingParameters) {
+            boolean debugParser, MergingOptions mergingOptions) {
         this.language = language;
         this.debugParser = debugParser;
         this.fileSuffixes = fileSuffixes == null || fileSuffixes.isEmpty() ? null : Collections.unmodifiableList(fileSuffixes);
@@ -81,91 +81,91 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, Set<Fil
         this.baseCodeSubmissionDirectory = baseCodeSubmissionDirectory;
         this.subdirectoryName = subdirectoryName;
         this.clusteringOptions = clusteringOptions;
-        this.mergingParameters = mergingParameters;
+        this.mergingOptions = mergingOptions;
     }
 
     public JPlagOptions withLanguageOption(Language language) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withDebugParser(boolean debugParser) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withFileSuffixes(List<String> fileSuffixes) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withSimilarityThreshold(double similarityThreshold) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withMaximumNumberOfComparisons(int maximumNumberOfComparisons) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withSimilarityMetric(SimilarityMetric similarityMetric) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withMinimumTokenMatch(Integer minimumTokenMatch) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withExclusionFileName(String exclusionFileName) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withSubmissionDirectories(Set<File> submissionDirectories) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withOldSubmissionDirectories(Set<File> oldSubmissionDirectories) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withBaseCodeSubmissionDirectory(File baseCodeSubmissionDirectory) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withSubdirectoryName(String subdirectoryName) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public JPlagOptions withClusteringOptions(ClusteringOptions clusteringOptions) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
-    public JPlagOptions withMergingParameters(MergingParameters mergingParameters) {
+    public JPlagOptions withMergingOptions(MergingOptions mergingOptions) {
         return new JPlagOptions(language, minimumTokenMatch, submissionDirectories, oldSubmissionDirectories, baseCodeSubmissionDirectory,
                 subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                clusteringOptions, debugParser, mergingParameters);
+                clusteringOptions, debugParser, mergingOptions);
     }
 
     public boolean hasBaseCode() {
@@ -254,10 +254,10 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, Set<Fil
     public JPlagOptions(Language language, Integer minimumTokenMatch, File submissionDirectory, Set<File> oldSubmissionDirectories,
             String baseCodeSubmissionName, String subdirectoryName, List<String> fileSuffixes, String exclusionFileName,
             SimilarityMetric similarityMetric, double similarityThreshold, int maximumNumberOfComparisons, ClusteringOptions clusteringOptions,
-            boolean debugParser, MergingParameters mergingParameters) throws BasecodeException {
+            boolean debugParser, MergingOptions mergingOptions) throws BasecodeException {
         this(language, minimumTokenMatch, Set.of(submissionDirectory), oldSubmissionDirectories,
                 convertLegacyBaseCodeToFile(baseCodeSubmissionName, submissionDirectory), subdirectoryName, fileSuffixes, exclusionFileName,
-                similarityMetric, similarityThreshold, maximumNumberOfComparisons, clusteringOptions, debugParser, mergingParameters);
+                similarityMetric, similarityThreshold, maximumNumberOfComparisons, clusteringOptions, debugParser, mergingOptions);
     }
 
     /**
@@ -280,7 +280,7 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, Set<Fil
         try {
             return new JPlagOptions(language, minimumTokenMatch, submissionDirectory, oldSubmissionDirectories, baseCodeSubmissionName,
                     subdirectoryName, fileSuffixes, exclusionFileName, similarityMetric, similarityThreshold, maximumNumberOfComparisons,
-                    clusteringOptions, debugParser, mergingParameters);
+                    clusteringOptions, debugParser, mergingOptions);
         } catch (BasecodeException e) {
             throw new IllegalArgumentException(e.getMessage(), e.getCause());
         }

--- a/core/src/test/java/de/jplag/merging/MergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MergingTest.java
@@ -41,10 +41,10 @@ class MergingTest extends TestBase {
     private ComparisonStrategy comparisonStrategy;
     private SubmissionSet submissionSet;
     private final int MERGE_BUFFER = 1;
-    private final int SEPERATING_THRESHOLD = 10;
+    private final int GAP_SIZE = 10;
 
     MergingTest() throws ExitException {
-        options = getDefaultOptions("merging").withMergingParameters(new MergingParameters(true, MERGE_BUFFER, SEPERATING_THRESHOLD));
+        options = getDefaultOptions("merging").withMergingParameters(new MergingParameters(true, MERGE_BUFFER, GAP_SIZE));
 
         GreedyStringTiling coreAlgorithm = new GreedyStringTiling(options);
         comparisonStrategy = new ParallelComparisonStrategy(options, coreAlgorithm);

--- a/core/src/test/java/de/jplag/merging/MergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MergingTest.java
@@ -40,7 +40,7 @@ class MergingTest extends TestBase {
     private List<JPlagComparison> comparisonsAfter;
     private ComparisonStrategy comparisonStrategy;
     private SubmissionSet submissionSet;
-    private final int MERGE_BUFFER = 8;
+    private final int MERGE_BUFFER = 1;
     private final int SEPERATING_THRESHOLD = 10;
 
     MergingTest() throws ExitException {
@@ -79,8 +79,7 @@ class MergingTest extends TestBase {
     @Test
     @DisplayName("Test length of ignored matches after Greedy String Tiling")
     void testGSTIgnoredMatches() {
-        int matchLengthThreshold = options.minimumTokenMatch() - options.mergingParameters().mergeBuffer();
-        checkMatchLength(JPlagComparison::ignoredMatches, matchLengthThreshold, comparisonsBefore);
+        checkMatchLength(JPlagComparison::ignoredMatches, options.mergingParameters().mergeBuffer(), comparisonsBefore);
     }
 
     private void checkMatchLength(Function<JPlagComparison, List<Match>> matchFunction, int threshold, List<JPlagComparison> comparisons) {

--- a/core/src/test/java/de/jplag/merging/MergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MergingTest.java
@@ -44,7 +44,7 @@ class MergingTest extends TestBase {
     private final int GAP_SIZE = 10;
 
     MergingTest() throws ExitException {
-        options = getDefaultOptions("merging").withMergingParameters(new MergingParameters(true, NEIGHBOR_LENGTH, GAP_SIZE));
+        options = getDefaultOptions("merging").withMergingOptions(new MergingOptions(true, NEIGHBOR_LENGTH, GAP_SIZE));
 
         GreedyStringTiling coreAlgorithm = new GreedyStringTiling(options);
         comparisonStrategy = new ParallelComparisonStrategy(options, coreAlgorithm);
@@ -58,7 +58,7 @@ class MergingTest extends TestBase {
         result = comparisonStrategy.compareSubmissions(submissionSet);
         comparisonsBefore = result.getAllComparisons();
 
-        if (options.mergingParameters().enabled()) {
+        if (options.mergingOptions().enabled()) {
             result = new MatchMerging(options).mergeMatchesOf(result);
         }
         comparisonsAfter = result.getAllComparisons();
@@ -79,7 +79,7 @@ class MergingTest extends TestBase {
     @Test
     @DisplayName("Test length of ignored matches after Greedy String Tiling")
     void testGSTIgnoredMatches() {
-        checkMatchLength(JPlagComparison::ignoredMatches, options.mergingParameters().neighborLength(), comparisonsBefore);
+        checkMatchLength(JPlagComparison::ignoredMatches, options.mergingOptions().neighborLength(), comparisonsBefore);
     }
 
     private void checkMatchLength(Function<JPlagComparison, List<Match>> matchFunction, int threshold, List<JPlagComparison> comparisons) {

--- a/core/src/test/java/de/jplag/merging/MergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MergingTest.java
@@ -40,11 +40,11 @@ class MergingTest extends TestBase {
     private List<JPlagComparison> comparisonsAfter;
     private ComparisonStrategy comparisonStrategy;
     private SubmissionSet submissionSet;
-    private final int MERGE_BUFFER = 1;
+    private final int NEIGHBOR_LENGTH = 1;
     private final int GAP_SIZE = 10;
 
     MergingTest() throws ExitException {
-        options = getDefaultOptions("merging").withMergingParameters(new MergingParameters(true, MERGE_BUFFER, GAP_SIZE));
+        options = getDefaultOptions("merging").withMergingParameters(new MergingParameters(true, NEIGHBOR_LENGTH, GAP_SIZE));
 
         GreedyStringTiling coreAlgorithm = new GreedyStringTiling(options);
         comparisonStrategy = new ParallelComparisonStrategy(options, coreAlgorithm);
@@ -79,7 +79,7 @@ class MergingTest extends TestBase {
     @Test
     @DisplayName("Test length of ignored matches after Greedy String Tiling")
     void testGSTIgnoredMatches() {
-        checkMatchLength(JPlagComparison::ignoredMatches, options.mergingParameters().mergeBuffer(), comparisonsBefore);
+        checkMatchLength(JPlagComparison::ignoredMatches, options.mergingParameters().neighborLength(), comparisonsBefore);
     }
 
     private void checkMatchLength(Function<JPlagComparison, List<Match>> matchFunction, int threshold, List<JPlagComparison> comparisons) {

--- a/core/src/test/java/de/jplag/merging/MergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MergingTest.java
@@ -40,11 +40,11 @@ class MergingTest extends TestBase {
     private List<JPlagComparison> comparisonsAfter;
     private ComparisonStrategy comparisonStrategy;
     private SubmissionSet submissionSet;
-    private final int NEIGHBOR_LENGTH = 1;
-    private final int GAP_SIZE = 10;
+    private final int MINIMUM_NEIGHBOR_LENGTH = 1;
+    private final int MAXIMUM_GAP_SIZE = 10;
 
     MergingTest() throws ExitException {
-        options = getDefaultOptions("merging").withMergingOptions(new MergingOptions(true, NEIGHBOR_LENGTH, GAP_SIZE));
+        options = getDefaultOptions("merging").withMergingOptions(new MergingOptions(true, MINIMUM_NEIGHBOR_LENGTH, MAXIMUM_GAP_SIZE));
 
         GreedyStringTiling coreAlgorithm = new GreedyStringTiling(options);
         comparisonStrategy = new ParallelComparisonStrategy(options, coreAlgorithm);
@@ -79,7 +79,7 @@ class MergingTest extends TestBase {
     @Test
     @DisplayName("Test length of ignored matches after Greedy String Tiling")
     void testGSTIgnoredMatches() {
-        checkMatchLength(JPlagComparison::ignoredMatches, options.mergingOptions().neighborLength(), comparisonsBefore);
+        checkMatchLength(JPlagComparison::ignoredMatches, options.mergingOptions().minimumNeighborLength(), comparisonsBefore);
     }
 
     private void checkMatchLength(Function<JPlagComparison, List<Match>> matchFunction, int threshold, List<JPlagComparison> comparisons) {


### PR DESCRIPTION
This PR does 3 things:

1. Change mergeBuffer from being relative to MTM to an absolute Value
2. Set sensible default values for mergeBuffer and seperatingThreshold
3. Rename mergeBuffer to neighborLength and separatingThreshold to gapSize
