### PR TITLE
Show similarity for each submission

### DIFF
--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -58,7 +58,7 @@ public class ComparisonReportWriter {
             addToLookUp(firstSubmissionId, secondSubmissionId, fileName);
             var comparisonReport = new ComparisonReport(firstSubmissionId, secondSubmissionId,
                     Map.of(SimilarityMetric.AVG.name(), comparison.similarity(), SimilarityMetric.MAX.name(), comparison.maximalSimilarity()),
-                    convertMatchesToReportMatches(comparison));
+                    convertMatchesToReportMatches(comparison), comparison.similarityOfFirst(), comparison.similarityOfSecond());
             resultWriter.addJsonEntry(comparisonReport, fileName);
         }
     }

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/ComparisonReport.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/ComparisonReport.java
@@ -13,6 +13,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @param matches the list of matches found in the comparison of the two submissions
  */
 public record ComparisonReport(@JsonProperty("id1") String firstSubmissionId, @JsonProperty("id2") String secondSubmissionId,
-        @JsonProperty("similarities") Map<String, Double> similarities, @JsonProperty("matches") List<Match> matches) {
+        @JsonProperty("similarities") Map<String, Double> similarities, @JsonProperty("matches") List<Match> matches, @JsonProperty("first_similarity") double firstSimilarity, @JsonProperty("second_similarity") double secondSimilarity) {
 
 }

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/ComparisonReport.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/ComparisonReport.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @param matches the list of matches found in the comparison of the two submissions
  */
 public record ComparisonReport(@JsonProperty("id1") String firstSubmissionId, @JsonProperty("id2") String secondSubmissionId,
-        @JsonProperty("similarities") Map<String, Double> similarities, @JsonProperty("matches") List<Match> matches, @JsonProperty("first_similarity") double firstSimilarity, @JsonProperty("second_similarity") double secondSimilarity) {
+        @JsonProperty("similarities") Map<String, Double> similarities, @JsonProperty("matches") List<Match> matches,
+        @JsonProperty("first_similarity") double firstSimilarity, @JsonProperty("second_similarity") double secondSimilarity) {
 
 }

--- a/report-viewer/src/components/TextInformation.vue
+++ b/report-viewer/src/components/TextInformation.vue
@@ -3,7 +3,7 @@
 -->
 <template>
   <div class="print:flex-none">
-    <ToolTipComponent direction="bottom">
+    <ToolTipComponent :direction="tooltipSide">
       <template #default>
         {{ label }}:
         <i><slot name="default"></slot></i>
@@ -16,12 +16,19 @@
 </template>
 
 <script setup lang="ts">
+import type { PropType } from 'vue'
 import ToolTipComponent from './ToolTipComponent.vue'
+import type { ToolTipDirection } from '@/model/ui/ToolTip'
 
 defineProps({
   label: {
     type: String,
     required: true
+  },
+  tooltipSide: {
+    type: String as PropType<ToolTipDirection>,
+    required: false,
+    default: 'bottom'
   }
 })
 </script>

--- a/report-viewer/src/components/TextInformation.vue
+++ b/report-viewer/src/components/TextInformation.vue
@@ -2,7 +2,7 @@
   A container displaying simple text information
 -->
 <template>
-  <div class="flex-auto print:flex-none">
+  <div class="print:flex-none">
     <ToolTipComponent direction="bottom">
       <template #default>
         {{ label }}:

--- a/report-viewer/src/components/ToolTipComponent.vue
+++ b/report-viewer/src/components/ToolTipComponent.vue
@@ -14,11 +14,12 @@
 </template>
 
 <script setup lang="ts">
+import type { ToolTipDirection } from '@/model/ui/ToolTip'
 import { computed, type PropType, type StyleValue } from 'vue'
 
 const props = defineProps({
   direction: {
-    type: String as PropType<'top' | 'bottom' | 'left' | 'right'>,
+    type: String as PropType<ToolTipDirection>,
     required: false,
     default: 'top'
   }

--- a/report-viewer/src/model/Comparison.ts
+++ b/report-viewer/src/model/Comparison.ts
@@ -13,6 +13,8 @@ export class Comparison {
   private _filesOfFirstSubmission: SubmissionFile[]
   private _filesOfSecondSubmission: SubmissionFile[]
   private _allMatches: Array<Match>
+  private readonly _firstSimilarity?: number
+  private readonly _secondSimilarity?: number
 
   constructor(
     firstSubmissionId: string,
@@ -20,7 +22,9 @@ export class Comparison {
     similarities: Record<MetricType, number>,
     filesOfFirstSubmission: SubmissionFile[],
     filesOfSecondSubmission: SubmissionFile[],
-    allMatches: Array<Match>
+    allMatches: Array<Match>,
+    firstSimilarity?: number,
+    secondSimilarity?: number
   ) {
     this._firstSubmissionId = firstSubmissionId
     this._secondSubmissionId = secondSubmissionId
@@ -28,6 +32,8 @@ export class Comparison {
     this._filesOfFirstSubmission = filesOfFirstSubmission
     this._filesOfSecondSubmission = filesOfSecondSubmission
     this._allMatches = allMatches
+    this._firstSimilarity = firstSimilarity
+    this._secondSimilarity = secondSimilarity
   }
 
   /**
@@ -84,6 +90,14 @@ export class Comparison {
    */
   get similarities() {
     return this._similarities
+  }
+
+  get firstSimilarity(): number | undefined {
+    return this._firstSimilarity
+  }
+
+  get secondSimilarity(): number | undefined {
+    return this._secondSimilarity
   }
 
   private groupMatchesByFileName(index: 1 | 2): Map<string, Array<MatchInSingleFile>> {

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -43,7 +43,9 @@ export class ComparisonFactory extends BaseFactory {
       this.extractSimilarities(json),
       filesOfFirstSubmission,
       filesOfSecondSubmission,
-      this.colorMatches(unColoredMatches)
+      this.colorMatches(unColoredMatches),
+      json.first_similarity as number | undefined,
+      json.second_similarity as number | undefined
     )
   }
 

--- a/report-viewer/src/model/ui/ToolTip.ts
+++ b/report-viewer/src/model/ui/ToolTip.ts
@@ -2,3 +2,5 @@ export type ToolTipLabel = {
   displayValue: string
   tooltip: string
 }
+
+export type ToolTipDirection = 'top' | 'bottom' | 'left' | 'right'

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -23,9 +23,19 @@
             </template>
           </ToolTipComponent>
         </h2>
-        <div class="flex flex-row">
+        <div class="flex flex-row space-x-10">
           <TextInformation label="Average Similarity"
             >{{ (comparison.similarities[MetricType.AVERAGE] * 100).toFixed(2) }}%</TextInformation
+          >
+          <TextInformation
+            v-if="comparison.firstSimilarity"
+            :label="`Similarity ${store().getDisplayName(comparison.firstSubmissionId)}`"
+            >{{ (comparison.firstSimilarity * 100).toFixed(2) }}%</TextInformation
+          >
+          <TextInformation
+            v-if="comparison.secondSimilarity"
+            :label="`Similarity ${store().getDisplayName(comparison.secondSubmissionId)}`"
+            >{{ (comparison.secondSimilarity * 100).toFixed(2) }}%</TextInformation
           >
         </div>
         <MatchList

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -24,18 +24,47 @@
           </ToolTipComponent>
         </h2>
         <div class="flex flex-row space-x-10">
-          <TextInformation label="Average Similarity"
+          <TextInformation label="Average Similarity" class="font-bold"
             >{{ (comparison.similarities[MetricType.AVERAGE] * 100).toFixed(2) }}%</TextInformation
           >
           <TextInformation
             v-if="comparison.firstSimilarity"
             :label="`Similarity ${store().getDisplayName(comparison.firstSubmissionId)}`"
-            >{{ (comparison.firstSimilarity * 100).toFixed(2) }}%</TextInformation
+            tooltip-side="right"
           >
+            <template #default>{{ (comparison.firstSimilarity * 100).toFixed(2) }}%</template>
+            <template #tooltip
+              ><div class="whitespace-pre text-sm">
+                <p>
+                  Percentage of code from
+                  {{ store().getDisplayName(comparison.firstSubmissionId) }} that was found in the
+                  code of {{ store().getDisplayName(comparison.secondSubmissionId) }}.
+                </p>
+                <p>
+                  The numbers might not be symmetric, due to the submissions having different
+                  lengths.
+                </p>
+              </div></template
+            >
+          </TextInformation>
           <TextInformation
             v-if="comparison.secondSimilarity"
             :label="`Similarity ${store().getDisplayName(comparison.secondSubmissionId)}`"
-            >{{ (comparison.secondSimilarity * 100).toFixed(2) }}%</TextInformation
+            tooltip-side="right"
+            ><template #default>{{ (comparison.secondSimilarity * 100).toFixed(2) }}%</template>
+            <template #tooltip
+              ><div class="whitespace-pre text-sm">
+                <p>
+                  Percentage of code from
+                  {{ store().getDisplayName(comparison.secondSubmissionId) }} that was found in the
+                  code of {{ store().getDisplayName(comparison.firstSubmissionId) }}.
+                </p>
+                <p>
+                  The numbers might not be symmetric, due to the submissions having different
+                  lengths.
+                </p>
+              </div></template
+            ></TextInformation
           >
         </div>
         <MatchList

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -9,15 +9,17 @@
         <div
           class="flex flex-row items-center space-x-5 print:flex-col print:items-start print:space-x-0"
         >
-          <TextInformation label="Submission Directory">{{ submissionPathValue }}</TextInformation>
-          <TextInformation label="Result name">{{
+          <TextInformation label="Submission Directory" class="flex-auto">{{
+            submissionPathValue
+          }}</TextInformation>
+          <TextInformation label="Result name" class="flex-auto">{{
             store().state.uploadedFileName
           }}</TextInformation>
-          <TextInformation label="Total Submissions">{{
+          <TextInformation label="Total Submissions" class="flex-auto">{{
             store().getSubmissionIds.length
           }}</TextInformation>
 
-          <TextInformation label="Shown/Total Comparisons">
+          <TextInformation label="Shown/Total Comparisons" class="flex-auto">
             <template #default
               >{{ overview.shownComparisons }} / {{ overview.totalComparisons }}</template
             >
@@ -42,7 +44,7 @@
             </template>
           </TextInformation>
 
-          <TextInformation label="Min Token Match">
+          <TextInformation label="Min Token Match" class="flex-auto">
             <template #default>
               {{ overview.matchSensitivity }}
             </template>
@@ -57,7 +59,7 @@
             </template>
           </TextInformation>
 
-          <ToolTipComponent direction="left" class="print:hidden">
+          <ToolTipComponent direction="left" class="flex-grow-0 print:hidden">
             <template #default>
               <Button @click="router.push({ name: 'InfoView' })"> More </Button>
             </template>


### PR DESCRIPTION
Adds the similarity for each submission to the comparison view.

The similarity gets added to the report file of each comparsion.

The name of this similarity can still be discussed. In Jplag itsself, the report and the logic behinf the viewer they are labeld `firstSimilarity` and `secondSimilarity`. In the viewer UI they are shown as `Similarity DisplayName`.