### PR TITLE
Enhance search bar of comparison table

### DIFF
--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -2,7 +2,7 @@
   <div class="space-y-2">
     <div class="flex flex-row flex-wrap items-center gap-x-8 gap-y-2">
       <h2>{{ header }}</h2>
-      <ToolTipComponent direction="bottom" class="min-w-[50%] flex-grow">
+      <ToolTipComponent direction="left" class="min-w-[50%] flex-grow">
         <template #default>
           <SearchBarComponent placeholder="Filter/Unhide Comparisons" v-model="searchStringValue" />
         </template>
@@ -11,6 +11,16 @@
             Type in the name of a submission to only show comparisons that contain this submission.
           </p>
           <p class="whitespace-pre text-sm">Fully written out names get unhidden.</p>
+          <p class="whitespace-pre text-sm">
+            You can also filter by index by just writing a number or select a specific one by
+            writing <i>index:number</i>
+          </p>
+          <p class="whitespace-pre text-sm">
+            You can filter for specific similarity percantages by writing a &lt;/&gt;/&lt;=/&gt;=
+            followed by the percentage. <br />
+            You can filter for a specific metric, by prefacing the percentage with the three letter
+            metric name (e.g. <i>avg:>80</i>)
+          </p>
         </template>
       </ToolTipComponent>
 

--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -15,8 +15,8 @@
             You can also filter by index by entering a number or typing <i>index:number</i>
           </p>
           <p class="whitespace-pre text-sm">
-            You can filter for specific similarity thresholds via &lt;/&gt;/&lt;=/&gt;=
-            followed by the percentage. <br />
+            You can filter for specific similarity thresholds via &lt;/&gt;/&lt;=/&gt;= followed by
+            the percentage. <br />
             You can filter for a specific metric by prefacing the percentage with the three-letter
             metric name (e.g. <i>avg:>80</i>)
           </p>

--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -12,13 +12,12 @@
           </p>
           <p class="whitespace-pre text-sm">Fully written out names get unhidden.</p>
           <p class="whitespace-pre text-sm">
-            You can also filter by index by just writing a number or select a specific one by
-            writing <i>index:number</i>
+            You can also filter by index by entering a number or typing <i>index:number</i>
           </p>
           <p class="whitespace-pre text-sm">
-            You can filter for specific similarity percantages by writing a &lt;/&gt;/&lt;=/&gt;=
+            You can filter for specific similarity thresholds via &lt;/&gt;/&lt;=/&gt;=
             followed by the percentage. <br />
-            You can filter for a specific metric, by prefacing the percentage with the three letter
+            You can filter for a specific metric by prefacing the percentage with the three-letter
             metric name (e.g. <i>avg:>80</i>)
           </p>
         </template>

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -228,27 +228,76 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
     return comparisons
   }
 
-  const nameSearches = searches.filter((s) => !/index:[0-9]+/.test(s))
   const indexSearches = searches
     .filter((s) => /index:[0-9]+/.test(s))
     .map((s) => s.substring(6))
     .map((s) => parseInt(s))
 
+  const metricSearches = searches.filter((s) => /((avg|max):)?(>|<)=?[0-9]+%?/.test(s))
+
   return comparisons.filter((c) => {
+    // name search
     const id1 = c.firstSubmissionId.toLowerCase()
     const id2 = c.secondSubmissionId.toLowerCase()
-    if (nameSearches.some((s) => id1.includes(s) || id2.includes(s))) {
+    if (searches.some((s) => id1.includes(s) || id2.includes(s))) {
       return true
     }
+
+    // index search
     if (indexSearches.includes(c.sortingPlace + 1)) {
       return true
     }
-    if (nameSearches.some((s) => (c.sortingPlace + 1).toString().includes(s))) {
+    if (searches.some((s) => (c.sortingPlace + 1).toString().includes(s))) {
       return true
+    }
+
+    // metric search
+    const searchPerMetric: Record<MetricType, string[]> = {
+      [MetricType.AVERAGE]: [],
+      [MetricType.MAXIMUM]: []
+    }
+    metricSearches.forEach((s) => {
+      const regexResult = /^(?:(avg|max):)?((?:>|<)=?[0-9]+%?$)/.exec(s)
+      if (regexResult) {
+        const metric = regexResult[1] == 'avg' ? MetricType.AVERAGE : MetricType.MAXIMUM
+        searchPerMetric[metric].push(regexResult[2])
+      } else {
+        searchPerMetric[MetricType.AVERAGE].push(s)
+        searchPerMetric[MetricType.MAXIMUM].push(s)
+      }
+    })
+    for (const metric of [MetricType.AVERAGE, MetricType.MAXIMUM]) {
+      for (const search of searchPerMetric[metric]) {
+        const regexResult = /((?:>|<)=?)([0-9]+)%?/.exec(search)!
+        const operator = regexResult[1]
+        const value = parseInt(regexResult[2])
+        if (evaluateMetricComparison(c.similarities[metric] * 100, operator, value)) {
+          return true
+        }
+      }
     }
 
     return false
   })
+
+  function evaluateMetricComparison(
+    comparisonMetric: number,
+    operator: string,
+    checkValue: number
+  ) {
+    switch (operator) {
+      case '>':
+        return comparisonMetric > checkValue
+      case '<':
+        return comparisonMetric < checkValue
+      case '>=':
+        return comparisonMetric >= checkValue
+      case '<=':
+        return comparisonMetric <= checkValue
+      default:
+        return false
+    }
+  }
 }
 
 function getSortedComparisons(comparisons: ComparisonListElement[]) {

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -228,10 +228,26 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
     return comparisons
   }
 
+  const nameSearches = searches.filter((s) => !/index:[0-9]+/.test(s))
+  const indexSearches = searches
+    .filter((s) => /index:[0-9]+/.test(s))
+    .map((s) => s.substring(6))
+    .map((s) => parseInt(s))
+
   return comparisons.filter((c) => {
     const id1 = c.firstSubmissionId.toLowerCase()
     const id2 = c.secondSubmissionId.toLowerCase()
-    return searches.some((s) => id1.includes(s) || id2.includes(s))
+    if (nameSearches.some((s) => id1.includes(s) || id2.includes(s))) {
+      return true
+    }
+    if (indexSearches.includes(c.sortingPlace + 1)) {
+      return true
+    }
+    if (nameSearches.some((s) => (c.sortingPlace + 1).toString().includes(s))) {
+      return true
+    }
+
+    return false
   })
 }
 

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -259,7 +259,14 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
     metricSearches.forEach((s) => {
       const regexResult = /^(?:(avg|max):)?((?:>|<)=?[0-9]+%?$)/.exec(s)
       if (regexResult) {
-        const metric = regexResult[1] == 'avg' ? MetricType.AVERAGE : MetricType.MAXIMUM
+        const metricName = regexResult[1]
+        let metric = MetricType.AVERAGE
+        for (const m of [MetricType.AVERAGE, MetricType.MAXIMUM]) {
+          if (metricToolTips[m].shortName.toLowerCase() == metricName) {
+            metric = m
+            break
+          }
+        }
         searchPerMetric[metric].push(regexResult[2])
       } else {
         searchPerMetric[MetricType.AVERAGE].push(s)

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -233,7 +233,7 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
     .map((s) => s.substring(6))
     .map((s) => parseInt(s))
 
-  const metricSearches = searches.filter((s) => /((avg|max):)?(>|<)=?[0-9]+%?/.test(s))
+  const metricSearches = searches.filter((s) => /((avg|max):)?([<>])=?[0-9]+%?/.test(s))
 
   return comparisons.filter((c) => {
     // name search
@@ -257,7 +257,7 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
       [MetricType.MAXIMUM]: []
     }
     metricSearches.forEach((s) => {
-      const regexResult = /^(?:(avg|max):)?((?:>|<)=?[0-9]+%?$)/.exec(s)
+      const regexResult = /^(?:(avg|max):)?((?:[<>])=?[0-9]+%?$)/.exec(s)
       if (regexResult) {
         const metricName = regexResult[1]
         let metric = MetricType.AVERAGE
@@ -275,7 +275,7 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
     })
     for (const metric of [MetricType.AVERAGE, MetricType.MAXIMUM]) {
       for (const search of searchPerMetric[metric]) {
-        const regexResult = /((?:>|<)=?)([0-9]+)%?/.exec(search)!
+        const regexResult = /((?:[<>])=?)([0-9]+)%?/.exec(search)!
         const operator = regexResult[1]
         const value = parseInt(regexResult[2])
         if (evaluateMetricComparison(c.similarities[metric] * 100, operator, value)) {

--- a/report-viewer/tests/e2e/Comparison.spec.ts
+++ b/report-viewer/tests/e2e/Comparison.spec.ts
@@ -6,9 +6,7 @@ test('Test comparison table and comparsion view', async ({ page }) => {
 
   await uploadFile('progpedia-report.zip', page)
 
-  const comparisonContainer = page.getByText(
-    'Top Comparisons: Type in the name of a submission to only show comparisons that contain this submission. Fully written out names get unhidden.Hide AllSort By'
-  )
+  const comparisonContainer = page.getByText('Hide AllSort By')
 
   // check for elements in average similarity table
   await page.getByPlaceholder('Filter/Unhide Comparisons').fill('Purple')


### PR DESCRIPTION
This table adds new features to the search bar of the comparison table.

It is now possible to search for index. If a number is written, it will take all indexes containing this number. E.g. when `5` is written in the search bar 5, 15 and 51 are displayed.
To get a specific index only, the number can be prefaced with `index:`. E.g. `index:5` will only filter the 5th comparison in the current sorting.

It is now possible to filter for similarities. All these filters need to be prefaced with either >, <, >= or <= followed by the number of percentages to filter for. This searches over all similarities. A percentage symbol is optional. E.g. `<100` will show all comparisons where any metric (so either avg or max) is less than 100%.
It is possible to filter for a specific metric by prefacing the comparison symbol with its name in the table header, followed by a double colon. E.g. `max:>=90%` will filter for submission where the maximum similarity is greater than or equal to 90%.

This is also explained in the tooltip of the search bar. 
Due to the tooltip being cutoff, its direction changed.