### PR TITLE
Character precise matches

### DIFF
--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -105,12 +105,23 @@ public class ComparisonReportWriter {
         Token startOfSecond = tokensSecond.stream().min(lineComparator).orElseThrow();
         Token endOfSecond = tokensSecond.stream().max(lineComparator).orElseThrow();
 
-        return new Match(
-                FilePathUtil.getRelativeSubmissionPath(startOfFirst.getFile(), comparison.firstSubmission(), submissionToIdFunction).toString(),
-                FilePathUtil.getRelativeSubmissionPath(startOfSecond.getFile(), comparison.secondSubmission(), submissionToIdFunction).toString(),
-                startOfFirst.getLine(), startOfFirst.getColumn(), endOfFirst.getLine(), endOfFirst.getColumn() + endOfFirst.getLength(),
-                startOfSecond.getLine(), startOfSecond.getColumn(), endOfSecond.getLine(), endOfSecond.getColumn() + endOfSecond.getLength(),
-                match.length());
+        String firstFileName = FilePathUtil.getRelativeSubmissionPath(startOfFirst.getFile(), comparison.firstSubmission(), submissionToIdFunction)
+                .toString();
+        String secondFileName = FilePathUtil.getRelativeSubmissionPath(startOfSecond.getFile(), comparison.secondSubmission(), submissionToIdFunction)
+                .toString();
+
+        int startLineFirst = startOfFirst.getLine();
+        int startColumnFirst = startOfFirst.getColumn();
+        int endLineFirst = endOfFirst.getLine();
+        int endColumnFirst = endOfFirst.getColumn() + endOfFirst.getLength();
+
+        int startLineSecond = startOfSecond.getLine();
+        int startColumnSecond = startOfSecond.getColumn();
+        int endLineSecond = endOfSecond.getLine();
+        int endColumnSecond = endOfSecond.getColumn() + endOfSecond.getLength();
+
+        return new Match(firstFileName, secondFileName, startLineFirst, startColumnFirst, endLineFirst, endColumnFirst, startLineSecond,
+                startColumnSecond, endLineSecond, endColumnSecond, match.length());
     }
 
 }

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -113,12 +113,12 @@ public class ComparisonReportWriter {
         int startLineFirst = startOfFirst.getLine();
         int startColumnFirst = startOfFirst.getColumn();
         int endLineFirst = endOfFirst.getLine();
-        int endColumnFirst = endOfFirst.getColumn() + endOfFirst.getLength();
+        int endColumnFirst = endOfFirst.getColumn() + endOfFirst.getLength() - 1;
 
         int startLineSecond = startOfSecond.getLine();
         int startColumnSecond = startOfSecond.getColumn();
         int endLineSecond = endOfSecond.getLine();
-        int endColumnSecond = endOfSecond.getColumn() + endOfSecond.getLength();
+        int endColumnSecond = endOfSecond.getColumn() + endOfSecond.getLength() - 1;
 
         return new Match(firstFileName, secondFileName, startLineFirst, startColumnFirst, endLineFirst, endColumnFirst, startLineSecond,
                 startColumnSecond, endLineSecond, endColumnSecond, match.length());

--- a/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/ComparisonReportWriter.java
@@ -98,7 +98,7 @@ public class ComparisonReportWriter {
         List<Token> tokensFirst = comparison.firstSubmission().getTokenList().subList(match.startOfFirst(), match.endOfFirst() + 1);
         List<Token> tokensSecond = comparison.secondSubmission().getTokenList().subList(match.startOfSecond(), match.endOfSecond() + 1);
 
-        Comparator<? super Token> lineComparator = Comparator.comparingInt(Token::getLine);
+        Comparator<? super Token> lineComparator = Comparator.comparingInt(Token::getLine).thenComparingInt(Token::getColumn);
 
         Token startOfFirst = tokensFirst.stream().min(lineComparator).orElseThrow();
         Token endOfFirst = tokensFirst.stream().max(lineComparator).orElseThrow();
@@ -108,7 +108,9 @@ public class ComparisonReportWriter {
         return new Match(
                 FilePathUtil.getRelativeSubmissionPath(startOfFirst.getFile(), comparison.firstSubmission(), submissionToIdFunction).toString(),
                 FilePathUtil.getRelativeSubmissionPath(startOfSecond.getFile(), comparison.secondSubmission(), submissionToIdFunction).toString(),
-                startOfFirst.getLine(), endOfFirst.getLine(), startOfSecond.getLine(), endOfSecond.getLine(), match.length());
+                startOfFirst.getLine(), startOfFirst.getColumn(), endOfFirst.getLine(), endOfFirst.getColumn() + endOfFirst.getLength(),
+                startOfSecond.getLine(), startOfSecond.getColumn(), endOfSecond.getLine(), endOfSecond.getColumn() + endOfSecond.getLength(),
+                match.length());
     }
 
 }

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/Match.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/Match.java
@@ -3,6 +3,8 @@ package de.jplag.reporting.reportobject.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record Match(@JsonProperty("file1") String firstFileName, @JsonProperty("file2") String secondFileName,
-        @JsonProperty("start1") int startInFirst, @JsonProperty("end1") int endInFirst, @JsonProperty("start2") int startInSecond,
-        @JsonProperty("end2") int endInSecond, @JsonProperty("tokens") int tokens) {
+        @JsonProperty("start1") int startInFirst, @JsonProperty("start1_col") int startColumnInFirst, @JsonProperty("end1") int endInFirst,
+        @JsonProperty("end1_col") int endColumnInFirst, @JsonProperty("start2") int startInSecond,
+        @JsonProperty("start2_col") int startColumnInSecond, @JsonProperty("end2") int endInSecond, @JsonProperty("end2_col") int endColumnInSecond,
+        @JsonProperty("tokens") int tokens) {
 }

--- a/report-viewer/src/components/fileDisplaying/CodeLine.vue
+++ b/report-viewer/src/components/fileDisplaying/CodeLine.vue
@@ -141,7 +141,7 @@ function getNextLinePartTillColumn(endCol: number) {
     } else if (props.line[lineIndex.value] == '\t') {
       part += '    '
       lineIndex.value++
-      colIndex.value++
+      colIndex.value += 8
     } else {
       part += props.line[lineIndex.value]
       lineIndex.value++

--- a/report-viewer/src/components/fileDisplaying/CodeLine.vue
+++ b/report-viewer/src/components/fileDisplaying/CodeLine.vue
@@ -1,0 +1,156 @@
+<template>
+  <div
+    class="col-span-1 col-start-2 row-span-1 flex w-full cursor-default"
+    :class="{ 'cursor-pointer': matches.length > 0 }"
+    :style="{
+      gridRowStart: lineNumber
+    }"
+  >
+    <div
+      v-for="(part, index) in parts"
+      :key="index"
+      class="h-full last:flex-1"
+      @click="matchSelected(part.match)"
+      :style="{
+        background:
+          part.match != undefined
+            ? getMatchColor(0.3, part.match.match.colorIndex)
+            : 'hsla(0, 0%, 0%, 0)'
+      }"
+    >
+      <pre
+        v-html="part.line"
+        class="code-font print-excact break-child !bg-transparent print:whitespace-pre-wrap"
+      ></pre>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { MatchInSingleFile } from '@/model/MatchInSingleFile'
+import { getMatchColor } from '@/utils/ColorUtils'
+import { ref } from 'vue'
+
+const props = defineProps({
+  lineNumber: {
+    type: Number,
+    required: true
+  },
+  line: {
+    type: String,
+    required: true
+  },
+  matches: {
+    type: Array<MatchInSingleFile>,
+    required: true
+  }
+})
+
+const emit = defineEmits(['matchSelected'])
+
+function matchSelected(match?: MatchInSingleFile) {
+  if (match) {
+    emit('matchSelected', match)
+  }
+}
+
+interface MatchPart {
+  start: number
+  end: number
+  match?: MatchInSingleFile
+}
+
+interface Part extends MatchPart {
+  line: string
+}
+let lineIndex = ref(0)
+let colIndex = ref(0)
+
+function compParts() {
+  if (props.matches.length == 0) {
+    return [{ line: props.line, start: 0, end: props.line.length }]
+  }
+
+  const sortedMatches = Array.from(props.matches)
+    .sort((a, b) => a.startColumn - b.startColumn)
+    .sort((a, b) => a.start - b.start)
+  let matchParts: MatchPart[] = []
+
+  if (sortedMatches[0].start == props.lineNumber && sortedMatches[0].startColumn > 0) {
+    const end = sortedMatches[0].startColumn - 1
+    matchParts.push({ start: 0, end: end })
+  }
+
+  const start = sortedMatches[0].start == props.lineNumber ? sortedMatches[0].startColumn : 0
+  const end =
+    sortedMatches[0].end == props.lineNumber ? sortedMatches[0].endColumn : props.line.length
+  matchParts.push({ start: start, end: end, match: sortedMatches[0] })
+
+  let matchIndex = 1
+  while (matchIndex < sortedMatches.length) {
+    const match = sortedMatches[matchIndex]
+    const prevMatchPart = matchParts[matchIndex - 1]
+    if (prevMatchPart.end + 1 < match.startColumn) {
+      const end = match.startColumn - 1
+      matchParts.push({ start: prevMatchPart.end + 1, end: end })
+    }
+    const end = match.end == props.lineNumber ? match.endColumn : props.line.length
+    matchParts.push({ start: match.startColumn, end: end, match })
+    matchIndex++
+  }
+
+  if (matchParts[matchParts.length - 1].end < props.line.length) {
+    matchParts.push({ start: matchParts[matchParts.length - 1].end + 1, end: props.line.length })
+  }
+
+  let parts: Part[] = []
+  lineIndex.value = 0
+  colIndex.value = 0
+
+  for (let i = 0; i < matchParts.length; i++) {
+    const matchPart = matchParts[i]
+    const line = getNextLinePartTill(matchPart.end)
+    parts.push({ line, ...matchPart })
+  }
+
+  return parts
+}
+
+const parts = compParts()
+
+function getNextLinePartTill(endCol: number) {
+  let part = ''
+  while (colIndex.value <= endCol && lineIndex.value < props.line.length) {
+    if (props.line[lineIndex.value] == '<') {
+      while (props.line[lineIndex.value] != '>') {
+        part += props.line[lineIndex.value]
+        lineIndex.value++
+      }
+      part += props.line[lineIndex.value]
+      lineIndex.value++
+    } else if (props.line[lineIndex.value] == '\t') {
+      part += '    '
+      lineIndex.value++
+      colIndex.value++
+    } else {
+      part += props.line[lineIndex.value]
+      lineIndex.value++
+      colIndex.value++
+    }
+  }
+  return part
+}
+</script>
+
+<style scoped>
+.code-font {
+  font-family: 'JetBrains Mono NL', monospace !important;
+}
+
+@media print {
+  .break-child *,
+  .break-child {
+    word-break: break-word;
+  }
+}
+</style>

--- a/report-viewer/src/components/fileDisplaying/CodeLine.vue
+++ b/report-viewer/src/components/fileDisplaying/CodeLine.vue
@@ -117,8 +117,7 @@ function computeTextParts() {
   lineIndex.value = 0
   colIndex.value = 0
 
-  for (let i = 0; i < lineParts.length; i++) {
-    const matchPart = lineParts[i]
+  for (const matchPart of lineParts) {
     const line = getNextLinePartTillColumn(matchPart.end)
     textParts.push({ line, match: matchPart.match })
   }

--- a/report-viewer/src/components/fileDisplaying/CodeLine.vue
+++ b/report-viewer/src/components/fileDisplaying/CodeLine.vue
@@ -5,11 +5,12 @@
     :style="{
       gridRowStart: lineNumber
     }"
+    ref="lineRef"
   >
     <div
       v-for="(part, index) in textParts"
       :key="index"
-      class="h-full last:flex-1"
+      class="print-excact h-full last:flex-1"
       @click="matchSelected(part.match)"
       :style="{
         background:
@@ -50,9 +51,19 @@ const emit = defineEmits(['matchSelected'])
 
 function matchSelected(match?: MatchInSingleFile) {
   if (match) {
-    emit('matchSelected', match)
+    emit('matchSelected', match.match)
   }
 }
+
+const lineRef = ref<HTMLElement | null>(null)
+
+function scrollTo() {
+  if (lineRef.value) {
+    lineRef.value.scrollIntoView({ block: 'center' })
+  }
+}
+
+defineExpose({ scrollTo })
 
 interface TextPart {
   line: string

--- a/report-viewer/src/components/fileDisplaying/CodeLine.vue
+++ b/report-viewer/src/components/fileDisplaying/CodeLine.vue
@@ -131,6 +131,7 @@ const textParts = computeTextParts()
 function getNextLinePartTillColumn(endCol: number) {
   let part = ''
   while (colIndex.value <= endCol && lineIndex.value < props.line.length) {
+    // spans from highlighting do not count as characters in the code
     if (props.line[lineIndex.value] == '<') {
       while (props.line[lineIndex.value] != '>') {
         part += props.line[lineIndex.value]
@@ -139,9 +140,18 @@ function getNextLinePartTillColumn(endCol: number) {
       part += props.line[lineIndex.value]
       lineIndex.value++
     } else if (props.line[lineIndex.value] == '\t') {
+      // display tabs properly
       part += '    '
       lineIndex.value++
       colIndex.value += 8
+    } else if (props.line[lineIndex.value] == '&') {
+      // html escape characters for e.g. <,>,&
+      while (props.line[lineIndex.value] != ';') {
+        part += props.line[lineIndex.value]
+        lineIndex.value++
+      }
+      lineIndex.value++
+      colIndex.value++
     } else {
       part += props.line[lineIndex.value]
       lineIndex.value++

--- a/report-viewer/src/components/fileDisplaying/CodePanel.vue
+++ b/report-viewer/src/components/fileDisplaying/CodePanel.vue
@@ -44,7 +44,7 @@
             :line="line.line"
             :lineNumber="index + 1"
             :matches="line.matches"
-            @matchSelected="matchSelected"
+            @matchSelected="(match) => matchSelected(match)"
           />
         </div>
 
@@ -94,7 +94,7 @@ const props = defineProps({
 const emit = defineEmits(['matchSelected'])
 
 const collapsed = ref(true)
-const lineRefs = ref<HTMLElement[]>([])
+const lineRefs = ref<(typeof CodeLine)[]>([])
 
 const codeLines: Ref<{ line: string; matches: MatchInSingleFile[] }[]> = computed(() =>
   highlight(props.file.data, props.highlightLanguage).map((line, index) => {
@@ -116,7 +116,7 @@ function matchSelected(match: Match) {
 function scrollTo(lineNumber: number) {
   collapsed.value = false
   nextTick(function () {
-    lineRefs.value[lineNumber - 1].scrollIntoView({ block: 'center' })
+    lineRefs.value[lineNumber - 1].scrollTo()
   })
 }
 

--- a/report-viewer/src/components/fileDisplaying/CodePanel.vue
+++ b/report-viewer/src/components/fileDisplaying/CodePanel.vue
@@ -22,39 +22,31 @@
 
     <div class="mx-1 overflow-x-auto print:!mx-0 print:overflow-x-hidden">
       <div class="print:display-initial w-fit min-w-full !text-xs" :class="{ hidden: collapsed }">
-        <table
+        <div
           v-if="file.data.trim() !== ''"
-          class="w-full print:table-auto"
-          :aria-describedby="`Content of file ${file.fileName}`"
+          class="grid w-full grid-cols-[auto_1fr] gap-x-2 print:table-auto"
         >
+          <div
+            v-for="(_, index) in codeLines"
+            :key="index"
+            class="col-span-1 col-start-1 row-span-1 text-right"
+            :style="{
+              gridRowStart: index + 1
+            }"
+          >
+            {{ index + 1 }}
+          </div>
           <!-- One row in table per code line -->
-          <tr
+          <CodeLine
             v-for="(line, index) in codeLines"
             :key="index"
-            class="w-full cursor-default"
-            :class="{ 'cursor-pointer': line.match !== null }"
-            @click="lineSelected(index)"
-          >
-            <!-- Line number -->
-            <td class="float-right pr-3">{{ index + 1 }}</td>
-            <!-- Code line -->
-            <td
-              class="print-excact w-full"
-              :style="{
-                background:
-                  line.match !== null
-                    ? getMatchColor(0.3, line.match.colorIndex)
-                    : 'hsla(0, 0%, 0%, 0)'
-              }"
-            >
-              <pre
-                v-html="line.line"
-                class="code-font print-excact break-child !bg-transparent print:whitespace-pre-wrap"
-                ref="lineRefs"
-              ></pre>
-            </td>
-          </tr>
-        </table>
+            ref="lineRefs"
+            :line="line.line"
+            :lineNumber="index + 1"
+            :matches="line.matches"
+            @matchSelected="matchSelected"
+          />
+        </div>
 
         <div v-else class="flex flex-col items-start overflow-x-auto">
           <i>Empty File</i>
@@ -68,12 +60,12 @@
 import type { MatchInSingleFile } from '@/model/MatchInSingleFile'
 import { ref, nextTick, type PropType, computed, type Ref } from 'vue'
 import Interactable from '../InteractableComponent.vue'
-import type { Match } from '@/model/Match'
 import type { SubmissionFile } from '@/model/File'
 import { highlight } from '@/utils/CodeHighlighter'
 import type { Language } from '@/model/Language'
-import { getMatchColor } from '@/utils/ColorUtils'
 import ToolTipComponent from '../ToolTipComponent.vue'
+import CodeLine from './CodeLine.vue'
+import type { Match } from '@/model/Match'
 
 const props = defineProps({
   /**
@@ -99,24 +91,22 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['lineSelected'])
+const emit = defineEmits(['matchSelected'])
 
 const collapsed = ref(true)
 const lineRefs = ref<HTMLElement[]>([])
 
-const codeLines: Ref<{ line: string; match: null | Match }[]> = computed(() =>
+const codeLines: Ref<{ line: string; matches: MatchInSingleFile[] }[]> = computed(() =>
   highlight(props.file.data, props.highlightLanguage).map((line, index) => {
     return {
       line,
-      match: props.matches?.find((m) => m.start <= index + 1 && index + 1 <= m.end)?.match ?? null
+      matches: props.matches?.filter((m) => m.start <= index + 1 && index + 1 <= m.end) ?? []
     }
   })
 )
 
-function lineSelected(lineIndex: number) {
-  if (codeLines.value[lineIndex].match !== null) {
-    emit('lineSelected', codeLines.value[lineIndex].match)
-  }
+function matchSelected(match: Match) {
+  emit('matchSelected', match)
 }
 
 /**
@@ -154,16 +144,3 @@ function getFileDisplayName(file: SubmissionFile): string {
     : file.fileName
 }
 </script>
-
-<style scoped>
-.code-font {
-  font-family: 'JetBrains Mono NL', monospace !important;
-}
-
-@media print {
-  .break-child *,
-  .break-child {
-    word-break: break-word;
-  }
-}
-</style>

--- a/report-viewer/src/components/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/src/components/fileDisplaying/FilesContainer.vue
@@ -28,7 +28,7 @@
             !matches.get(file.fileName) ? [] : (matches.get(file.fileName) as MatchInSingleFile[])
           "
           :highlight-language="highlightLanguage"
-          @line-selected="(match) => $emit('lineSelected', match)"
+          @match-selected="(match) => $emit('matchSelected', match)"
           class="mt-1 first:mt-0"
         />
       </VueDraggableNext>
@@ -83,7 +83,7 @@ const props = defineProps({
   }
 })
 
-defineEmits(['lineSelected'])
+defineEmits(['matchSelected'])
 
 const codePanels: Ref<(typeof CodePanel)[]> = ref([])
 

--- a/report-viewer/src/model/Match.ts
+++ b/report-viewer/src/model/Match.ts
@@ -13,9 +13,13 @@ export interface Match {
   firstFile: string
   secondFile: string
   startInFirst: number
+  startColumnInFirst: number
   endInFirst: number
+  endColumnInFirst: number
   startInSecond: number
+  startColumnInSecond: number
   endInSecond: number
+  endColumnInSecond: number
   tokens: number
   colorIndex?: number
 }

--- a/report-viewer/src/model/MatchInSingleFile.ts
+++ b/report-viewer/src/model/MatchInSingleFile.ts
@@ -40,4 +40,20 @@ export class MatchInSingleFile {
       return this._match.endInSecond
     }
   }
+
+  get startColumn(): number {
+    if (this._index === 1) {
+      return this._match.startColumnInFirst
+    } else {
+      return this._match.startColumnInSecond
+    }
+  }
+
+  get endColumn(): number {
+    if (this._index === 1) {
+      return this._match.endColumnInFirst
+    } else {
+      return this._match.endColumnInSecond
+    }
+  }
 }

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -123,9 +123,13 @@ export class ComparisonFactory extends BaseFactory {
       firstFile: slash(match.file1 as string),
       secondFile: slash(match.file2 as string),
       startInFirst: match.start1 as number,
+      startColumnInFirst: ((match['start1_col'] as number) || 1) - 1,
       endInFirst: match.end1 as number,
+      endColumnInFirst: ((match['end1_col'] as number) || Infinity) - 1,
       startInSecond: match.start2 as number,
+      startColumnInSecond: ((match['start2_col'] as number) || 1) - 1,
       endInSecond: match.end2 as number,
+      endColumnInSecond: ((match['end2_col'] as number) || Infinity) - 1,
       tokens: match.tokens as number
     }
   }

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -85,7 +85,7 @@
         :matches="comparison.matchesInFirstSubmission"
         :file-owner-display-name="store().getDisplayName(comparison.firstSubmissionId)"
         :highlight-language="language"
-        @line-selected="showMatchInSecond"
+        @match-selected="showMatchInSecond"
         class="max-h-0 min-h-full flex-1 overflow-hidden print:max-h-none print:overflow-y-visible"
       />
       <FilesContainer
@@ -94,7 +94,7 @@
         :matches="comparison.matchesInSecondSubmissions"
         :file-owner-display-name="store().getDisplayName(comparison.secondSubmissionId)"
         :highlight-language="language"
-        @line-selected="showMatchInFirst"
+        @match-selected="showMatchInFirst"
         class="max-h-0 min-h-full flex-1 overflow-hidden print:max-h-none print:overflow-y-visible"
       />
     </div>


### PR DESCRIPTION
Previously JPlag could only display matches per line. This made it difficult to see where some matches ended and could even hide matches entirely.
This PR adds information to the report and displays it, so matches are highlighted character precise.
This PR is backwards compatible with 5.0.0

When writing the comparison report, JPlag now adds information about the start and end column to each match.
The report viewer reads that information and saves it. Code displaying was reworked, so that each line is now its own component. This component calculates which parts of the line need to be highlighted accordingly.

The columns might not be calculated correctly in some language modules, that save start and length not correctly when parsing.

![grafik](https://github.com/jplag/JPlag/assets/39801116/9625344c-9783-49f0-bfcb-6043942b73bb)
