### PR TITLE
Fix broken cluster sorting

### DIFF
--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -195,7 +195,7 @@ const props = defineProps({
 })
 
 const displayedComparisons = computed(() => {
-  const comparisons = getFilteredComparisons(getSortedComparisons(props.topComparisons))
+  const comparisons = getFilteredComparisons(getSortedComparisons(Array.from(props.topComparisons)))
   let index = 1
   comparisons.forEach((c) => {
     c.id = index++
@@ -250,7 +250,7 @@ function getSortedComparisons(comparisons: ComparisonListElement[]) {
   comparisons.forEach((c) => {
     c.sortingPlace = index++
   })
-  return props.topComparisons
+  return comparisons
 }
 
 function getClusterFor(clusterIndex: number) {


### PR DESCRIPTION
The report viewer froze when sorting large clusters. See the [demo](https://jplag.github.io/Demo/)
This was due to a the sorting method working directly on the reactive element which triggered the sorting again. This was an endless cycle.
It was just fixed by giveng the method a copy of the array to modify