### PR TITLE
Remove comparison single file upload

### DIFF
--- a/report-viewer/src/utils/fileHandling/FileHandler.ts
+++ b/report-viewer/src/utils/fileHandling/FileHandler.ts
@@ -6,5 +6,5 @@ export abstract class FileHandler {
    * Loads the content of the given file and stores it in the store.
    * @param file File to handle
    */
-  public abstract handleFile(file: Blob): Promise<any>
+  public abstract handleFile(file: Blob): Promise<void>
 }

--- a/report-viewer/src/utils/fileHandling/JsonFileHandler.ts
+++ b/report-viewer/src/utils/fileHandling/JsonFileHandler.ts
@@ -5,19 +5,13 @@ import { FileHandler } from './FileHandler'
  * Class for handling single json files.
  */
 export class JsonFileHandler extends FileHandler {
-  public async handleFile(
-    file: Blob
-  ): Promise<{ fileType: 'overview' } | { fileType: 'comparison'; id1: string; id2: string }> {
+  public async handleFile(file: Blob) {
     const content = await file.text()
     const json = JSON.parse(content)
 
     store().setSingleFileRawContent(content)
-    if (json['submission_folder_path']) {
-      return { fileType: 'overview' }
-    } else if (json['id1'] && json['id2']) {
-      return { fileType: 'comparison', id1: json['id1'], id2: json['id2'] }
-    } else {
-      throw new Error(`Invalid JSON: ${json}`)
+    if (!json['submission_folder_path']) {
+      throw new Error(`Invalid JSON: File is not an overview file.`)
     }
   }
 }

--- a/report-viewer/src/utils/fileHandling/ZipFileHandler.ts
+++ b/report-viewer/src/utils/fileHandling/ZipFileHandler.ts
@@ -7,7 +7,7 @@ import { FileHandler } from './FileHandler'
  * Class for handling zip files.
  */
 export class ZipFileHandler extends FileHandler {
-  public async handleFile(file: Blob): Promise<void> {
+  public async handleFile(file: Blob) {
     console.log('Start handling zip file and storing necessary data...')
     return jszip.loadAsync(file).then(async (zip) => {
       for (const originalFileName of Object.keys(zip.files)) {

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -107,32 +107,23 @@ function navigateToOverview() {
   })
 }
 
-function navigateToComparisonView(firstId: string, secondId: string) {
-  router.push({
-    name: 'ComparisonView',
-    params: {
-      firstId,
-      secondId
-    }
-  })
-}
-
 /**
  * Handles a json file on drop. It read the file and passes the file string to next window.
  * @param file The json file to handle
  */
 async function handleJsonFile(file: Blob) {
+  try {
+    await new JsonFileHandler().handleFile(file)
+  } catch (e) {
+    registerError(e as Error, 'upload')
+    return
+  }
   store().setLoadingType({
     local: false,
     zip: false,
     single: true
   })
-  const fileContentType = await new JsonFileHandler().handleFile(file)
-  if (fileContentType.fileType === 'overview') {
-    navigateToOverview()
-  } else if (fileContentType.fileType === 'comparison') {
-    navigateToComparisonView(fileContentType.id1, fileContentType.id2)
-  }
+  navigateToOverview()
 }
 
 /**


### PR DESCRIPTION
Currently JPlag supports uploading a single comparison file json and then navigates to the comparison view. This can not work since the files of the submission are missing. Because of this this PR removes it.

The single file upload for overview files is untouched