### PR TITLE
Added generic catch clause in the c language module

### DIFF
--- a/languages/c/src/main/java/de/jplag/c/Scanner.java
+++ b/languages/c/src/main/java/de/jplag/c/Scanner.java
@@ -26,7 +26,13 @@ public class Scanner extends AbstractParser {
         for (File file : files) {
             this.currentFile = file;
             logger.trace("Scanning file {}", currentFile);
-            CPPScanner.scanFile(file, this);
+            try {
+                CPPScanner.scanFile(file, this);
+            } catch (ParsingException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new ParsingException(file, "Unexpected error during parsing.\n" + e.getMessage(), e);
+            }
             tokens.add(Token.fileEnd(currentFile));
         }
         return tokens;

--- a/languages/c/src/main/java/de/jplag/c/Scanner.java
+++ b/languages/c/src/main/java/de/jplag/c/Scanner.java
@@ -31,7 +31,7 @@ public class Scanner extends AbstractParser {
             } catch (ParsingException e) {
                 throw e;
             } catch (Exception e) {
-                throw new ParsingException(file, "Unexpected error during parsing.\n" + e.getMessage(), e);
+                throw new ParsingException(file, "Unexpected error during parsing." + System.lineSeparator() + e.getMessage(), e);
             }
             tokens.add(Token.fileEnd(currentFile));
         }


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
Makes sure all exceptions thrown by the Java-CC parser are caught and wrapped in a JPlag exception. This ensures, that the exception shown to the user contains the file, that the parser to fail.

Similar to #1480