### PR TITLE
Fix submission file copying

### DIFF
--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -106,7 +106,7 @@ public class ReportObjectFactory {
         Set<Submission> submissions = getSubmissions(comparisons);
         Language language = result.getOptions().language();
         for (Submission submission : submissions) {
-            String submissionRootPath = SUBMISSIONS_ROOT_PATH + submissionToIdFunction.apply(submission) + "/";
+            String submissionRootPath = SUBMISSIONS_ROOT_PATH + submissionToIdFunction.apply(submission);
             for (File file : submission.getFiles()) {
                 String relativeFilePath = file.getAbsolutePath().substring(submission.getRoot().getAbsolutePath().length());
                 if (relativeFilePath.isEmpty()) {


### PR DESCRIPTION
Currently copying the submission files has a bug. Due to a `/` being appended to the filepath the folder structur looked as follows:
```
files
 └ SubmissionName
   └ _
     └ srcFiles
```
This is due to the paths looking like this `files/SubmissioName//srcFiles`. So there was an empty folder.
The `_` folder (no name) is unwanted. It breaks code highlighting and file names get displayed wrongly