### PR TITLE
Ensure JPlag fails gracefully if JavaC is not available and Java code is analyzed

### DIFF
--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.jplag.exceptions.LanguageException;
 import de.jplag.normalization.TokenStringNormalizer;
 import de.jplag.options.JPlagOptions;
 
@@ -218,8 +219,9 @@ public class Submission implements Comparable<Submission> {
      * @param normalize specifies if the tokens sequences should be normalized.
      * @param minimalTokens specifies the minimum number of tokens required of a valid submission.
      * @return Whether parsing was successful.
+     * @throws LanguageException if the language parser is not able to parse at all.
      */
-    /* package-private */ boolean parse(boolean debugParser, boolean normalize, int minimalTokens) {
+    /* package-private */ boolean parse(boolean debugParser, boolean normalize, int minimalTokens) throws LanguageException {
         if (files == null || files.isEmpty()) {
             logger.error("Nothing to parse for submission \"{}\"", name);
             state = NOTHING_TO_PARSE;
@@ -228,6 +230,8 @@ public class Submission implements Comparable<Submission> {
 
         try {
             tokenList = language.parse(new HashSet<>(files), normalize);
+        } catch (CriticalParsingException e) {
+            throw new LanguageException(e.getMessage(), e.getCause());
         } catch (ParsingException e) {
             String shortenedMessage = e.getMessage().replace(submissionRootFile.toString(), name);
             logger.warn("Failed to parse submission {}:{}{}", name, System.lineSeparator(), shortenedMessage);

--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import de.jplag.exceptions.BasecodeException;
 import de.jplag.exceptions.ExitException;
+import de.jplag.exceptions.LanguageException;
 import de.jplag.exceptions.SubmissionException;
 import de.jplag.logging.ProgressBar;
 import de.jplag.logging.ProgressBarLogger;
@@ -127,7 +128,7 @@ public class SubmissionSet {
     /**
      * Parse the given base code submission.
      */
-    private void parseBaseCodeSubmission(Submission baseCode) throws BasecodeException {
+    private void parseBaseCodeSubmission(Submission baseCode) throws BasecodeException, LanguageException {
         logger.trace("----- Parsing basecode submission: " + baseCode.getName());
         if (!baseCode.parse(options.debugParser(), options.normalize(), options.minimumTokenMatch())) {
             if (baseCode.getState() == SubmissionState.TOO_SMALL) {
@@ -143,7 +144,7 @@ public class SubmissionSet {
      * Parse all given submissions.
      * @param submissions The list of submissions
      */
-    private void parseSubmissions(List<Submission> submissions) {
+    private void parseSubmissions(List<Submission> submissions) throws LanguageException {
         if (submissions.isEmpty()) {
             logger.error("No submissions to parse!");
             return;

--- a/core/src/main/java/de/jplag/exceptions/LanguageException.java
+++ b/core/src/main/java/de/jplag/exceptions/LanguageException.java
@@ -1,0 +1,13 @@
+package de.jplag.exceptions;
+
+/**
+ * Exceptions for problems with the language module and its parser.
+ */
+public class LanguageException extends ExitException {
+
+    private static final long serialVersionUID = 5685703308840622858L; // generated
+
+    public LanguageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/language-api/src/main/java/de/jplag/CriticalParsingException.java
+++ b/language-api/src/main/java/de/jplag/CriticalParsingException.java
@@ -12,9 +12,8 @@ public class CriticalParsingException extends ParsingException {
     /**
      * Constructs a new exception indicating a critical parsing exception.
      * @param reason the reason the parsing failed. A null value is permitted.)
-     * @param cause the cause. (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
      */
-    public CriticalParsingException(String reason, Throwable cause) {
-        super(null, reason, cause);
+    public CriticalParsingException(String reason) {
+        super(null, reason);
     }
 }

--- a/language-api/src/main/java/de/jplag/CriticalParsingException.java
+++ b/language-api/src/main/java/de/jplag/CriticalParsingException.java
@@ -1,0 +1,20 @@
+package de.jplag;
+
+/**
+ * Exception indicating a critical error within the parser itself. This error is not associated with a specific
+ * submission but signifies a broader issue. When this exception is thrown, it means that the parser cannot continue
+ * parsing.
+ */
+public class CriticalParsingException extends ParsingException {
+
+    private static final long serialVersionUID = -637253490714738666L; // generated
+
+    /**
+     * Constructs a new exception indicating a critical parsing exception.
+     * @param reason the reason the parsing failed. A null value is permitted.)
+     * @param cause the cause. (A null value is permitted, and indicates that the cause is nonexistent or unknown.)
+     */
+    public CriticalParsingException(String reason, Throwable cause) {
+        super(null, reason, cause);
+    }
+}

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -29,19 +29,19 @@ import com.sun.source.util.Trees;
 
 public class JavacAdapter {
 
-    private static final JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+    private static final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
     public void parseFiles(Set<File> files, final Parser parser) throws ParsingException {
         var listener = new DiagnosticCollector<>();
 
         List<ParsingException> parsingExceptions = new ArrayList<>();
         final Charset guessedCharset = FileUtils.detectCharsetFromMultiple(files);
-        try (final StandardJavaFileManager fileManager = javac.getStandardFileManager(listener, null, guessedCharset)) {
+        try (final StandardJavaFileManager fileManager = compiler.getStandardFileManager(listener, null, guessedCharset)) {
             var javaFiles = fileManager.getJavaFileObjectsFromFiles(files);
 
             // We need to disable annotation processing, see
             // https://stackoverflow.com/questions/72737445/system-java-compiler-behaves-different-depending-on-dependencies-defined-in-mave
-            final CompilationTask task = javac.getTask(null, fileManager, listener,
+            final CompilationTask task = compiler.getTask(null, fileManager, listener,
                     List.of("-proc:none", "--enable-preview", "--release=" + JavaLanguage.JAVA_VERSION), null, javaFiles);
             final Trees trees = Trees.instance(task);
             final SourcePositions positions = new FixedSourcePositions(trees.getSourcePositions());

--- a/languages/java/src/main/java/de/jplag/java/Parser.java
+++ b/languages/java/src/main/java/de/jplag/java/Parser.java
@@ -6,10 +6,13 @@ import java.util.List;
 import java.util.Set;
 
 import de.jplag.AbstractParser;
+import de.jplag.CriticalParsingException;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
 public class Parser extends AbstractParser {
+    private static final String JDK_ERROR_MESSAGE = "Cannot parse as 'javac' is not available. Ensure a full JDK is installed.";
+    private static final String JAVAC_CLASS_NAME = "com.sun.source.util.JavacTask";
     private List<Token> tokens;
 
     /**
@@ -20,6 +23,7 @@ public class Parser extends AbstractParser {
     }
 
     public List<Token> parse(Set<File> files) throws ParsingException {
+        ensureJavacIsAvailable();
         tokens = new ArrayList<>();
         new JavacAdapter().parseFiles(files, this);
         logger.debug("--- token semantics ---");
@@ -27,6 +31,14 @@ public class Parser extends AbstractParser {
             logger.debug("{} | {} | {}", token.getLine(), token.getType().getDescription(), token.getSemantics());
         }
         return tokens;
+    }
+
+    private void ensureJavacIsAvailable() throws CriticalParsingException {
+        try {
+            Class.forName(JAVAC_CLASS_NAME);
+        } catch (ClassNotFoundException exception) {
+            throw new CriticalParsingException(JDK_ERROR_MESSAGE, exception);
+        }
     }
 
     public void add(Token token) {

--- a/languages/java/src/main/java/de/jplag/java/Parser.java
+++ b/languages/java/src/main/java/de/jplag/java/Parser.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import javax.tools.ToolProvider;
+
 import de.jplag.AbstractParser;
 import de.jplag.CriticalParsingException;
 import de.jplag.ParsingException;
@@ -12,7 +14,6 @@ import de.jplag.Token;
 
 public class Parser extends AbstractParser {
     private static final String JDK_ERROR_MESSAGE = "Cannot parse as 'javac' is not available. Ensure a full JDK is installed.";
-    private static final String JAVAC_CLASS_NAME = "com.sun.source.util.JavacTask";
     private List<Token> tokens;
 
     /**
@@ -34,10 +35,8 @@ public class Parser extends AbstractParser {
     }
 
     private void ensureJavacIsAvailable() throws CriticalParsingException {
-        try {
-            Class.forName(JAVAC_CLASS_NAME);
-        } catch (ClassNotFoundException exception) {
-            throw new CriticalParsingException(JDK_ERROR_MESSAGE, exception);
+        if (ToolProvider.getSystemJavaCompiler() == null) {
+            throw new CriticalParsingException(JDK_ERROR_MESSAGE);
         }
     }
 


### PR DESCRIPTION
Sometimes users run JPlag without a full JDK, and thus JavaC is not available. This manifests in an error like this:

```java
Exception in thread "main" java.lang.NoClassDefFoundError: com/sun/source/util/SourcePositions
        at de.jplag.java.Parser.parse(Parser.java:24)
```

To this end, this PR checks if JavaC is available by trying to load a corresponding class. If this does not work, it fails gracefully. To implement this, the exceptions of the API were extended: Language modules can now throw a `CriticalParsingException`, which leads to termination. The core uses a new subclass of `ExitException` to wrap this and pass it to the top.