### PR TITLE
Added a better error message, if no valid language was supplied.

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -6,6 +6,7 @@ import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_SYNOPSIS;
 
 import java.io.File;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -58,6 +59,7 @@ public final class CLI {
 
     private static final String IMPOSSIBLE_EXCEPTION = "This should not have happened."
             + " Please create an issue on github (https://github.com/jplag/JPlag/issues) with the entire output.";
+    private static final String UNKOWN_LANGAUGE_EXCEPTION = "Language %s does not exists. Available languages are: %s";
 
     private static final String DESCRIPTION_PATTERN = "%nJPlag - %s%n%s%n%n";
 
@@ -140,6 +142,12 @@ public final class CLI {
                 commandLine.getExecutionStrategy().execute(result);
             }
             return result;
+        } catch (CommandLine.ParameterException e) {
+            if (e.getArgSpec().isOption() && Arrays.asList(((OptionSpec) e.getArgSpec()).names()).contains("-l")) {
+                throw new CliException(String.format(UNKOWN_LANGAUGE_EXCEPTION, e.getValue(),
+                        String.join(", ", LanguageLoader.getAllAvailableLanguageIdentifiers())));
+            }
+            throw new CliException("Error during parsing", e);
         } catch (CommandLine.PicocliException e) {
             throw new CliException("Error during parsing", e);
         }


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

I an invalid language was supplied on the cli the following message is now printed:

```
Language asdf does not exists. Available languages are: cpp, cpp2, csharp, emf, emf-model, go, java, kotlin, llvmir, python3, rlang, rust, scala, scheme, scxml, swift, text, typescript
```