### PR TITLE
fix broken edge click on cluster chart

### DIFF
--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -286,8 +286,10 @@ const graphOptions = computed(() => {
         router.push({
           name: 'ComparisonView',
           params: {
-            firstId: hoveredEdge.value.firstId,
-            secondId: hoveredEdge.value.secondId
+            comparisonFileName: store().getComparisonFileName(
+              hoveredEdge.value.firstId,
+              hoveredEdge.value.secondId
+            )
           }
         })
       }


### PR DESCRIPTION
Currently clicking the edges in the cluster graph does not redirect to the comparison. 
The issue is because the params of the ComparisonView were changed in #1176 to support opening things in new tabs. This change was not addapted in the cluster graph
