### PR TITLE
feat: add query param with url to zip results

### DIFF
--- a/report-viewer/src/compositions/syncQueryParam.ts
+++ b/report-viewer/src/compositions/syncQueryParam.ts
@@ -1,0 +1,59 @@
+import { type Ref, watch } from 'vue';
+import type { RouteLocationNormalized, Router } from 'vue-router';
+
+export function syncQueryParam<T>(
+  variable: Ref<T>,
+  router: Router,
+  route: RouteLocationNormalized,
+  queryParam: string,
+  serializer: (value: T) => string | null | undefined,
+  deserializer: (value: string) => T
+) {
+  function updateRouteQuery() {
+    router.replace({ query: { ...route.query, [queryParam]: serializer(variable.value) } });
+  }
+
+  if (route.query[queryParam] !== undefined) {
+    variable.value = deserializer(route.query[queryParam] as string);
+  }
+
+  watch(variable, () => {
+    updateRouteQuery();
+  });
+
+  return {
+    updateRouteQuery
+  };
+}
+
+export function syncStringQueryParam(
+  variable: Ref<string | null>,
+  router: Router,
+  route: RouteLocationNormalized,
+  queryParam: string
+) {
+  return syncQueryParam(
+    variable,
+    router,
+    route,
+    queryParam,
+    (value) => value || undefined,
+    (value) => value
+  );
+}
+
+export function syncBooleanQueryParam(
+  variable: Ref<boolean>,
+  router: Router,
+  route: RouteLocationNormalized,
+  queryParam: string
+) {
+  return syncQueryParam(
+    variable,
+    router,
+    route,
+    queryParam,
+    (value) => (value ? null : undefined),
+    (value) => value !== undefined
+  );
+}


### PR DESCRIPTION
<!--
Pull requests regarding major or minor updates need to target the `develop` branch.
Pull requests regarding patch updates need to target the `main` branch.
Please make sure to select the appropriate branch while creating the pull request.
For a reference on semantic versioning, see https://semver.org.
-->

I am currently using JPlag but I am facing an issue with the viewer.

After running JPlag on our webservice, the reports are generated as the usual zip assets, that are then statically served by the Web Service itself.

The problem is that, as of now, the users would need to download those zip files, go to JPlag's viewer website and manually upload them. 

It would be nicer if they could just click a link and see the results of the wanted plagiarism result of our Web Service.

This has been achieved by adding a query param to the url, such as `https://jplag-viewer.euber.dev/?inputUrl=<my_jplag_zip_url_or_path>` and has been served on a modified clone of the web viewer.

The result can be tested here: https://jplag-viewer.euber.dev/ by adding the `?inputUrl=` with a zip that you can make available with a link.

I think that this feature could be useful to the full community and making this pull request, the code is working but you can refactor it with your needs, should still be a good proof of concept