### PR TITLE
New Cluster Visuaization

### DIFF
--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@fortawesome/vue-fontawesome": "^3.0.3",
         "chart.js": "^4.4.0",
+        "chartjs-chart-graph": "^4.2.5",
         "chartjs-plugin-datalabels": "^2.2.0",
         "highlight.js": "^11.8.0",
         "jszip": "^3.10.0",
@@ -765,6 +766,16 @@
       "dependencies": {
         "@types/chai": "*"
       }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.6.tgz",
+      "integrity": "sha512-G9wbOvCxkNlLrppoHLZ6oFpbm3z7ibfkXwLD8g5/4Aa7iTEV0Z7TQ0OL8UxAtvdOhCa2VZcSuqn1NQqyCEqmiw=="
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.4.tgz",
+      "integrity": "sha512-wrvjpRFdmEu6yAqgjGy8MSud9ggxJj+I9XLuztLeSf/E0j0j6RQYtxH2J8U0Cfbgiw9ZDHyhpmaVuWhxscYaAQ=="
     },
     "node_modules/@types/jsdom": {
       "version": "21.1.3",
@@ -1806,6 +1817,23 @@
         "pnpm": ">=7"
       }
     },
+    "node_modules/chartjs-chart-graph": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/chartjs-chart-graph/-/chartjs-chart-graph-4.2.5.tgz",
+      "integrity": "sha512-peZFFOYBLMn8cCvtT9xNapwOA8enfPQ3DO7bTBSNCTw0GjurnwxW3BF6H3lGjn+9VURVaVN/NHF2nSvUaCsxnw==",
+      "dependencies": {
+        "@types/d3-force": "^3.0.5",
+        "@types/d3-hierarchy": "^3.1.3",
+        "d3-dispatch": "^3.0.1",
+        "d3-force": "^3.0.0",
+        "d3-hierarchy": "^3.1.2",
+        "d3-quadtree": "^3.0.1",
+        "d3-timer": "^3.0.1"
+      },
+      "peerDependencies": {
+        "chart.js": "^4.1.0"
+      }
+    },
     "node_modules/chartjs-plugin-datalabels": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.2.0.tgz",
@@ -2001,6 +2029,51 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-urls": {
       "version": "4.0.0",

--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -22,6 +22,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@fortawesome/vue-fontawesome": "^3.0.3",
     "chart.js": "^4.4.0",
+    "chartjs-chart-graph": "^4.2.5",
     "chartjs-plugin-datalabels": "^2.2.0",
     "highlight.js": "^11.8.0",
     "jszip": "^3.10.0",

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -13,6 +13,7 @@ import ChartDataLabels from 'chartjs-plugin-datalabels'
 import { EdgeLine, GraphController, GraphChart } from 'chartjs-chart-graph'
 import { store } from '@/stores/store'
 import { graphColors } from '@/utils/ColorUtils'
+import { start } from 'repl'
 
 const props = defineProps({
   cluster: {
@@ -85,8 +86,27 @@ const graphData = computed(() => {
   }
 })
 
+const yPadding = 40
+const xPadding = computed(() => {
+  const avgCharacterLength = 8
+
+  const widths = labels.value.map((label) => label.length * avgCharacterLength)
+  const maxWidth = Math.max(...widths)
+  // Space needed for the longest name, but at most 200
+  console.log(maxWidth)
+  return Math.min(200, maxWidth)
+})
+
 const graphOptions = computed(() => {
   return {
+    layout: {
+      padding: {
+        top: yPadding,
+        bottom: yPadding,
+        left: xPadding.value,
+        right: xPadding.value
+      }
+    },
     animation: false as false,
     plugins: {
       legend: { display: false },
@@ -94,12 +114,13 @@ const graphOptions = computed(() => {
         display: true,
         font: {
           weight: 'bold' as 'bold',
-          size: 16
+          size: 12
         },
         formatter: (value: any, ctx: any) => {
           return labels.value[ctx.dataIndex]
         },
-        offset: 12,
+        align: (ctx: any) => (-360 * ctx.dataIndex) / keys.value.length,
+        offset: 8,
         color: graphColors.ticksAndFont.value
       },
       tooltip: {
@@ -124,7 +145,6 @@ function drawGraph() {
     loaded.value = false
     return
   }
-  console.log(graphCanvas.value)
   chart.value = new Chart(ctx, {
     type: 'graph',
     data: graphData.value,

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -1,0 +1,172 @@
+<template>
+  <div>
+    <canvas ref="graphCanvas"></canvas>
+    <div v-show="!loaded">Could not display graph</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { ClusterListElement } from '@/model/ClusterListElement'
+import { Chart, registerables } from 'chart.js'
+import { ref, type PropType, type Ref, onMounted, computed, watch } from 'vue'
+import ChartDataLabels from 'chartjs-plugin-datalabels'
+import { EdgeLine, GraphController, GraphChart } from 'chartjs-chart-graph'
+import { store } from '@/stores/store'
+import { graphColors } from '@/utils/ColorUtils'
+
+const props = defineProps({
+  cluster: {
+    type: Object as PropType<ClusterListElement>,
+    required: true
+  }
+})
+
+const graphCanvas: Ref<HTMLCanvasElement | null> = ref(null)
+const loaded = ref(false)
+
+Chart.register(...registerables)
+Chart.register(ChartDataLabels)
+Chart.register(EdgeLine)
+Chart.register(GraphController)
+Chart.register(GraphChart)
+
+const keys = computed(() => Array.from(props.cluster.members.keys()))
+const labels = computed(() =>
+  Array.from(keys.value).map((m) => store().submissionDisplayName(m) ?? m)
+)
+console.log(labels.value)
+const edges = computed(() => {
+  const edges: { source: number; target: number }[] = []
+  props.cluster.members.forEach((member, key) => {
+    member.forEach((match) => {
+      const firstIndex = keys.value.indexOf(key)
+      const secondIndex = keys.value.indexOf(match.matchedWith)
+      if (firstIndex == -1 || secondIndex == -1) {
+        console.log(`Could not find index for ${key} or ${match.matchedWith}`)
+      }
+      if (firstIndex < secondIndex) {
+        edges.push({ source: firstIndex, target: secondIndex })
+      }
+    })
+  })
+  return edges
+})
+
+const data = computed(() => {
+  return {
+    labels: labels.value,
+    datasets: [
+      {
+        pointRadius: 10,
+        pointHoverRadius: 10,
+        pointBackgroundColor: graphColors.contentFill,
+        pointHoverBackgroundColor: graphColors.contentFill,
+        pointBorderColor: graphColors.ticksAndFont.value,
+        pointHoverBorderColor: graphColors.ticksAndFont.value,
+        data: Array.from(keys.value).map((_, index) => ({ x: getX(index), y: getY(index) })),
+        edges: edges.value,
+        edgeLineBorderColor: (ctx: any) =>
+          borderColor(keys.value[ctx.raw.source], keys.value[ctx.raw.target]),
+        edgeLineBorderWidth: (ctx: any) =>
+          borderWidth(keys.value[ctx.raw.source], keys.value[ctx.raw.target])
+      }
+    ]
+  }
+})
+
+const options = computed(() => {
+  return {
+    animation: false as false,
+    plugins: {
+      legend: { display: false },
+      datalabels: {
+        display: true,
+        font: {
+          weight: 'bold' as 'bold',
+          size: 16
+        },
+        formatter: (value: any, ctx: any) => {
+          return labels.value[ctx.dataIndex]
+        },
+        offset: 12,
+        color: graphColors.ticksAndFont.value
+      },
+      tooltip: {
+        enabled: false
+      }
+    }
+  }
+})
+
+function borderColor(firstSubmissionId: string, secondSubmissionId: string) {
+  const firstSubmission = props.cluster.members.get(firstSubmissionId)
+  if (!firstSubmission) {
+    return 'rgba(0,0,0,0)'
+  }
+  const match = firstSubmission.find((m) => m.matchedWith == secondSubmissionId)
+  if (!match) {
+    return 'rgba(0,0,0,0)'
+  }
+  return graphColors.contentFillAlpha(match.similarity)
+}
+
+function borderWidth(firstSubmissionId: string, secondSubmissionId: string) {
+  const firstSubmission = props.cluster.members.get(firstSubmissionId)
+  if (!firstSubmission) {
+    return 'rgba(0,0,0,0)'
+  }
+  const match = firstSubmission.find((m) => m.matchedWith == secondSubmissionId)
+  if (!match) {
+    return 'rgba(0,0,0,0)'
+  }
+  return 4 * match.similarity + 1
+}
+
+function getX(index: number) {
+  return Math.sin((2 * Math.PI * index) / keys.value.length) + 1
+}
+
+function getY(index: number) {
+  return Math.cos((2 * Math.PI * index) / keys.value.length) + 1
+}
+
+const chart: Ref<Chart | null> = ref(null)
+
+function drawGraph() {
+  if (chart.value != null) {
+    chart.value.destroy()
+  }
+  if (graphCanvas.value == null) {
+    loaded.value = false
+    return
+  }
+  const ctx = graphCanvas.value.getContext('2d')
+  if (ctx == null) {
+    loaded.value = false
+    return
+  }
+  console.log(graphCanvas.value)
+  chart.value = new Chart(ctx, {
+    type: 'graph',
+    data: data.value,
+    options: options.value
+  })
+  loaded.value = true
+}
+
+onMounted(() => {
+  drawGraph()
+})
+
+watch(
+  computed(() => {
+    return {
+      d: data.value,
+      o: options.value
+    }
+  }),
+  () => {
+    drawGraph()
+  }
+)
+</script>

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -91,8 +91,9 @@ const xPadding = computed(() => {
 
   const widths = labels.value.map((label) => label.length * avgCharacterLength)
   const maxWidth = Math.max(...widths)
-  // Space needed for the longest name, but at most 200
-  return Math.min(200, maxWidth)
+  console.log(maxWidth)
+  // Makes sure there is always space to display a name but the padding does not get too big
+  return Math.max(Math.min(200, maxWidth), 40)
 })
 
 const graphOptions = computed(() => {

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -13,7 +13,6 @@ import ChartDataLabels from 'chartjs-plugin-datalabels'
 import { EdgeLine, GraphController, GraphChart } from 'chartjs-chart-graph'
 import { store } from '@/stores/store'
 import { graphColors } from '@/utils/ColorUtils'
-import { start } from 'repl'
 
 const props = defineProps({
   cluster: {

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -91,7 +91,6 @@ const xPadding = computed(() => {
 
   const widths = labels.value.map((label) => label.length * avgCharacterLength)
   const maxWidth = Math.max(...widths)
-  console.log(maxWidth)
   // Makes sure there is always space to display a name but the padding does not get too big
   return Math.max(Math.min(200, maxWidth), 40)
 })

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -92,7 +92,6 @@ const xPadding = computed(() => {
   const widths = labels.value.map((label) => label.length * avgCharacterLength)
   const maxWidth = Math.max(...widths)
   // Space needed for the longest name, but at most 200
-  console.log(maxWidth)
   return Math.min(200, maxWidth)
 })
 
@@ -123,7 +122,13 @@ const graphOptions = computed(() => {
         color: graphColors.ticksAndFont.value
       },
       tooltip: {
-        enabled: false
+        enabled: true,
+        displayColors: false,
+        callbacks: {
+          title: () => {
+            return ''
+          }
+        }
       }
     }
   }

--- a/report-viewer/src/utils/ColorUtils.ts
+++ b/report-viewer/src/utils/ColorUtils.ts
@@ -68,7 +68,10 @@ const graphColors = {
   }),
   contentFill: 'rgba(190, 22, 34, 0.5)',
   contentBorder: 'rgb(127, 15, 24)',
-  pointFill: 'rgba(190, 22, 34, 1)'
+  pointFill: 'rgba(190, 22, 34, 1)',
+  contentFillAlpha(alpha: number) {
+    return `rgba(190, 22, 34, ${alpha})`
+  }
 }
 
 export { generateColors, graphColors }

--- a/report-viewer/src/utils/ColorUtils.ts
+++ b/report-viewer/src/utils/ColorUtils.ts
@@ -59,6 +59,11 @@ function generateColorsForInterval(
   return colors
 }
 
+const graphRGB = {
+  red: 190,
+  green: 22,
+  blue: 34
+}
 const graphColors = {
   ticksAndFont: computed(() => {
     return store().uiState.useDarkMode ? '#ffffff' : '#000000'
@@ -66,11 +71,11 @@ const graphColors = {
   gridLines: computed(() => {
     return store().uiState.useDarkMode ? 'rgba(256, 256, 256, 0.2)' : 'rgba(0, 0, 0, 0.2)'
   }),
-  contentFill: 'rgba(190, 22, 34, 0.5)',
+  contentFill: `rgba(${graphRGB.red}, ${graphRGB.green}, ${graphRGB.blue}, 0.5)`,
   contentBorder: 'rgb(127, 15, 24)',
-  pointFill: 'rgba(190, 22, 34, 1)',
+  pointFill: `rgba(${graphRGB.red}, ${graphRGB.green}, ${graphRGB.blue}, 1)`,
   contentFillAlpha(alpha: number) {
-    return `rgba(190, 22, 34, ${alpha})`
+    return `rgba(${graphRGB.red}, ${graphRGB.green}, ${graphRGB.blue}, ${alpha})`
   }
 }
 

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -51,7 +51,7 @@ import type { ComparisonListElement } from '@/model/ComparisonListElement'
 import { MetricType } from '@/model/MetricType'
 import { OverviewFactory } from '@/model/factories/OverviewFactory'
 import OptionsSelectorComponent from '@/components/optionsSelectors/OptionsSelectorComponent.vue'
-import { ref } from 'vue'
+import { ref, type Ref } from 'vue'
 
 const props = defineProps({
   clusterIndex: {

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -14,7 +14,7 @@
     <div class="relative bottom-0 left-0 right-0 flex flex-grow justify-between space-x-5 p-5 pt-5">
       <Container class="flex max-h-0 min-h-full flex-1 flex-col overflow-hidden">
         <OptionsSelectorComponent
-          :labels="['Graph', 'Radar']"
+          :labels="clusterVisualizationOptions"
           @selectionChanged="
             (index) => (selectedClusterVisualization = index == 0 ? 'Graph' : 'Radar')
           "
@@ -68,6 +68,17 @@ const props = defineProps({
 const comparisons = [] as Array<ComparisonListElement>
 const clusterMemberList = new Map() as ClusterListElementMember
 const selectedClusterVisualization: Ref<'Graph' | 'Radar'> = ref('Graph')
+const clusterVisualizationOptions = [
+  {
+    displayValue: 'Graph',
+    tooltip: 'A graph having the average similarity between two submissions as the edges.'
+  },
+  {
+    displayValue: 'Radar',
+    tooltip:
+      'A radar chart showing the he other submissions in the cluster, relative one submission.'
+  }
+]
 const usedMetric = MetricType.AVERAGE
 
 function getComparisonFor(id1: string, id2: string) {

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -13,7 +13,8 @@
 
     <div class="relative bottom-0 left-0 right-0 flex flex-grow justify-between space-x-5 p-5 pt-5">
       <Container class="flex max-h-0 min-h-full flex-1 flex-col overflow-hidden">
-        <ClusterRadarChart :cluster="clusterListElement" class="flex-grow" />
+        <!--ClusterRadarChart :cluster="clusterListElement" class="flex-grow" /-->
+        <ClusterGraph :cluster="clusterListElement" class="flex-grow" />
       </Container>
       <Container class="flex max-h-0 min-h-full w-1/3 flex-col space-y-2">
         <h2>Comparisons of Cluster Members:</h2>
@@ -25,6 +26,7 @@
 
 <script setup lang="ts">
 import ClusterRadarChart from '@/components/ClusterRadarChart.vue'
+import ClusterGraph from '@/components/ClusterGraph.vue'
 import ComparisonsTable from '@/components/ComparisonsTable.vue'
 import Container from '@/components/ContainerComponent.vue'
 import TextInformation from '@/components/TextInformation.vue'

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -13,8 +13,24 @@
 
     <div class="relative bottom-0 left-0 right-0 flex flex-grow justify-between space-x-5 p-5 pt-5">
       <Container class="flex max-h-0 min-h-full flex-1 flex-col overflow-hidden">
-        <!--ClusterRadarChart :cluster="clusterListElement" class="flex-grow" /-->
-        <ClusterGraph :cluster="clusterListElement" class="flex-grow" />
+        <OptionsSelectorComponent
+          :labels="['Graph', 'Radar']"
+          @selectionChanged="
+            (index) => (selectedClusterVisualization = index == 0 ? 'Graph' : 'Radar')
+          "
+          title="Cluster Visualization:"
+          class="mb-3"
+        />
+        <ClusterRadarChart
+          v-if="selectedClusterVisualization == 'Radar'"
+          :cluster="clusterListElement"
+          class="flex-grow"
+        />
+        <ClusterGraph
+          v-if="selectedClusterVisualization == 'Graph'"
+          :cluster="clusterListElement"
+          class="flex-grow"
+        />
       </Container>
       <Container class="flex max-h-0 min-h-full w-1/3 flex-col space-y-2">
         <h2>Comparisons of Cluster Members:</h2>
@@ -34,6 +50,8 @@ import type { ClusterListElement, ClusterListElementMember } from '@/model/Clust
 import type { ComparisonListElement } from '@/model/ComparisonListElement'
 import { MetricType } from '@/model/MetricType'
 import { OverviewFactory } from '@/model/factories/OverviewFactory'
+import OptionsSelectorComponent from '@/components/optionsSelectors/OptionsSelectorComponent.vue'
+import { ref } from 'vue'
 
 const props = defineProps({
   clusterIndex: {
@@ -46,6 +64,7 @@ const overview = await OverviewFactory.getOverview()
 const cluster = overview.clusters[props.clusterIndex]
 const comparisons = [] as Array<ComparisonListElement>
 const clusterMemberList = new Map() as ClusterListElementMember
+const selectedClusterVisualization: Ref<'Graph' | 'Radar'> = ref('Graph')
 const usedMetric = MetricType.AVERAGE
 
 function getComparisonFor(id1: string, id2: string) {


### PR DESCRIPTION
This PR adds a new way to default way to visualize clusters. The default is a graph having the submissions in the cluster as nodes and the average similarity as edges. Edges can only exists between the comparisons in the top list.

The old radar chart visualization is still accassible through a selector at the top of the container.

![Unbenannt](https://github.com/jplag/JPlag/assets/39801116/32318dbe-0ad1-4fda-9071-fc2a3bead237)



