### PR TITLE
new color generation for matches

### DIFF
--- a/report-viewer/src/components/CodePanel.vue
+++ b/report-viewer/src/components/CodePanel.vue
@@ -28,7 +28,10 @@
             <td
               class="w-full"
               :style="{
-                background: line.match !== null ? line.match.color : 'hsla(0, 0%, 0%, 0)'
+                background:
+                  line.match !== null
+                    ? getMatchColor(line.match.colorIndex as number, 0.3)
+                    : 'hsla(0, 0%, 0%, 0)'
               }"
             >
               <pre v-html="line.line" class="code-font !bg-transparent" ref="lineRefs"></pre>
@@ -52,6 +55,7 @@ import type { Match } from '@/model/Match'
 import type { SubmissionFile } from '@/stores/state'
 import { highlight } from '@/utils/CodeHighlighter'
 import type { HighlightLanguage } from '@/model/Language'
+import { getMatchColor } from '@/utils/ColorUtils'
 
 const props = defineProps({
   /**

--- a/report-viewer/src/components/MatchList.vue
+++ b/report-viewer/src/components/MatchList.vue
@@ -9,7 +9,7 @@
     <div class="flex w-full flex-row space-x-1 overflow-x-auto">
       <Interactable
         class="my-2 flex h-6 items-center whitespace-nowrap !rounded-2xl !bg-opacity-50 text-center"
-        :style="{ background: match.color }"
+        :style="{ background: getMatchColor(match.colorIndex as number, 0.3) }"
         v-for="[index, match] in matches?.entries()"
         v-bind:key="index"
         @click="$emit('matchSelected', match)"
@@ -23,6 +23,7 @@
 <script setup lang="ts">
 import type { Match } from '@/model/Match'
 import Interactable from './InteractableComponent.vue'
+import { getMatchColor } from '@/utils/ColorUtils'
 
 defineProps({
   /**

--- a/report-viewer/src/model/Match.ts
+++ b/report-viewer/src/model/Match.ts
@@ -7,9 +7,9 @@
  * @property startInSecond - Starting line of the match in the second file.
  * @property endInSecond - Ending line of the match in the second file.
  * @property tokens - Number of tokens in the match.
- * @property color - Color of the match.
+ * @property colorIndex - Index of the color to use for the match.
  */
-export type Match = {
+export interface Match {
   firstFile: string
   secondFile: string
   startInFirst: number
@@ -17,5 +17,5 @@ export type Match = {
   startInSecond: number
   endInSecond: number
   tokens: number
-  color: string
+  colorIndex?: number
 }

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -119,7 +119,7 @@ export class ComparisonFactory extends BaseFactory {
     const matchesSecond = Array.from(matches)
       .sort((a, b) => a.startInSecond - b.startInSecond)
       .sort((a, b) => (a.secondFile > b.secondFile ? 1 : -1))
-    const sortedSize = Array.from(matches).sort((a, b) => a.tokens - b.tokens)
+    const sortedSize = Array.from(matches).sort((a, b) => b.tokens - a.tokens)
 
     function canColor(matchList: Match[], index: number) {
       return (

--- a/report-viewer/src/utils/ColorUtils.ts
+++ b/report-viewer/src/utils/ColorUtils.ts
@@ -59,6 +59,16 @@ function generateColorsForInterval(
   return colors
 }
 
+const matchColors: { red: number; green: number; blue: number }[] = []
+
+function getMatchColorCount() {
+  return matchColors.length
+}
+
+function getMatchColor(index: number, alpha: number) {
+  return `rgba(${matchColors[index].red}, ${matchColors[index].green}, ${matchColors[index].blue}, ${alpha})`
+}
+
 const graphColors = {
   ticksAndFont: computed(() => {
     return store().uiState.useDarkMode ? '#ffffff' : '#000000'
@@ -71,4 +81,4 @@ const graphColors = {
   pointFill: 'rgba(190, 22, 34, 1)'
 }
 
-export { generateColors, graphColors }
+export { generateColors, graphColors, getMatchColorCount, getMatchColor }

--- a/report-viewer/src/utils/ColorUtils.ts
+++ b/report-viewer/src/utils/ColorUtils.ts
@@ -59,7 +59,15 @@ function generateColorsForInterval(
   return colors
 }
 
-const matchColors: { red: number; green: number; blue: number }[] = []
+const matchColors: { red: number; green: number; blue: number }[] = [
+  { red: 0, green: 9, blue: 255 },
+  { red: 254, green: 255, blue: 0 },
+  { red: 0, green: 255, blue: 254 },
+  { red: 255, green: 0, blue: 243 },
+  { red: 0, green: 180, blue: 180 },
+  { red: 255, green: 118, blue: 0 },
+  { red: 0, green: 255, blue: 160 }
+]
 
 function getMatchColorCount() {
   return matchColors.length


### PR DESCRIPTION
This PR changes the color generation for matches.
Instead of distributing the colors across the hue spectrum, now there is a set of 7 (handpicked) colors from which each match is colored.
The algortihm for choosing colors: First all matches get sorted 3 times. (By line number in first and second submission and by number of tokens).  It then runs through the list of matches and chooses the first color it can find that is not neigboring this match in any of the three lists. To avoid having only the first few colors or even only two alternating colors, we dont start with the first color when having found a fitting color but go on with the next in the list and go through the list cyclical.