### PR TITLE
Fix close pr workflow closing wrong issues

### DIFF
--- a/.github/workflows/scripts/closeDevIssues.py
+++ b/.github/workflows/scripts/closeDevIssues.py
@@ -50,9 +50,10 @@ def subsequences_matching_regex(input_string, regex):
 
 # gets all issues linked to pr either via the closing keywords or the sidebar
 def get_linked_issues(result):
+    issue_body = result['body'].lower() + "." # we append a dot to the end of the body to make sure the last word is checked with the regex
     closing_issues = []
     for keyword in closing_keywords:
-        closing_issues.extend(subsequences_matching_regex(result['body'].lower(), f'{keyword} #([0-9]+)'))
+        closing_issues.extend(subsequences_matching_regex(issue_body, f'{keyword} #([0-9]+)[^0-9]'))
     for k in result['closingIssuesReferences']['nodes']:
         closing_issues.append(k['number'])
     return list(set(closing_issues))


### PR DESCRIPTION
The workflow that closes issues, closes issues with sub-starting numbers (e.g. Issue is `#1234`, it closes `#1`, `#12`,...)

Fixed by having check that after the last number, comes a non number. To ensure this works for the end of the text, we append a placeholder symbol (a dot)