### PR TITLE
Catch all Exceptions in java

### DIFF
--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -52,7 +52,7 @@ public class JavacAdapter {
                 ast.accept(scanner, null);
                 parser.add(Token.semanticFileEnd(file));
             }
-        } catch (IOException exception) {
+        } catch (Exception exception) {
             throw new ParsingException(null, exception.getMessage(), exception);
         }
         parsingExceptions.addAll(processErrors(listener));


### PR DESCRIPTION
When a generic exception was thrown whilst parsing java code, it was not possible to easily identify the failed submission. 
Exceptions now get wrapped in parsing exceptions.

Fixes #1720 