### PR TITLE
Improve performance of the match merging after the matching is done

### DIFF
--- a/core/src/main/java/de/jplag/Match.java
+++ b/core/src/main/java/de/jplag/Match.java
@@ -16,10 +16,8 @@ public record Match(int startOfFirst, int startOfSecond, int length) {
             if ((other.startOfFirst - startOfFirst) < length) {
                 return true;
             }
-        } else {
-            if ((startOfFirst - other.startOfFirst) < other.length) {
-                return true;
-            }
+        } else if ((startOfFirst - other.startOfFirst) < other.length) {
+            return true;
         }
 
         if (startOfSecond < other.startOfSecond) {


### PR DESCRIPTION
Partially addresses #1430:

- Improve the performance of the neighbor calculation by avoiding sorting
- Improve the performance of the match filtering by using streams instead of removal lists

Brings around 10 to 30% better performance for GST + merging for datasets of large programs depending on paramterization.
