### PR TITLE
Added related submission table to cluster view

### DIFF
--- a/report-viewer/src/components/TabbedContainer.vue
+++ b/report-viewer/src/components/TabbedContainer.vue
@@ -26,8 +26,8 @@
         class="flex-1 border-b border-container-border-light dark:border-container-border-dark"
       ></div>
     </div>
-    <div class="flex-1 overflow-hidden p-2">
-      <slot :name="selectedTab"></slot>
+    <div class="flex-1 flex-col overflow-hidden p-2">
+      <slot :name="selectedTab.replace(/\s/g, '-')"></slot>
     </div>
   </ContainerComponent>
 </template>

--- a/report-viewer/src/components/TabbedContainer.vue
+++ b/report-viewer/src/components/TabbedContainer.vue
@@ -1,0 +1,67 @@
+<template>
+  <ContainerComponent class="flex flex-col overflow-hidden !p-0">
+    <div class="flex w-full bg-container-secondary-light dark:bg-container-secondary-dark">
+      <div
+        v-for="index in Array(props.tabs.length).keys()"
+        class="cursor-pointer border-r border-container-border-light dark:border-container-border-dark"
+        @click="selectedTab = tabNames[index]"
+        :key="index"
+        :class="
+          tabNames[index] == selectedTab
+            ? 'border-b-0 bg-container-light dark:bg-container-dark'
+            : 'border-b bg-container-secondary-light dark:bg-container-secondary-dark'
+        "
+      >
+        <ToolTipComponent v-if="toolTips[index]" :direction="index < 2 ? 'right' : 'bottom'">
+          <template #default>
+            <p class="p-2 px-5">{{ tabNames[index] }}</p>
+          </template>
+          <template #tooltip>
+            <p class="whitespace-pre text-sm">{{ toolTips[index] }}</p>
+          </template>
+        </ToolTipComponent>
+        <p v-else class="p-2 px-5">{{ tabNames[index] }}</p>
+      </div>
+      <div
+        class="flex-1 border-b border-container-border-light dark:border-container-border-dark"
+      ></div>
+    </div>
+    <div class="flex-1 overflow-hidden p-2">
+      <slot :name="selectedTab"></slot>
+    </div>
+  </ContainerComponent>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, type Ref } from 'vue'
+import ContainerComponent from './ContainerComponent.vue'
+import type { ToolTipLabel } from '@/model/ui/ToolTip'
+import ToolTipComponent from './ToolTipComponent.vue'
+
+const props = defineProps({
+  tabs: {
+    type: Array<string | ToolTipLabel>,
+    required: true
+  }
+})
+
+const tabNames = computed(() =>
+  props.tabs.map((tab) => (typeof tab === 'string' ? tab : tab.displayValue))
+)
+const toolTips = computed(() =>
+  props.tabs.map((tab) => (typeof tab === 'string' ? null : tab.tooltip))
+)
+
+const _selectedTab: Ref<string | null> = ref(null)
+const selectedTab = computed({
+  set(value: string) {
+    _selectedTab.value = value
+  },
+  get() {
+    if (!_selectedTab.value) {
+      return tabNames.value[0]
+    }
+    return _selectedTab.value
+  }
+})
+</script>

--- a/report-viewer/src/components/TabbedContainer.vue
+++ b/report-viewer/src/components/TabbedContainer.vue
@@ -12,7 +12,10 @@
             : 'border-b bg-container-secondary-light dark:bg-container-secondary-dark'
         "
       >
-        <ToolTipComponent v-if="toolTips[index]" :direction="index < 2 ? 'right' : 'bottom'">
+        <ToolTipComponent
+          v-if="toolTips[index]"
+          :direction="index < firstBottomTooltipIndex ? 'right' : 'bottom'"
+        >
           <template #default>
             <p class="p-2 px-5">{{ tabNames[index] }}</p>
           </template>
@@ -42,6 +45,11 @@ const props = defineProps({
   tabs: {
     type: Array<string | ToolTipLabel>,
     required: true
+  },
+  firstBottomTooltipIndex: {
+    type: Number,
+    required: false,
+    default: 2
   }
 })
 

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -16,25 +16,12 @@
     >
       <Container
         class="flex max-h-0 min-h-full flex-1 flex-col overflow-hidden print:max-h-none print:min-h-0 print:flex-none"
+        v-if="cluster.members.length >= 35 || !canShowRadarChart"
       >
         <div
           class="flex max-h-full flex-col overflow-hidden print:flex-none"
           v-if="cluster.members.length < 35"
         >
-          <OptionsSelectorComponent
-            :labels="clusterVisualizationOptions"
-            @selectionChanged="
-              (index) => (selectedClusterVisualization = index == 0 ? 'Graph' : 'Radar')
-            "
-            title="Cluster Visualization:"
-            class="mb-3"
-            v-if="canShowRadarChart"
-          />
-          <ClusterRadarChart
-            v-if="selectedClusterVisualization == 'Radar'"
-            :cluster="clusterListElement"
-            class="flex-grow"
-          />
           <ClusterGraph
             v-if="selectedClusterVisualization == 'Graph'"
             :cluster="clusterListElement"
@@ -51,6 +38,23 @@
           </p>
         </div>
       </Container>
+      <TabbedContainer
+        class="flex max-h-0 min-h-full flex-1 flex-col overflow-hidden print:max-h-none print:min-h-0 print:flex-none"
+        :tabs="clusterVisualizationOptions"
+        v-else
+      >
+        <template #Graph>
+          <ClusterGraph
+            :cluster="clusterListElement"
+            class="flex-grow print:max-h-full print:max-w-full print:flex-grow-0"
+            @line-hovered="(value) => (highlightedElement = value)"
+          />
+        </template>
+        <template #Radar>
+          <ClusterRadarChart :cluster="clusterListElement" class="flex-grow" />
+        </template>
+      </TabbedContainer>
+
       <TabbedContainer
         class="flex max-h-0 min-h-full w-1/3 flex-col space-y-2 print:hidden"
         :tabs="['Members', 'Similar Comparisons']"
@@ -93,7 +97,6 @@ import type { ClusterListElement, ClusterListElementMember } from '@/model/Clust
 import { MetricType } from '@/model/MetricType'
 import type { Overview } from '@/model/Overview'
 import { computed, ref, onErrorCaptured, type PropType, type Ref } from 'vue'
-import OptionsSelectorComponent from '@/components/optionsSelectors/OptionsSelectorComponent.vue'
 import { redirectOnError } from '@/router'
 import TabbedContainer from '@/components/TabbedContainer.vue'
 

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -51,21 +51,33 @@
           </p>
         </div>
       </Container>
-      <Container class="flex max-h-0 min-h-full w-1/3 flex-col space-y-2 print:hidden">
-        <ComparisonsTable
-          :topComparisons="comparisons"
-          class="min-h-0 flex-1"
-          header="Comparisons of Cluster Members:"
-          :highlighted-row-ids="highlightedElement ?? undefined"
-        >
-          <template #footer v-if="comparisons.length < maxAmountOfComparisonsInCluster">
-            <p class="w-full pt-1 text-center font-bold">
-              Not all comparisons inside the cluster are shown. To see more, re-run JPlag with a
-              higher maximum number argument.
-            </p>
-          </template>
-        </ComparisonsTable>
-      </Container>
+      <TabbedContainer
+        class="flex max-h-0 min-h-full w-1/3 flex-col space-y-2 print:hidden"
+        :tabs="['Members', 'Similar Comparisons']"
+      >
+        <template #Members>
+          <ComparisonsTable
+            :topComparisons="comparisons"
+            class="max-h-0 min-h-full flex-1 overflow-hidden"
+            header="Comparisons of Cluster Members:"
+            :highlighted-row-ids="highlightedElement ?? undefined"
+          >
+            <template #footer v-if="comparisons.length < maxAmountOfComparisonsInCluster">
+              <p class="w-full pt-1 text-center font-bold">
+                Not all comparisons inside the cluster are shown. To see more, re-run JPlag with a
+                higher maximum number argument.
+              </p>
+            </template>
+          </ComparisonsTable>
+        </template>
+        <template #Similar-Comparisons>
+          <ComparisonsTable
+            :topComparisons="closeComparisons"
+            class="max-h-0 min-h-full flex-1 overflow-hidden"
+            header="Comparisons close to the Cluster:"
+          />
+        </template>
+      </TabbedContainer>
     </div>
   </div>
 </template>
@@ -78,12 +90,12 @@ import Container from '@/components/ContainerComponent.vue'
 import TextInformation from '@/components/TextInformation.vue'
 import type { Cluster } from '@/model/Cluster'
 import type { ClusterListElement, ClusterListElementMember } from '@/model/ClusterListElement'
-import type { ComparisonListElement } from '@/model/ComparisonListElement'
 import { MetricType } from '@/model/MetricType'
 import type { Overview } from '@/model/Overview'
 import { computed, ref, onErrorCaptured, type PropType, type Ref } from 'vue'
 import OptionsSelectorComponent from '@/components/optionsSelectors/OptionsSelectorComponent.vue'
 import { redirectOnError } from '@/router'
+import TabbedContainer from '@/components/TabbedContainer.vue'
 
 const props = defineProps({
   overview: {
@@ -96,7 +108,6 @@ const props = defineProps({
   }
 })
 
-const comparisons = [] as Array<ComparisonListElement>
 const clusterMemberList = new Map() as ClusterListElementMember
 const selectedClusterVisualization: Ref<'Graph' | 'Radar'> = ref('Graph')
 const clusterVisualizationOptions = [
@@ -112,24 +123,33 @@ const clusterVisualizationOptions = [
 ]
 const usedMetric = MetricType.AVERAGE
 
-function getComparisonFor(id1: string, id2: string) {
-  return props.overview.topComparisons.find(
+const comparisons = computed(() =>
+  props.overview.topComparisons.filter(
     (c) =>
-      (c.firstSubmissionId === id1 && c.secondSubmissionId === id2) ||
-      (c.firstSubmissionId === id2 && c.secondSubmissionId === id1)
+      props.cluster.members.includes(c.firstSubmissionId) &&
+      props.cluster.members.includes(c.secondSubmissionId)
   )
-}
+)
 
-for (let i = 0; i < props.cluster.members.length; i++) {
-  for (let j = i + 1; j < props.cluster.members.length; j++) {
-    const comparison = getComparisonFor(props.cluster.members[i], props.cluster.members[j])
-    if (comparison) {
-      comparisons.push(comparison)
-    }
-  }
-}
 let counter = 0
-comparisons
+comparisons.value
+  .sort((a, b) => b.similarities[usedMetric] - a.similarities[usedMetric])
+  .forEach((c) => {
+    c.sortingPlace = counter++
+    c.id = counter
+  })
+
+const closeComparisons = computed(() =>
+  props.overview.topComparisons.filter(
+    (c) =>
+      (props.cluster.members.includes(c.firstSubmissionId) &&
+        !props.cluster.members.includes(c.secondSubmissionId)) ||
+      (!props.cluster.members.includes(c.firstSubmissionId) &&
+        props.cluster.members.includes(c.secondSubmissionId))
+  )
+)
+counter = 0
+closeComparisons.value
   .sort((a, b) => b.similarities[usedMetric] - a.similarities[usedMetric])
   .forEach((c) => {
     c.sortingPlace = counter++
@@ -138,7 +158,7 @@ comparisons
 
 for (const member of props.cluster.members) {
   const membersComparisons: { matchedWith: string; similarity: number }[] = []
-  comparisons
+  comparisons.value
     .filter((c) => c.firstSubmissionId === member || c.secondSubmissionId === member)
     .forEach((c) => {
       membersComparisons.push({

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -75,11 +75,11 @@
             </template>
           </ComparisonsTable>
         </template>
-        <template #Similar-Comparisons>
+        <template #Related-Comparisons>
           <ComparisonsTable
-            :topComparisons="closeComparisons"
+            :topComparisons="relatedComparisons"
             class="max-h-0 min-h-full flex-1 overflow-hidden"
-            header="Comparisons close to the Cluster:"
+            header="Comparisons related to the Cluster:"
           />
         </template>
       </TabbedContainer>
@@ -131,7 +131,7 @@ const comparisonTableOptions = [
     tooltip: 'Comparisons between the cluster members.'
   },
   {
-    displayValue: 'Similar Comparisons',
+    displayValue: 'Related Comparisons',
     tooltip: 'Comparisons between the cluster members\nand other submissions.'
   }
 ]
@@ -153,7 +153,7 @@ comparisons.value
     c.id = counter
   })
 
-const closeComparisons = computed(() =>
+const relatedComparisons = computed(() =>
   props.overview.topComparisons.filter(
     (c) =>
       (props.cluster.members.includes(c.firstSubmissionId) &&
@@ -163,7 +163,7 @@ const closeComparisons = computed(() =>
   )
 )
 counter = 0
-closeComparisons.value
+relatedComparisons.value
   .sort((a, b) => b.similarities[usedMetric] - a.similarities[usedMetric])
   .forEach((c) => {
     c.sortingPlace = counter++

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -57,7 +57,8 @@
 
       <TabbedContainer
         class="flex max-h-0 min-h-full w-1/3 flex-col space-y-2 print:hidden"
-        :tabs="['Members', 'Similar Comparisons']"
+        :tabs="comparisonTableOptions"
+        :first-bottom-tooltip-index="1"
       >
         <template #Members>
           <ComparisonsTable
@@ -122,6 +123,16 @@ const clusterVisualizationOptions = [
     displayValue: 'Radar',
     tooltip:
       'A radar chart showing the he other submissions in the cluster, relative one submission.'
+  }
+]
+const comparisonTableOptions = [
+  {
+    displayValue: 'Members',
+    tooltip: 'Comparisons between the cluster members.'
+  },
+  {
+    displayValue: 'Similar Comparisons',
+    tooltip: 'Comparisons between the cluster members\nand other submissions.'
   }
 ]
 const usedMetric = MetricType.AVERAGE


### PR DESCRIPTION
This PR adds a second table to the cluster view. It is accissible by switching the tab of the container.
The table contains all comparisons where exectly one of the two members is part of the cluster.

![grafik](https://github.com/jplag/JPlag/assets/39801116/284ca041-5bf9-4a30-b4ea-a32a27e6640d)

This PR also changed the container with the cluster visualizations to use the new TabbedContainer instead of the selectors at the top

closes #1602