### PR TITLE
Fix Jar Upload

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Upload Assembly
       uses: actions/upload-artifact@v4
       with:
-        name: "JPlag"
-        path: "jplag.cli/target/jplag-*-jar-with-dependencies.jar"
+        name: "JPlag Jar"
+        path: "cli/target/jplag-*-jar-with-dependencies.jar"
 
 


### PR DESCRIPTION
fixes #1597 
Jar is now correctly attached to the workflow run