### PR TITLE
Move to nodejs 18

### DIFF
--- a/.github/workflows/report-viewer-build-test.yml
+++ b/.github/workflows/report-viewer-build-test.yml
@@ -30,7 +30,7 @@ jobs:
       
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Set version of Report Viewer
         shell: bash

--- a/.github/workflows/report-viewer-dev.yml
+++ b/.github/workflows/report-viewer-dev.yml
@@ -18,7 +18,7 @@ jobs:
       
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Set version of Report Viewer
         shell: bash

--- a/.github/workflows/report-viewer-e2e.yml
+++ b/.github/workflows/report-viewer-e2e.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install and Test 🧪
         working-directory: report-viewer

--- a/.github/workflows/report-viewer-lint.yml
+++ b/.github/workflows/report-viewer-lint.yml
@@ -4,7 +4,7 @@ name: Report Viewer ESLint Workflow # Checks linting of report viewer
 on:
   workflow_dispatch:
   push:
-    path:
+    paths:
       - ".github/workflows/report-viewer-lint.yml"
       - "report-viewer/**"
   pull_request:
@@ -35,7 +35,7 @@ jobs:
       
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install and Lint 🎨
         working-directory: report-viewer

--- a/.github/workflows/report-viewer-prettier.yml
+++ b/.github/workflows/report-viewer-prettier.yml
@@ -35,7 +35,7 @@ jobs:
       
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install and Check 🎨
         working-directory: report-viewer

--- a/.github/workflows/report-viewer-unit.yml
+++ b/.github/workflows/report-viewer-unit.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Install and Test 🧪
         working-directory: report-viewer

--- a/.github/workflows/report-viewer.yml
+++ b/.github/workflows/report-viewer.yml
@@ -15,7 +15,7 @@ jobs:
       
       - uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: Set version of Report Viewer
         shell: bash

--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -28,7 +28,7 @@
         "@playwright/test": "^1.37.1",
         "@rushstack/eslint-patch": "^1.3.3",
         "@types/jsdom": "^21.1.2",
-        "@types/node": "^20.6.0",
+        "@types/node": "^18.11.9",
         "@vitejs/plugin-vue": "^4.3.4",
         "@vue/eslint-config-prettier": "^8.0.0",
         "@vue/eslint-config-typescript": "^11.0.3",
@@ -788,9 +788,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
-      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
+      "version": "18.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.17.tgz",
+      "integrity": "sha512-cOxcXsQ2sxiwkykdJqvyFS+MLQPLvIdwh5l6gNg8qF6s+C7XSkEWOZjK+XhUZd+mYvHV/180g2cnCcIl4l06Pw==",
       "dev": true
     },
     "node_modules/@types/semver": {

--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -37,7 +37,7 @@
     "@playwright/test": "^1.37.1",
     "@rushstack/eslint-patch": "^1.3.3",
     "@types/jsdom": "^21.1.2",
-    "@types/node": "^20.6.0",
+    "@types/node": "^18.11.9",
     "@vitejs/plugin-vue": "^4.3.4",
     "@vue/eslint-config-prettier": "^8.0.0",
     "@vue/eslint-config-typescript": "^11.0.3",


### PR DESCRIPTION
Node js 16 is no longer activly maintained. This PR moves the report viewer to the latest LTS Version 18