### PR TITLE
FIx bug with --enable-preview on Java 22

### DIFF
--- a/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import de.jplag.exceptions.ExitException;
-import de.jplag.java.JavaLanguage;
 
 public class NewJavaFeaturesTest extends TestBase {
 
@@ -23,14 +22,16 @@ public class NewJavaFeaturesTest extends TestBase {
     private static final String JAVA_VERSION_KEY = "java.version";
     private static final String CI_VARIABLE = "CI";
 
+    public static final int JAVA_VERSION = 21;
+
     @Test
     @DisplayName("test comparison of Java files with modern language features")
     public void testJavaFeatureDuplicates() throws ExitException {
         // pre-condition
         String actualJavaVersion = System.getProperty(JAVA_VERSION_KEY);
         boolean isCiRun = System.getenv(CI_VARIABLE) != null;
-        boolean isCorrectJavaVersion = actualJavaVersion.startsWith(String.valueOf(JavaLanguage.JAVA_VERSION));
-        assumeTrue(isCorrectJavaVersion || isCiRun, VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, JavaLanguage.JAVA_VERSION));
+        boolean isCorrectJavaVersion = actualJavaVersion.startsWith(String.valueOf(JAVA_VERSION));
+        assumeTrue(isCorrectJavaVersion || isCiRun, VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, JAVA_VERSION));
 
         JPlagResult result = runJPlagWithExclusionFile(ROOT_DIRECTORY, EXCLUSION_FILE_NAME);
 

--- a/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
+++ b/core/src/test/java/de/jplag/NewJavaFeaturesTest.java
@@ -19,19 +19,17 @@ public class NewJavaFeaturesTest extends TestBase {
     private static final String CHANGE_MESSAGE = "Number of %s changed! If intended, modify the test case!";
     private static final String VERSION_MISMATCH_MESSAGE = "Using Java version %s instead of %s may skew the results.";
     private static final String VERSION_MATCH_MESSAGE = "Java version matches, but results deviate from expected values";
-    private static final String JAVA_VERSION_KEY = "java.version";
     private static final String CI_VARIABLE = "CI";
 
-    public static final int JAVA_VERSION = 21;
+    public static final int EXPECTED_JAVA_VERSION = 21;
 
     @Test
     @DisplayName("test comparison of Java files with modern language features")
     public void testJavaFeatureDuplicates() throws ExitException {
         // pre-condition
-        String actualJavaVersion = System.getProperty(JAVA_VERSION_KEY);
+        int javaVersion = Runtime.version().feature();
         boolean isCiRun = System.getenv(CI_VARIABLE) != null;
-        boolean isCorrectJavaVersion = actualJavaVersion.startsWith(String.valueOf(JAVA_VERSION));
-        assumeTrue(isCorrectJavaVersion || isCiRun, VERSION_MISMATCH_MESSAGE.formatted(actualJavaVersion, JAVA_VERSION));
+        assumeTrue(javaVersion == EXPECTED_JAVA_VERSION || isCiRun, VERSION_MISMATCH_MESSAGE.formatted(javaVersion, EXPECTED_JAVA_VERSION));
 
         JPlagResult result = runJPlagWithExclusionFile(ROOT_DIRECTORY, EXCLUSION_FILE_NAME);
 

--- a/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
+++ b/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
@@ -15,7 +15,6 @@ import de.jplag.Token;
 @MetaInfServices(de.jplag.Language.class)
 public class JavaLanguage implements de.jplag.Language {
     private static final String IDENTIFIER = "java";
-    public static final int JAVA_VERSION = 21;
 
     private final Parser parser;
 

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -29,6 +29,10 @@ import com.sun.source.util.Trees;
 
 public class JavacAdapter {
 
+    private static final String NO_ANNOTATION_PROCESSING = "-proc:none";
+    private static final String PREVIEW_FLAG = "--enable-preview";
+    private static final String RELEASE_VERSION_FLAG = "--release=";
+
     private static final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
     public void parseFiles(Set<File> files, final Parser parser) throws ParsingException {
@@ -39,10 +43,10 @@ public class JavacAdapter {
         try (final StandardJavaFileManager fileManager = compiler.getStandardFileManager(listener, null, guessedCharset)) {
             var javaFiles = fileManager.getJavaFileObjectsFromFiles(files);
 
-            // We need to disable annotation processing, see
-            // https://stackoverflow.com/questions/72737445/system-java-compiler-behaves-different-depending-on-dependencies-defined-in-mave
-            final CompilationTask task = compiler.getTask(null, fileManager, listener,
-                    List.of("-proc:none", "--enable-preview", "--release=" + JavaLanguage.JAVA_VERSION), null, javaFiles);
+            // We need to disable annotation processing, see https://stackoverflow.com/q/72737445
+            String releaseVersion = RELEASE_VERSION_FLAG + Runtime.version().feature(); // required for preview flag
+            List<String> options = List.of(NO_ANNOTATION_PROCESSING, PREVIEW_FLAG, releaseVersion);
+            final CompilationTask task = compiler.getTask(null, fileManager, listener, options, null, javaFiles);
             final Trees trees = Trees.instance(task);
             final SourcePositions positions = new FixedSourcePositions(trees.getSourcePositions());
             for (final CompilationUnitTree ast : executeCompilationTask(task, parser.logger)) {

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -31,7 +31,7 @@ public class JavacAdapter {
 
     private static final String NO_ANNOTATION_PROCESSING = "-proc:none";
     private static final String PREVIEW_FLAG = "--enable-preview";
-    private static final String RELEASE_VERSION_FLAG = "--release=";
+    private static final String RELEASE_VERSION_OPTION = "--release=";
 
     private static final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 
@@ -44,7 +44,7 @@ public class JavacAdapter {
             var javaFiles = fileManager.getJavaFileObjectsFromFiles(files);
 
             // We need to disable annotation processing, see https://stackoverflow.com/q/72737445
-            String releaseVersion = RELEASE_VERSION_FLAG + Runtime.version().feature(); // required for preview flag
+            String releaseVersion = RELEASE_VERSION_OPTION + Runtime.version().feature(); // required for preview flag
             List<String> options = List.of(NO_ANNOTATION_PROCESSING, PREVIEW_FLAG, releaseVersion);
             final CompilationTask task = compiler.getTask(null, fileManager, listener, options, null, javaFiles);
             final Trees trees = Trees.instance(task);


### PR DESCRIPTION
Fix a bug occurring on Java 22 caused by the `--enable-preview` option that is enabled for the Java language module (see #1851):

- Use the runtime Java version as the release version for the JavaC compilation task instead of the hardcoded version 21.
- Only use hardcoded language version in the Java feature test.
- Use constants for options flags.
- Use a short link in the StackOverflow comment.