### PR TITLE
Fix a bug where the basecode submission was not normalized

### DIFF
--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -99,6 +99,7 @@ public class SubmissionSet {
     }
 
     public void normalizeSubmissions() {
+        baseCodeSubmission.normalize();
         ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, Submission::normalize);
     }
 

--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -99,7 +99,9 @@ public class SubmissionSet {
     }
 
     public void normalizeSubmissions() {
-        baseCodeSubmission.normalize();
+        if(baseCodeSubmission != null) {
+            baseCodeSubmission.normalize();
+        }
         ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, Submission::normalize);
     }
 

--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -99,7 +99,7 @@ public class SubmissionSet {
     }
 
     public void normalizeSubmissions() {
-        if(baseCodeSubmission != null) {
+        if (baseCodeSubmission != null) {
             baseCodeSubmission.normalize();
         }
         ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, Submission::normalize);


### PR DESCRIPTION
When using `--normalize` all submissions except the basecode submission were normalized.
Thus, when using basecode (`-bc`) with the normalization, it can happen that basecode snippets in the submissions are no longer matched with the basecode. This PR fixes that issue by normalizing the basecode submission when basecode is used and normalization enabled.