### PR TITLE
Added missing line separator

### DIFF
--- a/cli/src/main/java/de/jplag/cli/options/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/options/CliOptions.java
@@ -123,7 +123,7 @@ public class CliOptions implements Runnable {
         public boolean enabled = MergingOptions.DEFAULT_ENABLED;
 
         @Option(names = {
-                "--neighbor-length"}, description = "Minimal length of neighboring matches to be merged (between 1 and minTokenMatch, default: ${DEFAULT-VALUE}).%n")
+                "--neighbor-length"}, description = "Minimal length of neighboring matches to be merged (between 1 and minTokenMatch, default: ${DEFAULT-VALUE}).")
         public int minimumNeighborLength = MergingOptions.DEFAULT_NEIGHBOR_LENGTH;
 
         @Option(names = {

--- a/cli/src/main/java/de/jplag/cli/picocli/CliInputHandler.java
+++ b/cli/src/main/java/de/jplag/cli/picocli/CliInputHandler.java
@@ -69,7 +69,7 @@ public class CliInputHandler {
                 return PARAMETER_SHORT_ADDITIONAL_INDENT + it;
             }
             return it;
-        }).collect(Collectors.joining(System.lineSeparator())));
+        }).collect(Collectors.joining(System.lineSeparator())) + System.lineSeparator());
 
         buildSubcommands().forEach(cli::addSubcommand);
 


### PR DESCRIPTION
Re added the missing line separator for the cli.
It was missing due to the custom format for the help text.

Fixes #1581