### PR TITLE
Allow passing multiple options in the "Advanced" group

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -53,7 +53,7 @@ public class CliOptions implements Runnable {
             "--result-directory"}, description = "Name of the directory in which the comparison results will be stored (default: result)%n")
     public String resultFolder = "results";
 
-    @ArgGroup(heading = "Advanced%n")
+    @ArgGroup(heading = "Advanced%n", exclusive = false)
     public Advanced advanced = new Advanced();
 
     @ArgGroup(validate = false, heading = "Clustering%n")

--- a/cli/src/test/java/de/jplag/cli/AdvancedGroupTest.java
+++ b/cli/src/test/java/de/jplag/cli/AdvancedGroupTest.java
@@ -1,0 +1,23 @@
+package de.jplag.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class AdvancedGroupTest extends CommandLineInterfaceTest {
+    private static final String SUFFIXES = ".sc,.scala";
+
+    private static final double SIMILARITY_THRESHOLD = 0.5;
+
+    /**
+     * Verify that it is possible to set multiple options in the "advanced" options group.
+     */
+    @Test
+    void testNotExclusive() throws CliException {
+        buildOptionsFromCLI(defaultArguments().suffixes(SUFFIXES).similarityThreshold(SIMILARITY_THRESHOLD));
+        assertEquals(Arrays.stream(SUFFIXES.split(",")).toList(), options.fileSuffixes());
+        assertEquals(0.5, options.similarityThreshold());
+    }
+}


### PR DESCRIPTION
By default, `picocli` sets `exclusive = true` on `ArgGroup`s, which means that it is not allowed to pass multiple options within the group [1].

[1] https://picocli.info/#_mutually_exclusive_options

<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
