### PR TITLE
Fixed bug in the end-to-end test, that occurred on mac, due to symbolic links.

### DIFF
--- a/endtoend-testing/src/main/java/de/jplag/endtoend/helper/FileHelper.java
+++ b/endtoend-testing/src/main/java/de/jplag/endtoend/helper/FileHelper.java
@@ -72,6 +72,7 @@ public class FileHelper {
     public static void unzip(File zip, File targetDirectory) throws IOException {
         try (ZipFile zipFile = new ZipFile(zip)) {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            File canonicalTarget = targetDirectory.getCanonicalFile();
 
             long totalSizeArchive = 0;
             long totalEntriesArchive = 0;
@@ -80,9 +81,9 @@ public class FileHelper {
                 totalEntriesArchive++;
 
                 ZipEntry entry = entries.nextElement();
-                File unzippedFile = new File(targetDirectory, entry.getName()).getCanonicalFile();
+                File unzippedFile = new File(canonicalTarget, entry.getName()).getCanonicalFile();
 
-                if (unzippedFile.getAbsolutePath().startsWith(targetDirectory.getAbsolutePath())) {
+                if (unzippedFile.getAbsolutePath().startsWith(canonicalTarget.getAbsolutePath())) {
                     if (entry.isDirectory()) {
                         unzippedFile.mkdirs();
                     } else {


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

There was a bug in unzipping the files for the end-to-end tests.
For security reasons, files are only created, if they are located within the target directory (not pointing outside through the use of links). For that comparison the file from the zip was compared using its canonical path, the target directory was not. Now both use the canonical path (path with all sym-links and other references resolved).