### PR TITLE
show hover text all the time

### DIFF
--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="relative bottom-0 overflow-hidden print:max-h-full print:max-w-full">
-    <div class="flex flex-col print:max-h-full print:max-w-full">
-      <canvas ref="graphCanvas" class="flex-grow print:max-h-full print:max-w-full"></canvas>
-      <div class="mt-8 text-xs font-bold text-gray-500 dark:text-gray-400 print:hidden">
+  <div class="flex max-h-full flex-col overflow-hidden print:max-w-full">
+    <div class="flex max-h-full flex-col overflow-hidden print:max-w-full">
+      <canvas
+        ref="graphCanvas"
+        class="min-h-0 flex-grow print:max-h-full print:max-w-full"
+      ></canvas>
+      <div class="mt-5 text-xs font-bold text-gray-500 dark:text-gray-400 print:hidden">
         <p>Hover over an edge to highlight it in the table.</p>
         <p class="mt-2" v-if="!allComparisonsPresent">
           Not all comparisons of this cluster are present. These comparisons are indicated by the

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -1,13 +1,10 @@
 <template>
-  <div class="print:max-h-full print:max-w-full">
-    <div class="print:max-h-full print:max-w-full">
-      <canvas ref="graphCanvas" class="print:max-h-full print:max-w-full"></canvas>
-      <div
-        v-if="!allComparisonsPresent"
-        class="mt-8 text-xs font-bold text-gray-500 dark:text-gray-400"
-      >
+  <div class="relative bottom-0 overflow-hidden print:max-h-full print:max-w-full">
+    <div class="flex flex-col print:max-h-full print:max-w-full">
+      <canvas ref="graphCanvas" class="flex-grow print:max-h-full print:max-w-full"></canvas>
+      <div class="mt-8 text-xs font-bold text-gray-500 dark:text-gray-400 print:hidden">
         <p>Hover over an edge to highlight it in the table.</p>
-        <p class="mt-2">
+        <p class="mt-2" v-if="!allComparisonsPresent">
           Not all comparisons of this cluster are present. These comparisons are indicated by the
           dashed lines. <br />
           To include more comparisons, increase the number of increased comparisons in the CLI.

--- a/report-viewer/src/components/ClusterRadarChart.vue
+++ b/report-viewer/src/components/ClusterRadarChart.vue
@@ -15,7 +15,7 @@
       <div class="flex min-h-0 flex-grow justify-center">
         <Radar :data="chartData" :options="radarChartOptions" />
       </div>
-      <div class="text-xs font-bold text-gray-500 dark:text-gray-400">
+      <div class="text-xs font-bold text-gray-500 dark:text-gray-400 print:hidden">
         <p>
           This Chart shows the average similarity of the selected submission to the other
           submissions in the cluster. <br />


### PR DESCRIPTION
The text on the cluster graph has two bugs:

- The text stating that you could hover over eged was hidden when all comparisons were included in the report
- The text could be cut off, if the window had the wrong format, since the cluster took the whole height.

These two are now fixed