### PR TITLE
Set minimum report viewer version to 4.2.0

### DIFF
--- a/report-viewer/src/model/factories/OverviewFactory.ts
+++ b/report-viewer/src/model/factories/OverviewFactory.ts
@@ -271,7 +271,7 @@ export class OverviewFactory extends BaseFactory {
         "The result's version(" +
         jsonVersion.toString() +
         ') is older than the minimal support version of the report viewer(' +
-        reportViewerVersion.toString() +
+        minimalVersion.toString() +
         '). ' +
         'Can not read the report.'
       )

--- a/report-viewer/src/router/index.ts
+++ b/report-viewer/src/router/index.ts
@@ -62,7 +62,7 @@ function redirectOnError(
   router.push({
     name: 'ErrorView',
     params: {
-      message: prefix + error.message,
+      message: prefix + (error.message ?? error),
       to: redirectRoute,
       routerInfo: redirectRouteTitle
     }

--- a/report-viewer/src/version.json
+++ b/report-viewer/src/version.json
@@ -1,12 +1,12 @@
 {
   "report_viewer_version": {
-    "major": 0,
+    "major": 5,
     "minor": 0,
     "patch": 0
   },
   "minimal_report_version": {
     "major": 4,
-    "minor": 0,
+    "minor": 2,
     "patch": 0
   }
 }

--- a/report-viewer/tests/unit/model/factories/ValidNewOverview.json
+++ b/report-viewer/tests/unit/model/factories/ValidNewOverview.json
@@ -1,5 +1,5 @@
 {
-  "jplag_version": { "major": 4, "minor": 0, "patch": 0 },
+  "jplag_version": { "major": 5, "minor": 0, "patch": 0 },
   "submission_folder_path": ["files"],
   "base_code_folder_path": "",
   "language": "Javac based AST plugin",


### PR DESCRIPTION
As discovered in #1565 the report viewer is not compatible with version 4.1.0 and lower. Thus the minimal version for the report viewer is now set to 4.2.0

In addition fixed a mistake in giving the wrong reference version in the error message 
Fixed the error not being correctly passed to its view