### PR TITLE
Fix bugs in CLI error handling

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -144,7 +144,7 @@ public final class CLI {
             }
             return result;
         } catch (CommandLine.ParameterException e) {
-            if (e.getArgSpec().isOption() && Arrays.asList(((OptionSpec) e.getArgSpec()).names()).contains("-l")) {
+            if (e.getArgSpec() != null && e.getArgSpec().isOption() && Arrays.asList(((OptionSpec) e.getArgSpec()).names()).contains("-l")) {
                 throw new CliException(String.format(UNKOWN_LANGAUGE_EXCEPTION, e.getValue(),
                         String.join(", ", LanguageLoader.getAllAvailableLanguageIdentifiers())));
             }

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -86,7 +86,7 @@ public final class CLI {
             }
         } catch (ExitException | FileNotFoundException exception) { // do not pass exceptions here to keep log clean
             if (exception.getCause() != null) {
-                logger.error(exception.getMessage() + " - " + exception.getCause().getMessage());
+                logger.error("{} - {}", exception.getMessage(), exception.getCause().getMessage());
             } else {
                 logger.error(exception.getMessage());
             }

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -84,8 +84,13 @@ public final class CLI {
 
                 OutputFileGenerator.generateCsvOutput(result, new File(cli.getResultFolder()), cli.options);
             }
-        } catch (ExitException | FileNotFoundException exception) {
-            logger.error(exception.getMessage()); // do not pass exception here to keep log clean
+        } catch (ExitException | FileNotFoundException exception) { // do not pass exceptions here to keep log clean
+            if (exception.getCause() != null) {
+                logger.error(exception.getMessage() + " - " + exception.getCause().getMessage());
+            } else {
+                logger.error(exception.getMessage());
+            }
+
             finalizeLogger();
             System.exit(1);
         }
@@ -103,9 +108,8 @@ public final class CLI {
         this.commandLine.getHelpSectionMap().put(SECTION_KEY_OPTION_LIST, help -> help.optionList().lines().map(it -> {
             if (it.startsWith("  -")) {
                 return "    " + it;
-            } else {
-                return it;
             }
+            return it;
         }).collect(Collectors.joining(System.lineSeparator())));
 
         buildSubcommands().forEach(commandLine::addSubcommand);
@@ -188,27 +192,25 @@ public final class CLI {
         File baseCodeDirectory = baseCodePath == null ? null : new File(baseCodePath);
         if (baseCodeDirectory == null || baseCodeDirectory.exists()) {
             return jPlagOptions.withBaseCodeSubmissionDirectory(baseCodeDirectory);
-        } else {
-            logger.warn("Using legacy partial base code API. Please migrate to new full path base code API.");
-            return jPlagOptions.withBaseCodeSubmissionName(baseCodePath);
         }
+        logger.warn("Using legacy partial base code API. Please migrate to new full path base code API.");
+        return jPlagOptions.withBaseCodeSubmissionName(baseCodePath);
     }
 
     private Language loadLanguage(ParseResult result) throws CliException {
-        if (result.subcommand() != null) {
-            ParseResult subcommandResult = result.subcommand();
-            Language language = LanguageLoader.getLanguage(subcommandResult.commandSpec().name())
-                    .orElseThrow(() -> new CliException(IMPOSSIBLE_EXCEPTION));
-            LanguageOptions languageOptions = language.getOptions();
-            languageOptions.getOptionsAsList().forEach(option -> {
-                if (subcommandResult.hasMatchedOption(option.getNameAsUnixParameter())) {
-                    option.setValue(subcommandResult.matchedOptionValue(option.getNameAsUnixParameter(), null));
-                }
-            });
-            return language;
-        } else {
+        if (result.subcommand() == null) {
             return this.options.language;
         }
+        ParseResult subcommandResult = result.subcommand();
+        Language language = LanguageLoader.getLanguage(subcommandResult.commandSpec().name())
+                .orElseThrow(() -> new CliException(IMPOSSIBLE_EXCEPTION));
+        LanguageOptions languageOptions = language.getOptions();
+        languageOptions.getOptionsAsList().forEach(option -> {
+            if (subcommandResult.hasMatchedOption(option.getNameAsUnixParameter())) {
+                option.setValue(subcommandResult.matchedOptionValue(option.getNameAsUnixParameter(), null));
+            }
+        });
+        return language;
     }
 
     private static ClusteringOptions getClusteringOptions(CliOptions options) {

--- a/cli/src/main/java/de/jplag/cli/LanguageLoader.java
+++ b/cli/src/main/java/de/jplag/cli/LanguageLoader.java
@@ -32,8 +32,9 @@ public final class LanguageLoader {
      * @return the languages as unmodifiable map from identifier to language instance.
      */
     public static synchronized Map<String, Language> getAllAvailableLanguages() {
-        if (cachedLanguageInstances != null)
+        if (cachedLanguageInstances != null) {
             return cachedLanguageInstances;
+        }
 
         Map<String, Language> languages = new TreeMap<>();
 
@@ -61,8 +62,9 @@ public final class LanguageLoader {
      */
     public static Optional<Language> getLanguage(String identifier) {
         var language = getAllAvailableLanguages().get(identifier);
-        if (language == null)
+        if (language == null) {
             logger.warn("Attempt to load Language {} was not successful", identifier);
+        }
         return Optional.ofNullable(language);
     }
 


### PR DESCRIPTION
Due to a missing null check, a null pointer exception was caused in the exception handling of the CLI class.

```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "picocli.CommandLine$Model$ArgSpec.isOption()" because the return value of "picocli.CommandLine$ParameterException.getArgSpec()" is null
	at de.jplag.cli.CLI.parseOptions(CLI.java:147)
	at de.jplag.cli.CLI.main(CLI.java:77)
```

This occurs when a user enters a cli flag that does not exist, e.g. `--foo-bar`.

Furthermore, the CLI API error messages were not properly passed through. Now, the messages of wrapped exceptions are logged as well.