### PR TITLE
Increase default number of exported comparisons to 500.

### DIFF
--- a/core/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/core/src/main/java/de/jplag/options/JPlagOptions.java
@@ -51,7 +51,7 @@ public record JPlagOptions(Language language, Integer minimumTokenMatch, Set<Fil
         boolean debugParser, MergingOptions mergingOptions) {
 
     public static final double DEFAULT_SIMILARITY_THRESHOLD = 0;
-    public static final int DEFAULT_SHOWN_COMPARISONS = 100;
+    public static final int DEFAULT_SHOWN_COMPARISONS = 500;
     public static final int SHOW_ALL_COMPARISONS = 0;
     public static final SimilarityMetric DEFAULT_SIMILARITY_METRIC = SimilarityMetric.AVG;
     public static final Charset CHARSET = StandardCharsets.UTF_8;


### PR DESCRIPTION
In our experience, very often, one wants to export more than 100 comparisons, which was the current default value for the exported comparisons. While the number of exported comparisons can be controlled by the user via `-n`, we feel that 500 is a more suitable default value. A dataset of 33 programs already leads to just above 500 comparisons.
