### PR TITLE
Fix version of intra-project dependency for the kotlin module

### DIFF
--- a/languages/kotlin/pom.xml
+++ b/languages/kotlin/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>4.4.0-SNAPSHOT</version>
+            <version>${revision}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Replace the explicit version with the revision property.
