### PR TITLE
Output antlr error to a logger instead of System.err

### DIFF
--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
@@ -62,6 +62,8 @@ public abstract class AbstractAntlrParserAdapter<T extends Parser> extends Abstr
             Lexer lexer = this.createLexer(CharStreams.fromReader(reader));
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
             T parser = this.createParser(tokenStream);
+            parser.removeErrorListeners();
+            parser.addErrorListener(new AntlrLoggerErrorListener());
             ParserRuleContext entryContext = this.getEntryContext(parser);
             ParseTreeWalker treeWalker = new ParseTreeWalker();
             InternalListener listener = new InternalListener(this.getListener(), collector);

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AntlrLoggerErrorListener.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AntlrLoggerErrorListener.java
@@ -1,0 +1,21 @@
+package de.jplag.antlr;
+
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Writes error messages from ANTLR to a logger
+ */
+public class AntlrLoggerErrorListener extends BaseErrorListener {
+    private static final Logger logger = LoggerFactory.getLogger(AntlrLoggerErrorListener.class);
+    private static final String ERROR_TEMPLATE = "ANTLR error - line {}:{} {}";
+
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg,
+            RecognitionException e) {
+        logger.error(ERROR_TEMPLATE, line, charPositionInLine, msg);
+    }
+}


### PR DESCRIPTION
This PR makes antlr write syntax errors to the logger instead of System.err.

Relates to #1866 