### PR TITLE
Fix bugs for WSL

### DIFF
--- a/cli/src/main/java/de/jplag/cli/JPlagRunner.java
+++ b/cli/src/main/java/de/jplag/cli/JPlagRunner.java
@@ -43,7 +43,11 @@ public final class JPlagRunner {
         ReportViewer reportViewer = new ReportViewer(zipFile, port);
         int actualPort = reportViewer.start();
         logger.info("ReportViewer started on port http://localhost:{}", actualPort);
-        Desktop.getDesktop().browse(URI.create("http://localhost:" + actualPort + "/"));
+        if (Desktop.isDesktopSupported()) {
+            Desktop.getDesktop().browse(URI.create("http://localhost:" + actualPort + "/"));
+        } else {
+            logger.info("Could not open browser. You can open the Report Viewer here: http://localhost:{}/", actualPort);
+        }
 
         System.out.println("Press Enter key to exit...");
         System.in.read();

--- a/cli/src/main/java/de/jplag/cli/JPlagRunner.java
+++ b/cli/src/main/java/de/jplag/cli/JPlagRunner.java
@@ -43,7 +43,7 @@ public final class JPlagRunner {
         ReportViewer reportViewer = new ReportViewer(zipFile, port);
         int actualPort = reportViewer.start();
         logger.info("ReportViewer started on port http://localhost:{}", actualPort);
-        if (Desktop.isDesktopSupported()) {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
             Desktop.getDesktop().browse(URI.create("http://localhost:" + actualPort + "/"));
         } else {
             logger.info("Could not open browser. You can open the Report Viewer here: http://localhost:{}/", actualPort);

--- a/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
+++ b/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.BindException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -27,7 +28,6 @@ public class ReportViewer implements HttpHandler {
     private static final int SUCCESS_RESPONSE = 200;
     private static final int NOT_FOUND_RESPONSE = 404;
     private static final int MAX_PORT_LOOKUPS = 4;
-    private static final String DEFAULT_IP_ADDRESS = "0.0.0.0";
 
     private final RoutingTree routingTree;
     private final int port;
@@ -59,12 +59,14 @@ public class ReportViewer implements HttpHandler {
             throw new IllegalStateException("Server already started");
         }
 
+        System.setProperty("java.net.preferIPv4Stack", "true");
+
         int currentPort = this.port;
         int remainingLookups = MAX_PORT_LOOKUPS;
         BindException lastException = new BindException("Could not create server. Probably due to no free port found.");
         while (server == null && remainingLookups-- > 0) {
             try {
-                server = HttpServer.create(new InetSocketAddress(DEFAULT_IP_ADDRESS, currentPort), 0);
+                server = HttpServer.create(new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), currentPort), 0);
             } catch (BindException e) {
                 logger.info("Port {} is not available. Trying to find a different one.", currentPort);
                 lastException = e;

--- a/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
+++ b/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.BindException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -28,6 +27,7 @@ public class ReportViewer implements HttpHandler {
     private static final int SUCCESS_RESPONSE = 200;
     private static final int NOT_FOUND_RESPONSE = 404;
     private static final int MAX_PORT_LOOKUPS = 4;
+    private static final String DEFAULT_IP_ADDRESS = "0.0.0.0";
 
     private final RoutingTree routingTree;
     private final int port;
@@ -64,7 +64,7 @@ public class ReportViewer implements HttpHandler {
         BindException lastException = new BindException("Could not create server. Probably due to no free port found.");
         while (server == null && remainingLookups-- > 0) {
             try {
-                server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), currentPort), 0);
+                server = HttpServer.create(new InetSocketAddress(DEFAULT_IP_ADDRESS, currentPort), 0);
             } catch (BindException e) {
                 logger.info("Port {} is not available. Trying to find a different one.", currentPort);
                 lastException = e;


### PR DESCRIPTION
When opening the local report viewer on WSL, JPlag terminated since no browser was found. Now there is an info message that the browser could not be opened.
![grafik](https://github.com/jplag/JPlag/assets/39801116/015ac97d-2f7e-4b20-8175-0cf6b79d3b7a)


~~Another issue was that WSL did not access the windows localhost with the given IP Address. Thus, I changed it to the universal Address `0.0.0.0`~~