### PR TITLE
Improve code quality of token sequence normalization

### DIFF
--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -72,7 +72,8 @@ public class JPlag {
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
         SubmissionSet submissionSet = builder.buildSubmissionSet();
         if (options.normalize() && options.language().supportsNormalization() && options.language().requiresCoreNormalization()) {
-            submissionSet.normalizeSubmissions();
+            boolean normalizeOrder = !options.mergingOptions().enabled(); // match merging conflicts with sorting
+            submissionSet.normalizeSubmissions(normalizeOrder);
         }
         int submissionCount = submissionSet.numberOfSubmissions();
         if (submissionCount < 2) {

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -72,8 +72,7 @@ public class JPlag {
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
         SubmissionSet submissionSet = builder.buildSubmissionSet();
         if (options.normalize() && options.language().supportsNormalization() && options.language().requiresCoreNormalization()) {
-            boolean normalizeOrder = !options.mergingOptions().enabled(); // match merging conflicts with sorting
-            submissionSet.normalizeSubmissions(normalizeOrder);
+            submissionSet.normalizeSubmissions();
         }
         int submissionCount = submissionSet.numberOfSubmissions();
         if (submissionCount < 2) {

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -256,11 +256,10 @@ public class Submission implements Comparable<Submission> {
     /**
      * Perform token sequence normalization, which makes the token sequence invariant to dead code insertion and independent
      * statement reordering.
-     * @param sorting determines whether to perform topological sorting during normalization.
      */
-    void normalize(boolean sorting) {
+    void normalize() {
         List<Integer> originalOrder = getOrder(tokenList);
-        tokenList = TokenSequenceNormalizer.normalize(tokenList, sorting);
+        tokenList = TokenSequenceNormalizer.normalize(tokenList);
         List<Integer> normalizedOrder = getOrder(tokenList);
 
         logger.debug("original line order: {}", originalOrder);

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.jplag.exceptions.LanguageException;
-import de.jplag.normalization.TokenStringNormalizer;
+import de.jplag.normalization.TokenSequenceNormalizer;
 import de.jplag.options.JPlagOptions;
 
 /**
@@ -256,10 +256,11 @@ public class Submission implements Comparable<Submission> {
     /**
      * Perform token sequence normalization, which makes the token sequence invariant to dead code insertion and independent
      * statement reordering.
+     * @param sorting determines whether to perform topological sorting during normalization.
      */
-    void normalize() {
+    void normalize(boolean sorting) {
         List<Integer> originalOrder = getOrder(tokenList);
-        tokenList = TokenStringNormalizer.normalize(tokenList);
+        tokenList = TokenSequenceNormalizer.normalize(tokenList, sorting);
         List<Integer> normalizedOrder = getOrder(tokenList);
 
         logger.debug("original line order: {}", originalOrder);

--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -103,13 +103,12 @@ public class SubmissionSet {
      * Normalizes the token sequences of all submissions (including basecode). This makes the token sequence invariant to
      * dead code insertion and independent statement reordering by removing dead tokens and optionally reordering tokens to
      * a deterministic order.
-     * @param sorting determines whether to perform topological sorting during normalization.
      */
-    public void normalizeSubmissions(boolean sorting) {
+    public void normalizeSubmissions() {
         if (baseCodeSubmission != null) {
-            baseCodeSubmission.normalize(sorting);
+            baseCodeSubmission.normalize();
         }
-        ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, submission -> submission.normalize(sorting));
+        ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, submission -> submission.normalize());
     }
 
     private List<Submission> filterValidSubmissions() {

--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -108,7 +108,7 @@ public class SubmissionSet {
         if (baseCodeSubmission != null) {
             baseCodeSubmission.normalize();
         }
-        ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, submission -> submission.normalize());
+        ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, Submission::normalize);
     }
 
     private List<Submission> filterValidSubmissions() {

--- a/core/src/main/java/de/jplag/SubmissionSet.java
+++ b/core/src/main/java/de/jplag/SubmissionSet.java
@@ -99,11 +99,17 @@ public class SubmissionSet {
         return invalidSubmissions;
     }
 
-    public void normalizeSubmissions() {
+    /**
+     * Normalizes the token sequences of all submissions (including basecode). This makes the token sequence invariant to
+     * dead code insertion and independent statement reordering by removing dead tokens and optionally reordering tokens to
+     * a deterministic order.
+     * @param sorting determines whether to perform topological sorting during normalization.
+     */
+    public void normalizeSubmissions(boolean sorting) {
         if (baseCodeSubmission != null) {
-            baseCodeSubmission.normalize();
+            baseCodeSubmission.normalize(sorting);
         }
-        ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, Submission::normalize);
+        ProgressBarLogger.iterate(ProgressBarType.TOKEN_STRING_NORMALIZATION, submissions, submission -> submission.normalize(sorting));
     }
 
     private List<Submission> filterValidSubmissions() {

--- a/core/src/main/java/de/jplag/normalization/MultipleEdge.java
+++ b/core/src/main/java/de/jplag/normalization/MultipleEdge.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import de.jplag.semantics.Variable;
 
 /**
- * Models a multiple edge in the normalization graph. Contains multiple edges.
+ * Models multiple edges between two nodes in the normalization graph.
  */
 class MultipleEdge {
     private final Set<Edge> edges;

--- a/core/src/main/java/de/jplag/normalization/NormalizationGraph.java
+++ b/core/src/main/java/de/jplag/normalization/NormalizationGraph.java
@@ -23,13 +23,13 @@ public class NormalizationGraph extends SimpleDirectedGraph<Statement, MultipleE
     private static final long serialVersionUID = -8407465274643809647L; // generated
 
     private int bidirectionalBlockDepth;
-    private final Collection<Statement> fullPositionSignificanceIncoming;
-    private Statement lastFullPositionSignificance;
-    private Statement lastPartialPositionSignificance;
-    private final Map<Variable, Collection<Statement>> variableReads;
-    private final Map<Variable, Collection<Statement>> variableWrites;
-    private final Set<Statement> inCurrentBidirectionalBlock;
-    private Statement current;
+    private final transient Collection<Statement> fullPositionSignificanceIncoming;
+    private transient Statement lastFullPositionSignificance;
+    private transient Statement lastPartialPositionSignificance;
+    private final transient Map<Variable, Collection<Statement>> variableReads;
+    private final transient Map<Variable, Collection<Statement>> variableWrites;
+    private final transient Set<Statement> inCurrentBidirectionalBlock;
+    private transient Statement current;
 
     /**
      * Creates a new normalization graph.

--- a/core/src/main/java/de/jplag/normalization/NormalizationGraph.java
+++ b/core/src/main/java/de/jplag/normalization/NormalizationGraph.java
@@ -14,10 +14,14 @@ import de.jplag.Token;
 import de.jplag.semantics.Variable;
 
 /**
- * Constructs the normalization graph.
+ * Token normalization graph, which is a directed graph based on nodes of type {@link Statement} and edges of type
+ * {@link MultipleEdge}. This class class inherits from {@link SimpleDirectedGraph} to provide a data structure for the
+ * token sequence normalization.
  */
-class NormalizationGraphConstructor {
-    private final SimpleDirectedGraph<Statement, MultipleEdge> graph;
+public class NormalizationGraph extends SimpleDirectedGraph<Statement, MultipleEdge> {
+
+    private static final long serialVersionUID = -8407465274643809647L; // generated
+
     private int bidirectionalBlockDepth;
     private final Collection<Statement> fullPositionSignificanceIncoming;
     private Statement lastFullPositionSignificance;
@@ -27,8 +31,11 @@ class NormalizationGraphConstructor {
     private final Set<Statement> inCurrentBidirectionalBlock;
     private Statement current;
 
-    NormalizationGraphConstructor(List<Token> tokens) {
-        graph = new SimpleDirectedGraph<>(MultipleEdge.class);
+    /**
+     * Creates a new normalization graph.
+     */
+    public NormalizationGraph(List<Token> tokens) {
+        super(MultipleEdge.class);
         bidirectionalBlockDepth = 0;
         fullPositionSignificanceIncoming = new ArrayList<>();
         variableReads = new HashMap<>();
@@ -45,12 +52,8 @@ class NormalizationGraphConstructor {
         addStatement(builderForCurrent.build());
     }
 
-    SimpleDirectedGraph<Statement, MultipleEdge> get() {
-        return graph;
-    }
-
     private void addStatement(Statement statement) {
-        graph.addVertex(statement);
+        addVertex(statement);
         this.current = statement;
         processBidirectionalBlock();
         processFullPositionSignificance();
@@ -123,10 +126,10 @@ class NormalizationGraphConstructor {
      * @param cause the variable that caused the edge, may be null
      */
     private void addIncomingEdgeToCurrent(Statement start, EdgeType type, Variable cause) {
-        MultipleEdge multipleEdge = graph.getEdge(start, current);
+        MultipleEdge multipleEdge = getEdge(start, current);
         if (multipleEdge == null) {
             multipleEdge = new MultipleEdge();
-            graph.addEdge(start, current, multipleEdge);
+            addEdge(start, current, multipleEdge);
         }
         multipleEdge.addEdge(type, cause);
     }
@@ -135,4 +138,5 @@ class NormalizationGraphConstructor {
         variableMap.putIfAbsent(variable, new ArrayList<>());
         variableMap.get(variable).add(current);
     }
+
 }

--- a/core/src/main/java/de/jplag/normalization/Statement.java
+++ b/core/src/main/java/de/jplag/normalization/Statement.java
@@ -8,7 +8,7 @@ import de.jplag.Token;
 import de.jplag.semantics.CodeSemantics;
 
 /**
- * Models statements, which are the nodes of the normalization graph.
+ * Models statements, which are the nodes of the normalization graph. A statement refers to one or more tokens.
  */
 class Statement implements Comparable<Statement> {
 
@@ -16,6 +16,11 @@ class Statement implements Comparable<Statement> {
     private final int lineNumber;
     private final CodeSemantics semantics;
 
+    /**
+     * Constructs a new Statement.
+     * @param tokens the list of tokens that represent this statement.
+     * @param lineNumber the line number where this statement occurs in the source code.
+     */
     Statement(List<Token> tokens, int lineNumber) {
         this.tokens = Collections.unmodifiableList(tokens);
         this.lineNumber = lineNumber;
@@ -30,8 +35,8 @@ class Statement implements Comparable<Statement> {
         return semantics;
     }
 
-    void markKeep() {
-        semantics.markKeep();
+    void markAsCritical() {
+        semantics.markAsCritical();
     }
 
     private int tokenOrdinal(Token token) {

--- a/core/src/main/java/de/jplag/normalization/StatementBuilder.java
+++ b/core/src/main/java/de/jplag/normalization/StatementBuilder.java
@@ -13,6 +13,10 @@ class StatementBuilder {
     private final List<Token> tokens;
     private final int lineNumber;
 
+    /**
+     * Constructs a new StatementBuilder.
+     * @param lineNumber the line number where the statement starts in the source code.
+     */
     StatementBuilder(int lineNumber) {
         this.lineNumber = lineNumber;
         this.tokens = new ArrayList<>();

--- a/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
+++ b/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
@@ -1,7 +1,6 @@
 package de.jplag.normalization;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;

--- a/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
+++ b/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
@@ -33,10 +33,8 @@ public class TokenSequenceNormalizer {
         propagateKeepStatus(normalizationGraph);
         if (sorting) {
             return normalizeWithSorting(tokens, normalizationGraph);
-        } else {
-            return normalizeWithoutSorting(normalizationGraph, tokens);
         }
-
+        return normalizeWithoutSorting(normalizationGraph, tokens);
     }
 
     // Add tokens in normalized original order, removing dead tokens

--- a/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
+++ b/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
@@ -15,9 +15,10 @@ import de.jplag.Token;
 /**
  * Performs token sequence normalization.
  */
-public class TokenSequenceNormalizer {
+public final class TokenSequenceNormalizer {
 
     private TokenSequenceNormalizer() {
+        // private constructor for non-instantiability.
     }
 
     /**

--- a/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
+++ b/core/src/main/java/de/jplag/normalization/TokenSequenceNormalizer.java
@@ -26,16 +26,12 @@ public final class TokenSequenceNormalizer {
      * Normalization Graph and then turning it back into a token sequence. For more information refer to the
      * <a href="https://doi.org/10.1145/3639478.3643074">corresponding paper</a>
      * @param tokens The original token sequence, remains unaltered.
-     * @param sorting Boolean flag to control if the tokens should be topologically sorted.
      * @return The normalized token sequence.
      */
-    public static List<Token> normalize(List<Token> tokens, boolean sorting) {
+    public static List<Token> normalize(List<Token> tokens) {
         NormalizationGraph graph = new NormalizationGraph(tokens);
         propagateCriticalityStatus(graph);
-        if (sorting) {
-            return normalizeWithSorting(tokens, graph);
-        }
-        return normalizeWithoutSorting(tokens, graph);
+        return normalizeWithSorting(tokens, graph);
     }
 
     // Add tokens in normalized original order, removing dead tokens
@@ -59,17 +55,6 @@ public final class TokenSequenceNormalizer {
                 }
             } while (!roots.isEmpty());
             roots = newRoots;
-        }
-        return normalizedTokens;
-    }
-
-    // Add tokens in the original order, removing dead tokens
-    private static List<Token> normalizeWithoutSorting(List<Token> tokens, NormalizationGraph normalizationGraph) {
-        List<Token> normalizedTokens = new ArrayList<>(tokens.size());
-        for (Statement statement : normalizationGraph.vertexSet()) {
-            if (statement.semantics().isCritical()) {
-                normalizedTokens.addAll(statement.tokens());
-            }
         }
         return normalizedTokens;
     }

--- a/core/src/test/java/de/jplag/NormalizationTest.java
+++ b/core/src/test/java/de/jplag/NormalizationTest.java
@@ -6,51 +6,37 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import de.jplag.exceptions.ExitException;
 import de.jplag.options.JPlagOptions;
 
 class NormalizationTest extends TestBase {
-    private Map<String, List<TokenType>> tokenStringMap;
-    private List<TokenType> originalTokenString;
-    private SubmissionSet submissionSet;
+    private final Map<String, List<TokenType>> tokenStringMap;
+    private final List<TokenType> originalTokenString;
 
-    @BeforeEach
-    void setUp() throws ExitException {
+    NormalizationTest() throws ExitException {
         JPlagOptions options = getDefaultOptions("normalization");
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
-        submissionSet = builder.buildSubmissionSet();
-    }
-
-    // normalize submission set and initialize fields
-    private void normalizeSubmissions(boolean sorting) {
-        submissionSet.normalizeSubmissions(sorting);
+        SubmissionSet submissionSet = builder.buildSubmissionSet();
+        submissionSet.normalizeSubmissions();
         Function<Submission, List<TokenType>> getTokenString = submission -> submission.getTokenList().stream().map(Token::getType).toList();
         tokenStringMap = submissionSet.getSubmissions().stream().collect(Collectors.toMap(Submission::getName, getTokenString));
         originalTokenString = tokenStringMap.get("Squares.java");
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testInsertionNormalization(boolean sorting) {
-        normalizeSubmissions(sorting);
+    @Test
+    void testInsertionNormalization() {
         Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresInserted.java"));
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testReorderingNormalization(boolean sorting) {
-        normalizeSubmissions(sorting);
-        Assertions.assertEquals(sorting, originalTokenString.equals(tokenStringMap.get("SquaresReordered.java")));
+    @Test
+    void testReorderingNormalization() {
+        Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresReordered.java"));
     }
 
     @Test
     void testInsertionReorderingNormalization() {
-        normalizeSubmissions(true);
         Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresInsertedReordered.java"));
     }
 }

--- a/core/src/test/java/de/jplag/NormalizationTest.java
+++ b/core/src/test/java/de/jplag/NormalizationTest.java
@@ -24,9 +24,9 @@ class NormalizationTest extends TestBase {
         JPlagOptions options = getDefaultOptions("normalization");
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
         submissionSet = builder.buildSubmissionSet();
-
     }
 
+    // normalize submission set and initialize fields
     private void normalizeSubmissions(boolean sorting) {
         submissionSet.normalizeSubmissions(sorting);
         Function<Submission, List<TokenType>> getTokenString = submission -> submission.getTokenList().stream().map(Token::getType).toList();
@@ -41,10 +41,11 @@ class NormalizationTest extends TestBase {
         Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresInserted.java"));
     }
 
-    @Test
-    void testReorderingNormalization() {
-        normalizeSubmissions(true);
-        Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresReordered.java"));
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testReorderingNormalization(boolean sorting) {
+        normalizeSubmissions(sorting);
+        Assertions.assertEquals(sorting, originalTokenString.equals(tokenStringMap.get("SquaresReordered.java")));
     }
 
     @Test

--- a/core/src/test/java/de/jplag/NormalizationTest.java
+++ b/core/src/test/java/de/jplag/NormalizationTest.java
@@ -6,37 +6,50 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import de.jplag.exceptions.ExitException;
 import de.jplag.options.JPlagOptions;
 
 class NormalizationTest extends TestBase {
-    private final Map<String, List<TokenType>> tokenStringMap;
-    private final List<TokenType> originalTokenString;
+    private Map<String, List<TokenType>> tokenStringMap;
+    private List<TokenType> originalTokenString;
+    private SubmissionSet submissionSet;
 
-    NormalizationTest() throws ExitException {
+    @BeforeEach
+    void setUp() throws ExitException {
         JPlagOptions options = getDefaultOptions("normalization");
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
-        SubmissionSet submissionSet = builder.buildSubmissionSet();
-        submissionSet.normalizeSubmissions();
+        submissionSet = builder.buildSubmissionSet();
+
+    }
+
+    private void normalizeSubmissions(boolean sorting) {
+        submissionSet.normalizeSubmissions(sorting);
         Function<Submission, List<TokenType>> getTokenString = submission -> submission.getTokenList().stream().map(Token::getType).toList();
         tokenStringMap = submissionSet.getSubmissions().stream().collect(Collectors.toMap(Submission::getName, getTokenString));
         originalTokenString = tokenStringMap.get("Squares.java");
     }
 
-    @Test
-    void testInsertionNormalization() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testInsertionNormalization(boolean sorting) {
+        normalizeSubmissions(sorting);
         Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresInserted.java"));
     }
 
     @Test
     void testReorderingNormalization() {
+        normalizeSubmissions(true);
         Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresReordered.java"));
     }
 
     @Test
     void testInsertionReorderingNormalization() {
+        normalizeSubmissions(true);
         Assertions.assertIterableEquals(originalTokenString, tokenStringMap.get("SquaresInsertedReordered.java"));
     }
 }


### PR DESCRIPTION
This PR improves the code quality of the token sequence normalization module:

- Add more documentation
- Use more speaking names to avoid cryptic code
- Merge graph builder into dedicated graph class to avoid using unspecific data structures
- Rename concepts to be consistent with the paper
- Add paper link

<details><summary>Old Description (Outdated)</summary>

Run [token sequence normalization](https://doi.org/10.1145/3597503.3639192) (`--normalize`) without topological sorting whenever match merging (`--match--merging`) is enabled to prevent interference. This PR also adapts the naming of `TokenStringNormalizer` to `TokenSequenceNormalizer` which is the terminology used in JDoc and the scientific literature.

This PR also refactors the token sequence normalization to improve code quality.

**Background:**
The reordering of tokens to normalize the token order helps to improve detection quality slightly, but the main impact comes from dead token removal. When match merging is also enabled, it struggles to revert split matches due to the sorting of the token sequence normalization. Thus, when using both, the topological sorting is now disabled in favor of match merging.

</details>