### PR TITLE
Improve cluster sorting speed

### DIFF
--- a/report-viewer/src/model/ComparisonListElement.ts
+++ b/report-viewer/src/model/ComparisonListElement.ts
@@ -9,6 +9,7 @@ import type { MetricType } from './MetricType'
  * @property firstSubmissionId - Id of the first submission
  * @property secondSubmissionId - Id of the second submission
  * @property similarity - Similarity of the two submissions
+ * @property clusterIndex - Index of the associatedCluster in the array in the overview
  */
 export type ComparisonListElement = {
   sortingPlace: number
@@ -16,4 +17,5 @@ export type ComparisonListElement = {
   firstSubmissionId: string
   secondSubmissionId: string
   similarities: Record<MetricType, number>
+  clusterIndex: number
 }


### PR DESCRIPTION
This PR improves the speed of the cluster sorting.
Previously it was slow, because when it was enabled, the report-viewer iterated over all comparisons and checked for every cluster whether it applied to this comparison. Due to the function for this being called in every comparsion during the sort method, it was slow.

Now the cluster fitting to a comparison gets added to its object on parsing the json, which takes the load from the moment where the table gets sorted