### PR TITLE
Match merging: Use default values for CLI 

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -116,13 +116,13 @@ public class CliOptions implements Runnable {
     }
 
     public static class Merging {
-        @Option(names = {"--match-merging"}, description = "Enables match merging (default: false)%n")
+        @Option(names = {"--match-merging"}, defaultValue = "false", description = "Enables match merging (default: false)%n")
         public boolean enabled;
 
-        @Option(names = {"--neighbor-length"}, description = "Defines how short a match can be, to be considered (default: 2)%n")
+        @Option(names = {"--neighbor-length"}, defaultValue = "2", description = "Defines how short a match can be, to be considered (default: 2)%n")
         public int minimumNeighborLength;
 
-        @Option(names = {"--gap-size"}, description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
+        @Option(names = {"--gap-size"}, defaultValue = "6", description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
         public int maximumGapSize;
 
     }

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -122,7 +122,8 @@ public class CliOptions implements Runnable {
         @Option(names = {"--neighbor-length"}, defaultValue = "2", description = "Defines how short a match can be, to be considered (default: 2)%n")
         public int minimumNeighborLength;
 
-        @Option(names = {"--gap-size"}, defaultValue = "6", description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
+        @Option(names = {
+                "--gap-size"}, defaultValue = "6", description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
         public int maximumGapSize;
 
     }

--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -7,6 +7,7 @@ import de.jplag.clustering.ClusteringAlgorithm;
 import de.jplag.clustering.ClusteringOptions;
 import de.jplag.clustering.algorithm.InterClusterSimilarity;
 import de.jplag.java.JavaLanguage;
+import de.jplag.merging.MergingOptions;
 import de.jplag.options.JPlagOptions;
 import de.jplag.options.SimilarityMetric;
 
@@ -116,15 +117,15 @@ public class CliOptions implements Runnable {
     }
 
     public static class Merging {
-        @Option(names = {"--match-merging"}, defaultValue = "false", description = "Enables match merging (default: false)%n")
-        public boolean enabled;
+        @Option(names = {"--match-merging"}, description = "Enables match merging (default: ${DEFAULT-VALUE})%n")
+        public boolean enabled = MergingOptions.DEFAULT_ENABLED;
 
-        @Option(names = {"--neighbor-length"}, defaultValue = "2", description = "Defines how short a match can be, to be considered (default: 2)%n")
-        public int minimumNeighborLength;
+        @Option(names = {"--neighbor-length"}, description = "Defines how short a match can be, to be considered (default: ${DEFAULT-VALUE})%n")
+        public int minimumNeighborLength = MergingOptions.DEFAULT_NEIGHBOR_LENGTH;
 
         @Option(names = {
-                "--gap-size"}, defaultValue = "6", description = "Defines how many token there can be between two neighboring matches (default: 6)%n")
-        public int maximumGapSize;
+                "--gap-size"}, description = "Defines how many token there can be between two neighboring matches (default: ${DEFAULT-VALUE})%n")
+        public int maximumGapSize = MergingOptions.DEFAULT_GAP_SIZE;
 
     }
 

--- a/cli/src/test/java/de/jplag/cli/MergingOptionsTest.java
+++ b/cli/src/test/java/de/jplag/cli/MergingOptionsTest.java
@@ -11,15 +11,15 @@ import de.jplag.merging.MergingOptions;
 /**
  * Test cases for the options of the match merging mechanism.
  */
-public class MergingOptionsTest extends CommandLineInterfaceTest {
+class MergingOptionsTest extends CommandLineInterfaceTest {
 
     @Test
     @DisplayName("Test if default values are used when creating merging options from CLI")
     void testMergingDefault() throws CliException {
         buildOptionsFromCLI(defaultArguments());
         assertNotNull(options.mergingOptions());
-        assertEquals(options.mergingOptions().enabled(), MergingOptions.DEFAULT_ENABLED);
-        assertEquals(options.mergingOptions().minimumNeighborLength(), MergingOptions.DEFAULT_NEIGHBOR_LENGTH);
-        assertEquals(options.mergingOptions().maximumGapSize(), MergingOptions.DEFAULT_GAP_SIZE);
+        assertEquals(MergingOptions.DEFAULT_ENABLED, options.mergingOptions().enabled());
+        assertEquals(MergingOptions.DEFAULT_NEIGHBOR_LENGTH, options.mergingOptions().minimumNeighborLength());
+        assertEquals(MergingOptions.DEFAULT_GAP_SIZE, options.mergingOptions().maximumGapSize());
     }
 }

--- a/cli/src/test/java/de/jplag/cli/MergingOptionsTest.java
+++ b/cli/src/test/java/de/jplag/cli/MergingOptionsTest.java
@@ -3,12 +3,18 @@ package de.jplag.cli;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import de.jplag.merging.MergingOptions;
 
+/**
+ * Test cases for the options of the match merging mechanism.
+ */
 public class MergingOptionsTest extends CommandLineInterfaceTest {
+
     @Test
+    @DisplayName("Test if default values are used when creating merging options from CLI")
     void testMergingDefault() throws CliException {
         buildOptionsFromCLI(defaultArguments());
         assertNotNull(options.mergingOptions());

--- a/cli/src/test/java/de/jplag/cli/MergingOptionsTest.java
+++ b/cli/src/test/java/de/jplag/cli/MergingOptionsTest.java
@@ -1,0 +1,19 @@
+package de.jplag.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import de.jplag.merging.MergingOptions;
+
+public class MergingOptionsTest extends CommandLineInterfaceTest {
+    @Test
+    void testMergingDefault() throws CliException {
+        buildOptionsFromCLI(defaultArguments());
+        assertNotNull(options.mergingOptions());
+        assertEquals(options.mergingOptions().enabled(), MergingOptions.DEFAULT_ENABLED);
+        assertEquals(options.mergingOptions().minimumNeighborLength(), MergingOptions.DEFAULT_NEIGHBOR_LENGTH);
+        assertEquals(options.mergingOptions().maximumGapSize(), MergingOptions.DEFAULT_GAP_SIZE);
+    }
+}

--- a/core/src/main/java/de/jplag/merging/MergingOptions.java
+++ b/core/src/main/java/de/jplag/merging/MergingOptions.java
@@ -10,12 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public record MergingOptions(@JsonProperty("enabled") boolean enabled, @JsonProperty("min_neighbour_length") int minimumNeighborLength,
         @JsonProperty("max_gap_size") int maximumGapSize) {
 
+    public static final boolean DEFAULT_ENABLED = false;
+    public static final int DEFAULT_NEIGHBOR_LENGTH = 2;
+    public static final int DEFAULT_GAP_SIZE = 6;
+
     /**
      * The default values of MergingOptions are false for the enable-switch, which deactivate MatchMerging, while
      * minimumNeighborLength and maximumGapSize default to (2,6), which in testing yielded the best results.
      */
     public MergingOptions() {
-        this(false, 2, 6);
+        this(DEFAULT_ENABLED, DEFAULT_NEIGHBOR_LENGTH, DEFAULT_GAP_SIZE);
     }
 
     /**


### PR DESCRIPTION
Fixed an issue where the default values where not used for the CLI.
