### PR TITLE
Hide local files button in VIEW mode

### DIFF
--- a/report-viewer/src/model/factories/BaseFactory.ts
+++ b/report-viewer/src/model/factories/BaseFactory.ts
@@ -55,7 +55,7 @@ export class BaseFactory {
     if (request.status == 200) {
       const blob = await request.blob()
       // Check that file is not the index.html
-      if (blob.type == 'text/html') {
+      if (blob.type.includes('text/html')) {
         throw new Error(`Could not find ${path} in local files.`)
       }
       return blob


### PR DESCRIPTION
using the cli with `-M VIEW` shows a button stating that the user could continue with local files.

This is because the report viewer returns the index.html when the requested file was not found. There was a check for the filetype but it did not account for multiple variants of the `text/html` type.

This PR accounts for multiple variants of this like `text/html; charset=utf-8`