### PR TITLE
Update the location of sortAlgo resources

### DIFF
--- a/docs/5.-End-to-End-Testing.md
+++ b/docs/5.-End-to-End-Testing.md
@@ -31,7 +31,7 @@ adding/removing comments to architectural changes in the deliverables.
 These changes were now transferred to a base class and thus the plagiarism was created. The named base class was provided with the individual changes. The numbers in the list shown above are intended for the traceability of the test data. Here the test data filenames were named with the respective changes. Example: SortAlgo4d1 contains the changes "Variable declaration at the beginning of the program". If several points are combined, this is separated by "_" e.g.: SortAlgo1_3 contains "(1) Inserting comments or empty lines" and "(3) Insertion of unnecessary or changed code lines".
 
 The following code examples show how these changes affect the program code and also how the detection of JPLag behaves.
-All the code examples shown and more can be found at [testdata-resources-SortAlgo](https://github.com/jplag/JPlag/tree/main/endtoend-testing/src/test/resources/languageTestFiles/java/sortAlgo).
+All the code examples shown and more can be found at [testdata-resources-SortAlgo](https://github.com/jplag/JPlag/tree/main/endtoend-testing/src/test/resources/data/sortAlgo).
 
 ### (1) Inserting comments or empty lines
 


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->
**PR Summary**:
PR #1279 moved the location of `sortAlgo` from `resources/languageTestFiles/java` to `resources/data`. This PR adjusts the sources to changes.