### PR TITLE
Fix ParsingException in cases of null file parameter

### DIFF
--- a/language-api/src/main/java/de/jplag/ParsingException.java
+++ b/language-api/src/main/java/de/jplag/ParsingException.java
@@ -76,8 +76,9 @@ public class ParsingException extends Exception {
 
     private static String constructMessage(File file, String reason) {
         StringBuilder messageBuilder = new StringBuilder();
-        if (reason == null || !reason.contains(file.toString())) {
-            messageBuilder.append("failed to parse '%s'".formatted(file));
+        String fileName = file == null ? "<null>" : file.toString();
+        if (reason == null || !reason.contains(fileName)) {
+            messageBuilder.append("failed to parse '%s'".formatted(fileName));
         }
         if (reason != null && !reason.isBlank()) {
             messageBuilder.append(reason);


### PR DESCRIPTION
The comment for the constructor indicates that the file parameter can be null, but the constructMessage method will NPE if file is null.

This fixes the following: the 5.0 build crashes for me when running under OpenJDK 22 as follows:

```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.io.File.toString()" because "file" is null
	at de.jplag.ParsingException.constructMessage(ParsingException.java:79)
	at de.jplag.ParsingException.<init>(ParsingException.java:31)
	at de.jplag.java.JavacAdapter.lambda$processErrors$1(JavacAdapter.java:80)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:212)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:194)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1709)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:556)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:546)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:622)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:291)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:631)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:637)
	at java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:642)
	at de.jplag.java.JavacAdapter.processErrors(JavacAdapter.java:81)
	at de.jplag.java.JavacAdapter.parseFiles(JavacAdapter.java:58)
	at de.jplag.java.Parser.parse(Parser.java:24)
	at de.jplag.java.JavaLanguage.parse(JavaLanguage.java:48)
	at de.jplag.Submission.parse(Submission.java:255)
	at de.jplag.SubmissionSet.parseSubmissions(SubmissionSet.java:159)
	at de.jplag.SubmissionSet.parseAllSubmissions(SubmissionSet.java:111)
	at de.jplag.SubmissionSet.<init>(SubmissionSet.java:49)
	at de.jplag.SubmissionSetBuilder.buildSubmissionSet(SubmissionSetBuilder.java:102)
	at de.jplag.JPlag.run(JPlag.java:73)
	at de.jplag.cli.CLI.runJPlag(CLI.java:132)
	at de.jplag.cli.CLI.main(CLI.java:92)
```

<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
