### PR TITLE
Fixed a bug, where the cpp listener could throw a null pointer exception

### DIFF
--- a/languages/cpp/src/main/java/de/jplag/cpp/CPPListener.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/CPPListener.java
@@ -207,7 +207,7 @@ class CPPListener extends AbstractAntlrListener {
 
         visit(ParameterDeclarationContext.class).map(VARDEF).withSemantics(CodeSemantics::new).onEnter((ctx, varReg) -> {
             // don't register parameters in function declarations, e.g. bc6h_enc lines 117-120
-            if (hasAncestor(ctx, FunctionDefinitionContext.class, SimpleDeclarationContext.class)) {
+            if (hasAncestor(ctx, FunctionDefinitionContext.class, SimpleDeclarationContext.class) && ctx.declarator() != null) {
                 CPP14Parser.PointerDeclaratorContext pd = ctx.declarator().pointerDeclarator();
                 String name = pd.noPointerDeclarator().getText();
                 varReg.registerVariable(name, VariableScope.LOCAL, true);


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

In some cases see #1612 the cpp listener threw a null pointer exception. This PR add a check to prevent that.