### PR TITLE
Improve character index of token tracing information for better visualization of Java matches

### DIFF
--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -458,7 +458,8 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     public Void visitVariable(VariableTree node, Void unused) {
         if (!node.getName().contentEquals(ANONYMOUS_VARIABLE_NAME)) {
             long start = positions.getStartPosition(ast, node);
-            int length = node.toString().length() - (node.getInitializer() == null ? 0 : node.getInitializer().toString().length());
+            long end = positions.getEndPosition(ast, node) - 1;
+            end -= node.getInitializer() == null ? 0 : node.getInitializer().toString().length();
             String name = node.getName().toString();
             boolean inLocalScope = variableRegistry.inLocalScope();
             // this presents a problem when classes are declared in local scopes, which can happen in ad-hoc implementations
@@ -470,7 +471,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
             } else {
                 semantics = CodeSemantics.createKeep();
             }
-            addToken(JavaTokenType.J_VARDEF, start, length, semantics);
+            addToken(JavaTokenType.J_VARDEF, start, end, semantics);
             // manually add variable to semantics since identifier isn't visited
             variableRegistry.setNextVariableAccessType(VariableAccessType.WRITE);
             variableRegistry.registerVariableAccess(name, !inLocalScope);

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -380,10 +380,11 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     @Override
     public Void visitNewClass(NewClassTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
+        long end = positions.getEndPosition(ast, node.getIdentifier());
         if (!node.getTypeArguments().isEmpty()) {
             addToken(JavaTokenType.J_GENERIC, start, 3 + node.getIdentifier().toString().length(), new CodeSemantics());
         }
-        addToken(JavaTokenType.J_NEWCLASS, start, node.toString().length(), new CodeSemantics());
+        addToken(JavaTokenType.J_NEWCLASS, start, end, new CodeSemantics());
         super.visitNewClass(node, null);
         return null;
     }
@@ -399,8 +400,8 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     @Override
     public Void visitNewArray(NewArrayTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
-        long end = positions.getEndPosition(ast, node) - 1;
-        addToken(JavaTokenType.J_NEWARRAY, start, node.toString().length(), new CodeSemantics());
+        long end = node.getType() == null ? start + 1 : positions.getEndPosition(ast, node.getType());
+        addToken(JavaTokenType.J_NEWARRAY, start, end, new CodeSemantics());
         scan(node.getType(), null);
         scan(node.getDimensions(), null);
         boolean hasInit = node.getInitializers() != null && !node.getInitializers().isEmpty();
@@ -411,6 +412,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         scan(node.getInitializers(), null);
         // super method has annotation processing but we have it disabled anyways
         if (hasInit) {
+            end = positions.getEndPosition(ast, node.getInitializers().getLast()) - 1;
             addToken(JavaTokenType.J_ARRAY_INIT_END, end, 1, new CodeSemantics());
         }
         return null;

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -400,7 +400,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     public Void visitNewArray(NewArrayTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
         long end = positions.getEndPosition(ast, node) - 1;
-        addToken(JavaTokenType.J_NEWARRAY, start, 3, new CodeSemantics());
+        addToken(JavaTokenType.J_NEWARRAY, start, node.toString().length(), new CodeSemantics());
         scan(node.getType(), null);
         scan(node.getDimensions(), null);
         boolean hasInit = node.getInitializers() != null && !node.getInitializers().isEmpty();


### PR DESCRIPTION
Fixes the tracing information for `ASSIGN`, `VARDEF`, `NEWCLASS`, and `APPLY` tokens in the Java language module.

**Old:**

```java
31              int myVariable = 77777777;
                |VARDEF                 |

32              myVariable--;
                |assign

33              myVariable = myVariable - 1;
                |assign

34              int[] myArray = new int[7000];
                |VARDEF                     |
                                |NEWARRAY

35              System.out.print(myVariable + 200);
                |apply
```
(variable definition includes initialization, assignment has length 1, new array or class has length 1, apply not correct)

**New:**

```java
31              int myVariable = 77777777;
                |VARDEF         |

32              myVariable--;
                |ASSIGN    |

33              myVariable = myVariable - 1;
                |ASSIGN    |

34              int[] myArray = new int[7000];
                |VARDEF        ||NEWARRAY   |

35              System.out.print(myVariable + 200);
                |APPLY         |
```

(context includes only what is necessary, no length 1 tokens)

**Diff:**

```diff
31              int myVariable = 77777777;
-                |VARDEF                 |
+                |VARDEF         |

32              myVariable--;
-               |assign
+               |ASSIGN    |

33              myVariable = myVariable - 1;
-               |assign
+               |ASSIGN    |

34              int[] myArray = new int[7000];
-               |VARDEF                     |
-                               |NEWARRAY
+               |VARDEF        ||NEWARRAY   |

35              System.out.print(myVariable + 200);
-               |apply
+               |APPLY         |
```
