### PR TITLE
Made the GreedyStringTiling class deterministic in case both submissi…

### DIFF
--- a/core/src/main/java/de/jplag/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/GreedyStringTiling.java
@@ -78,8 +78,10 @@ public class GreedyStringTiling {
     public final JPlagComparison compare(Submission firstSubmission, Submission secondSubmission) {
         Submission smallerSubmission;
         Submission largerSubmission;
-        Comparator<Submission> comp = Comparator.comparing((Submission s) -> s.getTokenList().size()).thenComparing(Submission::getName);
-        if (comp.compare(firstSubmission, secondSubmission) <= 0) {
+        Comparator<Submission> submissionComparator = Comparator.comparing((Submission it) -> it.getTokenList().size())
+                .thenComparing(Submission::getName);
+
+        if (submissionComparator.compare(firstSubmission, secondSubmission) <= 0) {
             smallerSubmission = firstSubmission;
             largerSubmission = secondSubmission;
         } else {


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

The greedy string tiling class used to result in an arbitrary comparison direction if both submissions had the same amount of tokens. This did result in noticeable discrepancies in the similarity (see https://github.com/jplag/JPlag/pull/1279). This PR fixes that by using the submission name as a tie breaker.

Also made some small changes removing warnings.