### PR TITLE
Increase development version to 5.0.0-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <emfatic.version>1.0.0</emfatic.version>
 
         <!-- The Revision of JPlag -->
-        <revision>4.4.0-SNAPSHOT</revision>
+        <revision>5.0.0-SNAPSHOT</revision>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Increase the development version of JPlag to 5.0.0-SNAPSHOT for the upcoming major release.