### PR TITLE
Fix slash issues

### DIFF
--- a/core/src/main/java/de/jplag/reporting/FilePathUtil.java
+++ b/core/src/main/java/de/jplag/reporting/FilePathUtil.java
@@ -41,7 +41,7 @@ public final class FilePathUtil {
         }
 
         String leftStripped = left;
-        while (leftStripped.endsWith(ZIP_PATH_SEPARATOR) || rightStripped.startsWith(WINDOWS_PATH_SEPARATOR)) {
+        while (leftStripped.endsWith(ZIP_PATH_SEPARATOR) || leftStripped.startsWith(WINDOWS_PATH_SEPARATOR)) {
             leftStripped = leftStripped.substring(0, leftStripped.length() - 1);
         }
 

--- a/core/src/main/java/de/jplag/reporting/FilePathUtil.java
+++ b/core/src/main/java/de/jplag/reporting/FilePathUtil.java
@@ -8,6 +8,7 @@ import de.jplag.Submission;
 
 public final class FilePathUtil {
     private static final String ZIP_PATH_SEPARATOR = "/"; // Paths in zip files are always separated by a slash
+    private static final String WINDOWS_PATH_SEPARATOR = "\\";
 
     private FilePathUtil() {
         // private constructor to prevent instantiation
@@ -35,12 +36,12 @@ public final class FilePathUtil {
      */
     public static String joinZipPathSegments(String left, String right) {
         String rightStripped = right;
-        while (rightStripped.startsWith(ZIP_PATH_SEPARATOR)) {
+        while (rightStripped.startsWith(ZIP_PATH_SEPARATOR) || rightStripped.startsWith(WINDOWS_PATH_SEPARATOR)) {
             rightStripped = rightStripped.substring(1);
         }
 
         String leftStripped = left;
-        while (leftStripped.endsWith(ZIP_PATH_SEPARATOR)) {
+        while (leftStripped.endsWith(ZIP_PATH_SEPARATOR) || rightStripped.startsWith(WINDOWS_PATH_SEPARATOR)) {
             leftStripped = leftStripped.substring(0, leftStripped.length() - 1);
         }
 


### PR DESCRIPTION
There was a bug introduced where on Windows file paths were `Name//FileName`. This caused issues in the report viewer.

This is a hotfix, we need to provide a proper solution in the future.