### PR TITLE
Replaced 'Commands' in the help text by 'Languages'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Subsequence Match Merging
       --neighbor-length=<minimumNeighborLength>
                         Minimal length of neighboring matches to be merged (between 1 and minTokenMatch, default: 2).
 
-Subcommands (supported languages):
+Languages:
   c
   cpp
   csharp

--- a/cli/src/main/java/de/jplag/cli/picocli/CliInputHandler.java
+++ b/cli/src/main/java/de/jplag/cli/picocli/CliInputHandler.java
@@ -1,5 +1,6 @@
 package de.jplag.cli.picocli;
 
+import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_COMMAND_LIST_HEADING;
 import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_DESCRIPTION_HEADING;
 import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_OPTION_LIST;
 import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_SYNOPSIS;
@@ -70,6 +71,7 @@ public class CliInputHandler {
             }
             return it;
         }).collect(Collectors.joining(System.lineSeparator())) + System.lineSeparator());
+        cli.getHelpSectionMap().put(SECTION_KEY_COMMAND_LIST_HEADING, help -> "Languages:" + System.lineSeparator());
 
         buildSubcommands().forEach(cli::addSubcommand);
 


### PR DESCRIPTION
Replaced 'Commands' in the help text by 'Languages'.