### PR TITLE
Better warning for missing files

### DIFF
--- a/report-viewer/src/stores/store.ts
+++ b/report-viewer/src/stores/store.ts
@@ -49,8 +49,8 @@ const store = defineStore('store', {
      */
     getSubmissionFile:
       (state) =>
-      (submissionId: string, fileName: string): SubmissionFile => {
-        return state.state.submissions[submissionId].get(fileName) as SubmissionFile
+      (submissionId: string, fileName: string): SubmissionFile | undefined => {
+        return state.state.submissions[submissionId].get(fileName)
       },
     /**
      * @param name the name of the submission


### PR DESCRIPTION
Previously when submission files were missing the report viewer would display an error message stating: `Could not load comparison: Cannot read properties of undefined`.
Now it tells the user that the report viewer expected a file that it did not find and states the name of the file:
`Could not load comparison: The report viewer expected to find the file Cyan Lynx\Sociologia.java in the submissions, but did not find it.`