### PR TITLE
Java 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'temurin'
             
     - name: Run Tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Build JPlag
         run: mvn -U -B clean package assembly:single

--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'temurin'
       
     - name: Check with Spotless

--- a/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import de.jplag.exceptions.ExitException;
+import de.jplag.java.JavaLanguage;
 
 public class NewJavaFeaturesTest extends TestBase {
 
     private static final int EXPECTED_MATCHES = 8; // might change if you add files to the submissions
     private static final int NUMBER_OF_TEST_FILES = 8;
     private static final double EXPECTED_SIMILARITY = 0.971; // might change if you add files to the submissions
-    private static final String EXPECTED_JAVA_VERSION = "21"; // might change with newer JPlag versions
 
     private static final String EXCLUSION_FILE_NAME = "blacklist.txt";
     private static final String ROOT_DIRECTORY = "NewJavaFeatures";
@@ -29,8 +29,8 @@ public class NewJavaFeaturesTest extends TestBase {
         // pre-condition
         String actualJavaVersion = System.getProperty(JAVA_VERSION_KEY);
         boolean isCiRun = System.getenv(CI_VARIABLE) != null;
-        boolean isCorrectJavaVersion = actualJavaVersion.startsWith(EXPECTED_JAVA_VERSION);
-        assumeTrue(isCorrectJavaVersion || isCiRun, VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, EXPECTED_JAVA_VERSION));
+        boolean isCorrectJavaVersion = actualJavaVersion.startsWith(String.valueOf(JavaLanguage.JAVA_VERSION));
+        assumeTrue(isCorrectJavaVersion || isCiRun, VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, JavaLanguage.JAVA_VERSION));
 
         JPlagResult result = runJPlagWithExclusionFile(ROOT_DIRECTORY, EXCLUSION_FILE_NAME);
 

--- a/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -10,8 +10,9 @@ import de.jplag.exceptions.ExitException;
 
 public class NewJavaFeaturesTest extends TestBase {
 
-    private static final int EXPECTED_MATCHES = 6; // might change if you add files to the submissions
-    private static final double EXPECTED_SIMILARITY = 0.953; // might change if you add files to the submissions
+    private static final int EXPECTED_MATCHES = 8; // might change if you add files to the submissions
+    private static final int NUMBER_OF_TEST_FILES = 8;
+    private static final double EXPECTED_SIMILARITY = 0.971; // might change if you add files to the submissions
     private static final String EXPECTED_JAVA_VERSION = "21"; // might change with newer JPlag versions
 
     private static final String EXCLUSION_FILE_NAME = "blacklist.txt";
@@ -36,7 +37,7 @@ public class NewJavaFeaturesTest extends TestBase {
         // Ensure test input did not change:
         assertEquals(2, result.getNumberOfSubmissions(), String.format(CHANGE_MESSAGE, "Submissions"));
         for (Submission submission : result.getSubmissions().getSubmissions()) {
-            assertEquals(6, submission.getFiles().size(), String.format(CHANGE_MESSAGE, "Files"));
+            assertEquals(NUMBER_OF_TEST_FILES, submission.getFiles().size(), String.format(CHANGE_MESSAGE, "Files"));
         }
         assertEquals(1, result.getAllComparisons().size(), String.format(CHANGE_MESSAGE, "Comparisons"));
 

--- a/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -11,8 +11,8 @@ import de.jplag.exceptions.ExitException;
 public class NewJavaFeaturesTest extends TestBase {
 
     private static final int EXPECTED_MATCHES = 6; // might change if you add files to the submissions
-    private static final double EXPECTED_SIMILARITY = 0.96; // might change if you add files to the submissions
-    private static final String EXPECTED_JAVA_VERSION = "17"; // might change with newer JPlag versions
+    private static final double EXPECTED_SIMILARITY = 0.953; // might change if you add files to the submissions
+    private static final String EXPECTED_JAVA_VERSION = "21"; // might change with newer JPlag versions
 
     private static final String EXCLUSION_FILE_NAME = "blacklist.txt";
     private static final String ROOT_DIRECTORY = "NewJavaFeatures";

--- a/core/src/test/resources/de/jplag/samples/NewJavaFeatures/A/Java21.java
+++ b/core/src/test/resources/de/jplag/samples/NewJavaFeatures/A/Java21.java
@@ -1,0 +1,31 @@
+public class Java21 {
+    private static final record Circle(int radius) {
+    }
+
+    private static final record Rect(int width, int height) {
+    }
+
+    private static final record Both(Circle circle, Rect rect) {
+    }
+
+    private static final record Square(int length) {
+    }
+
+    public void main() {
+        Shape s = new Circle();
+        switch (s) {
+            case Cricle(int r) -> System.out.println(r);
+            case Shape s -> System.out.println(c);
+            case Both(Circle c, Rect(int w, int _)) -> System.out.println("something");
+            case Square -> {
+                int l = ((Square) s).length;
+                System.out.println(STR."Square with length \{Math.abs(l)}");
+            }
+        }
+
+
+        if (s instanceof Circle(int r)) {
+
+        }
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/NewJavaFeatures/B/Java21.java
+++ b/core/src/test/resources/de/jplag/samples/NewJavaFeatures/B/Java21.java
@@ -1,0 +1,31 @@
+public class Java21 {
+    private static final record Circle(int radius) {
+    }
+
+    private static final record Rect(int width, int height) {
+    }
+
+    private static final record Both(Circle circle, Rect rect) {
+    }
+
+    private static final record Square(int length) {
+    }
+
+    public void main() {
+        Shape s = new Circle();
+        switch (s) {
+            case Cricle(int r) -> System.out.println(r);
+            case Shape s -> System.out.println(c);
+            case Both(Circle c, Rect(int _, int w)) -> System.out.println("something");
+            case Square -> {
+                int l = ((Square) s).length;
+                System.out.println(STR."Square with length \{Math.abs(l)}");
+            }
+        }
+
+
+        if (s instanceof Circle(int r)) {
+
+        }
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/NewJavaFeatures/blacklist.txt
+++ b/core/src/test/resources/de/jplag/samples/NewJavaFeatures/blacklist.txt
@@ -1,1 +1,0 @@
-Java17Preview.java

--- a/languages/java/src/main/java/de/jplag/java/FixedSourcePositions.java
+++ b/languages/java/src/main/java/de/jplag/java/FixedSourcePositions.java
@@ -1,0 +1,30 @@
+package de.jplag.java;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.SourcePositions;
+
+/**
+ * Fixes the source positions, so that the end position is always at least the same as the start position.
+ */
+public class FixedSourcePositions implements SourcePositions {
+    private final SourcePositions base;
+
+    /**
+     * New instance
+     * @param base The source positions to use as the base
+     */
+    public FixedSourcePositions(SourcePositions base) {
+        this.base = base;
+    }
+
+    @Override
+    public long getStartPosition(CompilationUnitTree compilationUnitTree, Tree tree) {
+        return this.base.getStartPosition(compilationUnitTree, tree);
+    }
+
+    @Override
+    public long getEndPosition(CompilationUnitTree compilationUnitTree, Tree tree) {
+        return Math.max(this.getStartPosition(compilationUnitTree, tree), this.base.getEndPosition(compilationUnitTree, tree));
+    }
+}

--- a/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
+++ b/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
@@ -15,6 +15,7 @@ import de.jplag.Token;
 @MetaInfServices(de.jplag.Language.class)
 public class JavaLanguage implements de.jplag.Language {
     private static final String IDENTIFIER = "java";
+    public static final int JAVA_VERSION = 21;
 
     private final Parser parser;
 

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -42,8 +42,8 @@ public class JavacAdapter {
 
             // We need to disable annotation processing, see
             // https://stackoverflow.com/questions/72737445/system-java-compiler-behaves-different-depending-on-dependencies-defined-in-mave
-            final CompilationTask task = javac.getTask(null, fileManager, listener, List.of("-proc:none", "--enable-preview", "--release=21"), null,
-                    javaFiles);
+            final CompilationTask task = javac.getTask(null, fileManager, listener,
+                    List.of("-proc:none", "--enable-preview", "--release=" + JavaLanguage.JAVA_VERSION), null, javaFiles);
             final Trees trees = Trees.instance(task);
             final SourcePositions positions = trees.getSourcePositions();
             for (final CompilationUnitTree ast : executeCompilationTask(task, parser.logger)) {
@@ -76,8 +76,7 @@ public class JavacAdapter {
     private List<ParsingException> processErrors(Logger logger, DiagnosticCollector<Object> listener) {
         return listener.getDiagnostics().stream().filter(it -> it.getKind() == javax.tools.Diagnostic.Kind.ERROR).map(diagnosticItem -> {
             File file = null;
-            if (diagnosticItem.getSource() instanceof JavaFileObject) {
-                JavaFileObject fileObject = (JavaFileObject) diagnosticItem.getSource();
+            if (diagnosticItem.getSource() instanceof JavaFileObject fileObject) {
                 file = new File(fileObject.toUri());
             }
             logger.error("{}", diagnosticItem);

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -45,7 +45,7 @@ public class JavacAdapter {
             final CompilationTask task = javac.getTask(null, fileManager, listener,
                     List.of("-proc:none", "--enable-preview", "--release=" + JavaLanguage.JAVA_VERSION), null, javaFiles);
             final Trees trees = Trees.instance(task);
-            final SourcePositions positions = trees.getSourcePositions();
+            final SourcePositions positions = new FixedSourcePositions(trees.getSourcePositions());
             for (final CompilationUnitTree ast : executeCompilationTask(task, parser.logger)) {
                 File file = new File(ast.getSourceFile().toUri());
                 final LineMap map = ast.getLineMap();

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -42,7 +42,8 @@ public class JavacAdapter {
 
             // We need to disable annotation processing, see
             // https://stackoverflow.com/questions/72737445/system-java-compiler-behaves-different-depending-on-dependencies-defined-in-mave
-            final CompilationTask task = javac.getTask(null, fileManager, listener, List.of("-proc:none"), null, javaFiles);
+            final CompilationTask task = javac.getTask(null, fileManager, listener, List.of("-proc:none", "--enable-preview", "--release=21"), null,
+                    javaFiles);
             final Trees trees = Trees.instance(task);
             final SourcePositions positions = trees.getSourcePositions();
             for (final CompilationUnitTree ast : executeCompilationTask(task, parser.logger)) {

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -282,7 +282,23 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     public Void visitCase(CaseTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
         addToken(JavaTokenType.J_CASE, start, 4, CodeSemantics.createControl());
-        return super.visitCase(node, null);
+
+        this.scan(node.getLabels(), null);
+        if (node.getGuard() != null) {
+            addToken(JavaTokenType.J_IF_BEGIN, positions.getStartPosition(ast, node.getGuard()), 0, CodeSemantics.createControl());
+        }
+        this.scan(node.getGuard(), null);
+        if (node.getCaseKind() == CaseTree.CaseKind.RULE) {
+            this.scan(node.getBody(), null);
+        } else {
+            this.scan(node.getStatements(), null);
+        }
+
+        if (node.getGuard() != null) {
+            addToken(JavaTokenType.J_IF_BEGIN, positions.getEndPosition(ast, node), 0, CodeSemantics.createControl());
+        }
+
+        return null;
     }
 
     @Override

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -60,6 +60,8 @@ import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreeScanner;
 
 final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
+    private final static String ANONYMOUS_VARIABLE_NAME = "";
+
     private final File file;
     private final Parser parser;
     private final LineMap map;
@@ -460,7 +462,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
 
     @Override
     public Void visitVariable(VariableTree node, Void unused) {
-        if (!node.getName().contentEquals("")) {
+        if (!node.getName().contentEquals(ANONYMOUS_VARIABLE_NAME)) {
             long start = positions.getStartPosition(ast, node);
             String name = node.getName().toString();
             boolean inLocalScope = variableRegistry.inLocalScope();

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -295,7 +295,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         }
 
         if (node.getGuard() != null) {
-            addToken(JavaTokenType.J_IF_BEGIN, positions.getEndPosition(ast, node), 0, CodeSemantics.createControl());
+            addToken(JavaTokenType.J_IF_END, positions.getEndPosition(ast, node), 0, CodeSemantics.createControl());
         }
 
         return null;

--- a/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
@@ -37,6 +37,15 @@ public class JavaLanguageTest extends LanguageModuleTest {
         collector.testFile("CLI.java").testSourceCoverage().testContainedTokens(J_TRY_END, J_IMPORT, J_VARDEF, J_LOOP_BEGIN, J_ARRAY_INIT_BEGIN,
                 J_IF_BEGIN, J_CATCH_END, J_COND, J_ARRAY_INIT_END, J_METHOD_BEGIN, J_TRY_BEGIN, J_CLASS_END, J_RETURN, J_ASSIGN, J_METHOD_END,
                 J_IF_END, J_CLASS_BEGIN, J_NEWARRAY, J_PACKAGE, J_APPLY, J_LOOP_END, J_THROW, J_NEWCLASS, J_CATCH_BEGIN);
+
+        collector.testFile("PatternMatching.java", "PatternMatchingManual.java").testSourceCoverage().testTokenSequence(J_CLASS_BEGIN, J_RECORD_BEGIN,
+                J_VARDEF, J_RECORD_END, J_METHOD_BEGIN, J_VARDEF, J_NEWCLASS, J_IF_BEGIN, J_VARDEF, J_IF_END, J_METHOD_END, J_CLASS_END);
+
+        collector.testFile("StringConcat.java", "StringTemplate.java").testSourceCoverage().testTokenSequence(J_CLASS_BEGIN, J_METHOD_BEGIN, J_VARDEF,
+                J_VARDEF, J_VARDEF, J_APPLY, J_METHOD_END, J_CLASS_END);
+
+        collector.testFile("AnonymousVariables.java").testTokenSequence(J_CLASS_BEGIN, J_METHOD_BEGIN, J_VARDEF, J_IF_BEGIN, J_IF_END, J_METHOD_END,
+                J_CLASS_END);
     }
 
     @Override

--- a/languages/java/src/test/resources/de/jplag/java/AnonymousVariables.java
+++ b/languages/java/src/test/resources/de/jplag/java/AnonymousVariables.java
@@ -1,0 +1,8 @@
+public class AnonymousVariables {
+    public void test(Object o) {
+        String _ = "";
+
+        if (o instanceof String _) {
+        }
+    }
+}

--- a/languages/java/src/test/resources/de/jplag/java/PatternMatching.java
+++ b/languages/java/src/test/resources/de/jplag/java/PatternMatching.java
@@ -1,0 +1,10 @@
+public class PatternMatchingManual {
+    private static final record Test(int x) {
+    }
+
+    public void test() {
+        Object a = new Test(1);
+        if (a instanceof Test testA) {
+        }
+    }
+}

--- a/languages/java/src/test/resources/de/jplag/java/PatternMatchingManual.java
+++ b/languages/java/src/test/resources/de/jplag/java/PatternMatchingManual.java
@@ -1,0 +1,11 @@
+public class PatternMatchingManual {
+    private static final record Test(int x) {
+    }
+
+    public void test() {
+        Object a = new Test(1);
+        if (a instanceof Test) {
+            Test testA = (Test) a;
+        }
+    }
+}

--- a/languages/java/src/test/resources/de/jplag/java/StringConcat.java
+++ b/languages/java/src/test/resources/de/jplag/java/StringConcat.java
@@ -1,0 +1,8 @@
+public class StringConcat {
+    void test() {
+        int param1 = 1;
+        String param2 = "test";
+
+        String result = "prefix " + param1 + " infix " + param2.length() + "suffix";
+    }
+}

--- a/languages/java/src/test/resources/de/jplag/java/StringTemplate.java
+++ b/languages/java/src/test/resources/de/jplag/java/StringTemplate.java
@@ -1,0 +1,8 @@
+public class StringTemplate {
+    void test() {
+        int param1 = 1;
+        String param2 = "test";
+
+        String result = STR."prefix \{param1} infix + \{param2.length()} suffix";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <spotless.version>2.40.0</spotless.version>
         <slf4j.version>2.0.9</slf4j.version>
         <junit.version>5.10.0</junit.version>


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

To update java for java 21 the following things have to be done:
- [x] Update java version in pom.xml
- [x] Update java version in workflow files
- [x] Update expected java version for tests
- [x] Verify the old tests are still working
- [x] Write rules and tests for new java features
- [x] Verify the rules below indeed do not impact jplag
- [x] Enable Previews
- [x] Right now the java version for enabling previews is hard coded. It should be unified with the version in NewJavaFeaturesTest

The following new features are relevant to jplag:
- [x] Record Patterns and Pattern matching for switch have been finalized
    Works without changes
- [x] String templates (preview)
    Works without changes
- [x] Unnamed patterns and variables (preview)
    Ignore vardefs without name (javac maps "_" to an empty string)
- [x] Anonymous classes. Produced negative positions for end of class tokens
- [x] Guards for cases. Should be extracted as an additional if.

The following changes should not impact jplag:
- [x] Virtual threads / Structured concurrency
- [x] Foreign function api (preview) [maybe poses problems for obfuscation of plagiarisms]
- [x] Scoped values