### PR TITLE
Fix table index not centered

### DIFF
--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -199,7 +199,7 @@ function getClusterIndexesFor(id1: string, id2: string): Array<number> {
 }
 
 .tableCellNumber {
-  @apply table-cell w-12 flex-shrink-0;
+  @apply w-12 tableCell flex-shrink-0;
 }
 
 .tableCellSimilarity {


### PR DESCRIPTION
When the name in the comparison table is longer than 1 line all other objects (cluster info, similarities) get centered vertically. Due to a typo this was not the case with the index at the beginning of the row.