### PR TITLE
Fix report viewer unit test imports

### DIFF
--- a/report-viewer/tsconfig.app.json
+++ b/report-viewer/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": ["@vue/tsconfig/tsconfig.dom.json", "./tsconfig.module.json"],
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "src/**/*.json"],
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "src/**/*.json", "tests/unit/**/*"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
The unit tests were not included in the ts-config. this lead to the typescript/ides not being able to resolve imports that start with `@/`. That made development more tedious than it needed to be.
This pr fixes that