### PR TITLE
Improve flaky e2e tests

### DIFF
--- a/report-viewer/tests/e2e/Distribution.spec.ts
+++ b/report-viewer/tests/e2e/Distribution.spec.ts
@@ -38,11 +38,11 @@ function getTestCombinations() {
     ['Linear', 'Logarithmic']
   ]
 
-  const combinations: string[][] = []
-
   const baseOptions = options.map((o) => o[0])
+  const combinations: string[][] = [baseOptions]
+
   for (let i = 0; i < options.length; i++) {
-    for (let j = 0; j < options[i].length; j++) {
+    for (let j = 1; j < options[i].length; j++) {
       const combination = Array.from(baseOptions)
       combination[i] = options[i][j]
       combinations.push(combination)


### PR DESCRIPTION
Previously the generated options for the distribution diagram test looked like this:
```
[
  [ 'Average Similarity', 'Linear' ],
  [ 'Maximum Similarity', 'Linear' ],
  [ 'Average Similarity', 'Linear' ],
  [ 'Average Similarity', 'Logarithmic' ]
]
```
Now, they do not include a duplicate case:
```
[
  [ 'Average Similarity', 'Linear' ],
  [ 'Maximum Similarity', 'Linear' ],
  [ 'Average Similarity', 'Logarithmic' ]
]
```