### PR TITLE
Fix logger name to ensure build is passing

### DIFF
--- a/cli/src/main/java/de/jplag/cli/OutputFileGenerator.java
+++ b/cli/src/main/java/de/jplag/cli/OutputFileGenerator.java
@@ -10,7 +10,7 @@ import de.jplag.JPlagResult;
 import de.jplag.csv.comparisons.CsvComparisonOutput;
 
 public final class OutputFileGenerator {
-    private static final Logger LOGGER = LoggerFactory.getLogger(OutputFileGenerator.class);
+    private static final Logger logger = LoggerFactory.getLogger(OutputFileGenerator.class);
 
     private OutputFileGenerator() {
         // Prevents default constructor
@@ -29,7 +29,7 @@ public final class OutputFileGenerator {
                 CsvComparisonOutput.writeCsvResults(result.getAllComparisons(), false, outputRoot, "results");
                 CsvComparisonOutput.writeCsvResults(result.getAllComparisons(), true, outputRoot, "results-anonymous");
             } catch (IOException e) {
-                LOGGER.warn("Could not write csv results", e);
+                logger.warn("Could not write csv results", e);
             }
         }
     }


### PR DESCRIPTION
Fixes the develop build, as the architecture test case regarding logger names was violated.
The violating PR was probably still on an old version of the development branch, thus this was not caught earlier.