### PR TITLE
Fix line breaks in comparison view

### DIFF
--- a/report-viewer/src/components/fileDisplaying/CodePanel.vue
+++ b/report-viewer/src/components/fileDisplaying/CodePanel.vue
@@ -7,11 +7,11 @@
       {{ getFileDisplayName(file) }}
     </div>
 
-    <div class="mx-1 overflow-x-auto print:!mx-0">
+    <div class="mx-1 overflow-x-auto print:!mx-0 print:overflow-x-hidden">
       <div class="print:display-initial w-fit min-w-full !text-xs" :class="{ hidden: collapsed }">
         <table
           v-if="file.data.trim() !== ''"
-          class="w-full"
+          class="w-full print:table-auto"
           :aria-describedby="`Content of file ${file.fileName}`"
         >
           <!-- One row in table per code line -->
@@ -36,7 +36,7 @@
             >
               <pre
                 v-html="line.line"
-                class="code-font print-excact !bg-transparent print:whitespace-pre-wrap"
+                class="code-font print-excact break-child !bg-transparent print:whitespace-pre-wrap"
                 ref="lineRefs"
               ></pre>
             </td>
@@ -144,5 +144,12 @@ function getFileDisplayName(file: SubmissionFile): string {
 <style scoped>
 .code-font {
   font-family: 'JetBrains Mono NL', monospace !important;
+}
+
+@media print {
+  .break-child *,
+  .break-child {
+    word-break: break-word;
+  }
 }
 </style>

--- a/report-viewer/src/components/fileDisplaying/CodePanel.vue
+++ b/report-viewer/src/components/fileDisplaying/CodePanel.vue
@@ -36,7 +36,7 @@
             >
               <pre
                 v-html="line.line"
-                class="code-font print-excact whitespace-pre-wrap !bg-transparent"
+                class="code-font print-excact !bg-transparent print:whitespace-pre-wrap"
                 ref="lineRefs"
               ></pre>
             </td>


### PR DESCRIPTION
The report viewer currently breaks and cuts lines of in the comparison view
![grafik](https://github.com/jplag/JPlag/assets/39801116/1985adce-0b2d-4efe-bae6-ac8a252c77f2)

Fixed an issue in print view, where long continous words that could not be broken, were just cut off
![grafik](https://github.com/jplag/JPlag/assets/39801116/cd087d5c-5ff5-4c95-afe0-298a9fece6bc)

