### PR TITLE
fix unhiding through searchbar

### DIFF
--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -64,20 +64,19 @@ const searchStringValue = computed({
     emit('update:searchString', value)
     // Update the anonymous set
 
-    const searches = value
+    const searchParts = value
       .trimEnd()
       .toLowerCase()
       .split(/ +/g)
       .map((s) => s.trim().replace(/,/g, ''))
-    if (searches.length == 0) {
+    if (searchParts.length == 0) {
       return
     }
 
-    for (const search of searches) {
-      for (const submissionId of store().getSubmissionIds) {
-        if (submissionId.toLowerCase() == search) {
-          store().state.anonymous.delete(submissionId)
-        }
+    for (const submissionId of store().getSubmissionIds) {
+      const submissionParts = submissionId.toLowerCase().split(/ +/g)
+      if (submissionParts.every((part) => searchParts.includes(part))) {
+        store().state.anonymous.delete(submissionId)
       }
     }
   }


### PR DESCRIPTION
Currently it was not possible to unhide names that contained spaces through the search bar.

This PR fixes it by also splitting names at spaces and checking if every part of the string is contained in the search string parts.

Fixes #1629 