### PR TITLE
Fix missing line break in CLI help text with workaround

### DIFF
--- a/cli/src/main/java/de/jplag/cli/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/CliOptions.java
@@ -122,7 +122,7 @@ public class CliOptions implements Runnable {
         public boolean enabled = MergingOptions.DEFAULT_ENABLED;
 
         @Option(names = {
-                "--neighbor-length"}, description = "Minimal length of neighboring matches to be merged (between 1 and minTokenMatch, default: ${DEFAULT-VALUE}).")
+                "--neighbor-length"}, description = "Minimal length of neighboring matches to be merged (between 1 and minTokenMatch, default: ${DEFAULT-VALUE}).%n")
         public int minimumNeighborLength = MergingOptions.DEFAULT_NEIGHBOR_LENGTH;
 
         @Option(names = {


### PR DESCRIPTION
The title of the subcommand group is part of the description of the previous argument. We do not know why, this PR is a hotfix for the release.