### PR TITLE
Changed AbstractAntlrParserAdapter to catch all exceptions during par…

### DIFF
--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
@@ -68,7 +68,7 @@ public abstract class AbstractAntlrParserAdapter<T extends Parser> extends Abstr
             for (ParseTree child : entryContext.children) {
                 treeWalker.walk(listener, child);
             }
-        } catch (Throwable exception) { // catching throwable to capture any exceptions thrown by ANTLR.
+        } catch (Exception exception) { // catching generic exception to capture any exceptions thrown by ANTLR.
             throw new ParsingException(file, exception.getMessage(), exception);
         }
         collector.addFileEndToken();

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
@@ -1,7 +1,6 @@
 package de.jplag.antlr;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
 import java.util.Set;
@@ -69,7 +68,7 @@ public abstract class AbstractAntlrParserAdapter<T extends Parser> extends Abstr
             for (ParseTree child : entryContext.children) {
                 treeWalker.walk(listener, child);
             }
-        } catch (IOException exception) {
+        } catch (Throwable exception) { // catching throwable to capture any exceptions thrown by ANTLR.
             throw new ParsingException(file, exception.getMessage(), exception);
         }
         collector.addFileEndToken();


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

This makes it, so all antlr exceptions are caught, so that the name of the file, that failed is always shown.
Addresses: #1386 