### PR TITLE
Fix superlinear regex

### DIFF
--- a/report-viewer/src/model/fileHandling/ZipFileHandler.ts
+++ b/report-viewer/src/model/fileHandling/ZipFileHandler.ts
@@ -12,7 +12,7 @@ export class ZipFileHandler extends FileHandler {
     return jszip.loadAsync(file).then(async (zip) => {
       for (const originalFileName of Object.keys(zip.files)) {
         const unixFileName = slash(originalFileName)
-        if (/\/?(files)\//.test(unixFileName) && !/^__MACOSX\//.test(unixFileName)) {
+        if (/\/?(files)\//.test(unixFileName) && !/\/?__MACOSX\//.test(unixFileName)) {
           const directoryPath = unixFileName.substring(0, unixFileName.lastIndexOf('/'))
           const fileBase = unixFileName.substring(unixFileName.lastIndexOf('/') + 1)
 

--- a/report-viewer/src/model/fileHandling/ZipFileHandler.ts
+++ b/report-viewer/src/model/fileHandling/ZipFileHandler.ts
@@ -12,10 +12,8 @@ export class ZipFileHandler extends FileHandler {
     return jszip.loadAsync(file).then(async (zip) => {
       for (const originalFileName of Object.keys(zip.files)) {
         const unixFileName = slash(originalFileName)
-        if (
-          /((.+\/)*)(files|submissions)\/(.+)\/(.+)/.test(unixFileName) &&
-          !/^__MACOSX\//.test(unixFileName)
-        ) {
+        console.log(unixFileName, /\/?(files)\//.test(unixFileName))
+        if (/\/?(files)\//.test(unixFileName) && !/^__MACOSX\//.test(unixFileName)) {
           const directoryPath = unixFileName.substring(0, unixFileName.lastIndexOf('/'))
           const fileBase = unixFileName.substring(unixFileName.lastIndexOf('/') + 1)
 

--- a/report-viewer/src/model/fileHandling/ZipFileHandler.ts
+++ b/report-viewer/src/model/fileHandling/ZipFileHandler.ts
@@ -12,7 +12,6 @@ export class ZipFileHandler extends FileHandler {
     return jszip.loadAsync(file).then(async (zip) => {
       for (const originalFileName of Object.keys(zip.files)) {
         const unixFileName = slash(originalFileName)
-        console.log(unixFileName, /\/?(files)\//.test(unixFileName))
         if (/\/?(files)\//.test(unixFileName) && !/^__MACOSX\//.test(unixFileName)) {
           const directoryPath = unixFileName.substring(0, unixFileName.lastIndexOf('/'))
           const fileBase = unixFileName.substring(unixFileName.lastIndexOf('/') + 1)


### PR DESCRIPTION
The report viewer was operating with a regex that is vulnerable to superlinear runtime. In theory this should never by a problem, since it is only used in file parsing and thus does not operate on user data. In practice this change can decrease the runtime of the zip parsing, even if it is only slightly.

The check whether the folder name is `submissions` could be removed, since it was last used in version 4.1.0 which is not supported by the current report viewer

@tsaglam @TwoOfTwelve @uuqjz  could you quickly verify that the report viewer with this change works with reports generated under your respective operating systems