### PR TITLE
Adapt deploy action to also trigger when release drafts are published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Deploy to Maven Central & GitHub
 on:
   workflow_dispatch:
   release:
-    types: [created]
+    types: [created, published]
 jobs:
   publish-maven-central:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Modified the GitHub Actions workflow to include the release event `published` alongside `created` ([see doc](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)). This change ensures that the workflow is triggered not only when a regular release is created but also when a draft release is published.