### PR TITLE
Rework Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,16 @@ on:
   push: 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/maven-build.yml"
+      - "cli/**"
+      - "core/**"
+      - "endtoend-testing/**"
+      - "language-antlr-utils/**"
+      - "language-api/**"
+      - "language-testutils/**"
+      - "languages/**"
+      - "pom.xml"
   
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/report-viewer-build-test.yml
+++ b/.github/workflows/report-viewer-build-test.yml
@@ -4,6 +4,9 @@ on:
  workflow_dispatch:
  pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/report-viewer-build-test.yml"
+      - "report-viewer/**"
       
 jobs:
   pre_job:

--- a/.github/workflows/report-viewer-dev.yml
+++ b/.github/workflows/report-viewer-dev.yml
@@ -5,6 +5,9 @@ on:
  push:
     branches:
       - develop
+    paths:
+      - ".github/workflows/report-viewer-dev.yml"
+      - "report-viewer/**"
       
 jobs:
   build-and-deploy:

--- a/.github/workflows/report-viewer-e2e.yml
+++ b/.github/workflows/report-viewer-e2e.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/report-viewer-e2e.yml"
+      - "report-viewer/**"
 
 jobs:
   pre_job:

--- a/.github/workflows/report-viewer-lint.yml
+++ b/.github/workflows/report-viewer-lint.yml
@@ -5,9 +5,13 @@ on:
   workflow_dispatch:
   push:
     path:
-      - report-viewer/**
+      - ".github/workflows/report-viewer-lint.yml"
+      - "report-viewer/**"
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/report-viewer-lint.yml"
+      - "report-viewer/**"
       
 jobs:
   pre_job:

--- a/.github/workflows/report-viewer-prettier.yml
+++ b/.github/workflows/report-viewer-prettier.yml
@@ -3,10 +3,15 @@ name: Report Viewer Prettier Check Workflow # Checks the report viewer against t
 on:
   workflow_dispatch:
   push:
-    path:
-      - report-viewer/**
+    paths:
+      - ".github/workflows/report-viewer-prettier.yml"
+      - "report-viewer/**"
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/report-viewer-prettier.yml"
+      - "report-viewer/**"
+
       
 jobs:
   pre_job:

--- a/.github/workflows/report-viewer-sonarcloud.yml
+++ b/.github/workflows/report-viewer-sonarcloud.yml
@@ -21,6 +21,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/report-viewer-unit.yml
+++ b/.github/workflows/report-viewer-unit.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/report-viewer-unit.yml"
+      - "report-viewer/**"
 
 jobs:
   pre_job:

--- a/.github/workflows/sonarcloud-branch.yml
+++ b/.github/workflows/sonarcloud-branch.yml
@@ -5,6 +5,16 @@ on:
     branches:
       - main
       - develop
+    paths:
+      - ".github/workflows/sonarcloud-branch.yml"
+      - "cli/**"
+      - "core/**"
+      - "endtoend-testing/**"
+      - "language-antlr-utils/**"
+      - "language-api/**"
+      - "language-testutils/**"
+      - "languages/**"
+      - "pom.xml"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -1,7 +1,19 @@
 name: Spotless Style Check
 
 on:
-  push: 
+  push:
+    paths:
+      - ".github/workflows/spotless.yml"
+      - "cli/**"
+      - "core/**"
+      - "endtoend-testing/**"
+      - "language-antlr-utils/**"
+      - "language-api/**"
+      - "language-testutils/**"
+      - "languages/**"
+      - "pom.xml"
+      - "formatter.xml"
+      - "spotless.importorder"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -4,6 +4,18 @@ on:
   push: 
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/spotless.yml"
+      - "cli/**"
+      - "core/**"
+      - "endtoend-testing/**"
+      - "language-antlr-utils/**"
+      - "language-api/**"
+      - "language-testutils/**"
+      - "languages/**"
+      - "pom.xml"
+      - "formatter.xml"
+      - "spotless.importorder"
   
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This PR changes all actions, that previosly did not, to only run when the underlying code changed.
I renamed the `report-viwer-test` action to `report-viewer-build-test` because since we also have actions for unit and e2e test and in my opinion the naming can be confusing. I also renamed the sonarcloud action for the report viewer to fit the naming sceme of the other report viewer actions.

In addition the report viewer sonarcloud scans do not get activated on dependabot PRs.

Fixes #1147 