### PR TITLE
Added structure for token position tests.

### DIFF
--- a/docs/4.-Adding-New-Languages.md
+++ b/docs/4.-Adding-New-Languages.md
@@ -510,6 +510,31 @@ protected File getTestFileLocation() {
 }
 ```
 
+## Testing token positions
+
+The precise position of a token can be relevant for the visualization in the report viewer. To make sure the token positions are extracted correctly language modules should include some test for that.
+
+Writing such tests can be done using a specific syntax in the test sources directly.
+Such a file can look like this:
+```java
+>class Test {
+>    int test;
+$    | J_VARDEF 8
+>}
+```
+
+Every line that is prefixed with '>' will be interpreted as a line of test source code.
+
+Every line starting with '$' contains information about one expected token. The token is expected in the first source line above this one.
+The '|' marks the column the token should be in. It is followed by one space, then the name of the token (The name of the enum constant).
+Finally separated with another space is the length of the token.
+A single file may contain any number of tokens.
+The test will verify that at least one token with those exact properties exist.
+
+These test files have to be added in the TestDataCollector. Put all test files in a single directory and specify it though collector.addTokenPositionTests("<directory>").
+If the directory is in the default location for test files, a relative path is enough, otherwise a full path has to be specified.
+
+
 # Adding code highlighting to the report-viewer
 To ensure your language gets properly registered and its code is correctly highlighted in the report-viewer:
 1) Add your language to the `ParserLanguage` enum in 'src/model/Language.ts'. As the value for the entry use its frontend name.

--- a/docs/4.-Adding-New-Languages.md
+++ b/docs/4.-Adding-New-Languages.md
@@ -512,7 +512,7 @@ protected File getTestFileLocation() {
 
 ## Testing token positions
 
-The precise position of a token can be relevant for the visualization in the report viewer. To make sure the token positions are extracted correctly language modules should include some test for that.
+The precise position of a token can be relevant for the visualization in the report viewer. To make sure the token positions are extracted correctly language modules should include some tests for that.
 
 Writing such tests can be done using a specific syntax in the test sources directly.
 Such a file can look like this:
@@ -527,11 +527,11 @@ Every line that is prefixed with '>' will be interpreted as a line of test sourc
 
 Every line starting with '$' contains information about one expected token. The token is expected in the first source line above this one.
 The '|' marks the column the token should be in. It is followed by one space, then the name of the token (The name of the enum constant).
-Finally separated with another space is the length of the token.
+Finally, separated by another space is the length of the token.
 A single file may contain any number of tokens.
-The test will verify that at least one token with those exact properties exist.
+The test will verify that at least one token with those exact properties exists.
 
-These test files have to be added in the TestDataCollector. Put all test files in a single directory and specify it though collector.addTokenPositionTests("<directory>").
+These test files have to be added in the TestDataCollector. Put all test files in a single directory and specify it through collector.addTokenPositionTests("<directory>").
 If the directory is in the default location for test files, a relative path is enough, otherwise a full path has to be specified.
 
 

--- a/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
@@ -222,7 +222,7 @@ public abstract class LanguageModuleTest {
     }
 
     final List<TokenPositionTestData> getTokenPositionTestData() {
-        return this.collector.getTokenPositionTestData();
+        return ignoreEmptyTestType(this.collector.getTokenPositionTestData());
     }
 
     /**

--- a/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
@@ -176,7 +176,7 @@ public abstract class LanguageModuleTest {
     final void testTokenSequence(TestDataCollector.TokenListTest test) throws ParsingException, IOException {
         List<TokenType> actual = extractTokenTypes(test.data());
         List<TokenType> expected = new ArrayList<>(test.tokens());
-        if (expected.get(expected.size() - 1) != SharedTokenType.FILE_END) {
+        if (expected.getLast() != SharedTokenType.FILE_END) {
             expected.add(SharedTokenType.FILE_END);
         }
         assertTokensMatch(expected, actual, "Extracted token from " + test.data().describeTestSource() + " does not match expected sequence.");
@@ -198,6 +198,12 @@ public abstract class LanguageModuleTest {
         return ignoreEmptyTestType(this.collector.getTokenSequenceTest());
     }
 
+    /**
+     * Tests if the tokens specified for the token position tests are present in the sources
+     * @param testData The specifications of the expected tokens and the test source
+     * @throws ParsingException If the parsing fails
+     * @throws IOException If IO operations fail. If this happens, that should be unrelated to the test itself.
+     */
     @ParameterizedTest
     @MethodSource("getTokenPositionTestData")
     @DisplayName("Tests if the extracted tokens contain the tokens specified in the test files.")
@@ -206,7 +212,8 @@ public abstract class LanguageModuleTest {
         List<TokenPositionTestData.TokenData> failedTokens = new ArrayList<>();
 
         for (TokenPositionTestData.TokenData expectedToken : testData.getExpectedTokens()) {
-            TokenType expectedType = this.languageTokens.stream().filter(type -> type.toString().equals(expectedToken.typeName())).findFirst().get();
+            TokenType expectedType = this.languageTokens.stream().filter(type -> type.toString().equals(expectedToken.typeName())).findFirst()
+                    .orElseThrow(() -> new IOException(String.format("The token type %s does not exist.", expectedToken.typeName())));
 
             if (extractedTokens.stream().noneMatch(token -> token.getType() == expectedType && token.getLine() == expectedToken.line()
                     && token.getColumn() == expectedToken.col() && token.getLength() == expectedToken.length())) {
@@ -221,6 +228,9 @@ public abstract class LanguageModuleTest {
         }
     }
 
+    /**
+     * @return All token positions tests that are configured
+     */
     final List<TokenPositionTestData> getTokenPositionTestData() {
         return ignoreEmptyTestType(this.collector.getTokenPositionTestData());
     }
@@ -260,8 +270,7 @@ public abstract class LanguageModuleTest {
     final void testTokenSequencesEndsWithFileEnd(TestData data) throws ParsingException, IOException {
         List<Token> tokens = parseTokens(data);
 
-        assertEquals(SharedTokenType.FILE_END, tokens.get(tokens.size() - 1).getType(),
-                "Last token in " + data.describeTestSource() + " is not file end.");
+        assertEquals(SharedTokenType.FILE_END, tokens.getLast().getType(), "Last token in " + data.describeTestSource() + " is not file end.");
     }
 
     /**

--- a/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
@@ -215,16 +215,18 @@ public abstract class LanguageModuleTest {
             TokenType expectedType = this.languageTokens.stream().filter(type -> type.toString().equals(expectedToken.typeName())).findFirst()
                     .orElseThrow(() -> new IOException(String.format("The token type %s does not exist.", expectedToken.typeName())));
 
-            if (extractedTokens.stream().noneMatch(token -> token.getType() == expectedType && token.getLine() == expectedToken.line()
-                    && token.getColumn() == expectedToken.col() && token.getLength() == expectedToken.length())) {
+            if (extractedTokens.stream().noneMatch(token -> token.getType() == expectedType && token.getLine() == expectedToken.lineNumber()
+                    && token.getColumn() == expectedToken.columnNumber() && token.getLength() == expectedToken.length())) {
                 failedTokens.add(expectedToken);
             }
         }
 
         if (!failedTokens.isEmpty()) {
-            String failDescriptors = String.join(System.lineSeparator(), failedTokens.stream()
-                    .map(token -> token.typeName() + " at (" + token.line() + ":" + token.col() + ") with length " + token.length()).toList());
-            fail("Some tokens weren't extracted with the correct properties:" + System.lineSeparator() + failDescriptors);
+            String failureDescriptors = String.join(System.lineSeparator(),
+                    failedTokens.stream().map(
+                            token -> token.typeName() + " at (" + token.lineNumber() + ":" + token.columnNumber() + ") with length " + token.length())
+                            .toList());
+            fail("Some tokens weren't extracted with the correct properties:" + System.lineSeparator() + failureDescriptors);
         }
     }
 
@@ -290,8 +292,8 @@ public abstract class LanguageModuleTest {
     }
 
     @AfterAll
-    final void releaseTmpFiles() {
-        TmpFileHolder.deleteTmpFiles();
+    final void deleteTemporaryFiles() {
+        TemporaryFileHolder.deleteTemporaryFiles();
     }
 
     private List<Token> parseTokens(TestData source) throws ParsingException, IOException {

--- a/language-testutils/src/test/java/de/jplag/testutils/TemporaryFileHolder.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/TemporaryFileHolder.java
@@ -7,14 +7,14 @@ import java.util.List;
 /**
  * Stores all temporary files that are created for a {@link LanguageModuleTest} and provides the option to delete them
  */
-public class TmpFileHolder {
-    public static List<File> tmpFiles = new ArrayList<>();
+public class TemporaryFileHolder {
+    public static List<File> temporaryFiles = new ArrayList<>();
 
     /**
      * Deletes all temporary files that have been created up to this point
      */
-    public static void deleteTmpFiles() {
-        tmpFiles.forEach(File::delete);
-        tmpFiles.clear();
+    public static void deleteTemporaryFiles() {
+        temporaryFiles.forEach(File::delete);
+        temporaryFiles.clear();
     }
 }

--- a/language-testutils/src/test/java/de/jplag/testutils/TmpFileHolder.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/TmpFileHolder.java
@@ -4,9 +4,15 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Stores all temporary files that are created for a {@link LanguageModuleTest} and provides the option to delete them
+ */
 public class TmpFileHolder {
     public static List<File> tmpFiles = new ArrayList<>();
 
+    /**
+     * Deletes all temporary files that have been created up to this point
+     */
     public static void deleteTmpFiles() {
         tmpFiles.forEach(File::delete);
         tmpFiles.clear();

--- a/language-testutils/src/test/java/de/jplag/testutils/TmpFileHolder.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/TmpFileHolder.java
@@ -1,0 +1,14 @@
+package de.jplag.testutils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TmpFileHolder {
+    public static List<File> tmpFiles = new ArrayList<>();
+
+    public static void deleteTmpFiles() {
+        tmpFiles.forEach(File::delete);
+        tmpFiles.clear();
+    }
+}

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
@@ -8,7 +8,7 @@ import java.util.List;
 import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
-import de.jplag.testutils.TmpFileHolder;
+import de.jplag.testutils.TemporaryFileHolder;
 import de.jplag.util.FileUtils;
 
 /**
@@ -26,7 +26,7 @@ class InlineTestData implements TestData {
         File file = File.createTempFile("testSource", language.suffixes()[0]);
         FileUtils.write(file, this.testData);
         List<Token> tokens = language.parse(Collections.singleton(file));
-        TmpFileHolder.tmpFiles.add(file);
+        TemporaryFileHolder.temporaryFiles.add(file);
         return tokens;
     }
 

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
@@ -8,6 +8,7 @@ import java.util.List;
 import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
+import de.jplag.testutils.TmpFileHolder;
 import de.jplag.util.FileUtils;
 
 /**
@@ -25,7 +26,7 @@ class InlineTestData implements TestData {
         File file = File.createTempFile("testSource", language.suffixes()[0]);
         FileUtils.write(file, this.testData);
         List<Token> tokens = language.parse(Collections.singleton(file));
-        file.delete();
+        TmpFileHolder.tmpFiles.add(file);
         return tokens;
     }
 

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
@@ -1,10 +1,13 @@
 package de.jplag.testutils.datacollector;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -18,6 +21,7 @@ public class TestDataCollector {
     private final List<TestData> tokenCoverageData;
     private final List<TokenListTest> containedTokenData;
     private final List<TokenListTest> tokenSequenceTest;
+    private final List<TokenPositionTestData> tokenPositionTestData;
 
     private final List<TestData> allTestData;
 
@@ -34,6 +38,7 @@ public class TestDataCollector {
         this.tokenCoverageData = new ArrayList<>();
         this.containedTokenData = new ArrayList<>();
         this.tokenSequenceTest = new ArrayList<>();
+        this.tokenPositionTestData = new ArrayList<>();
 
         this.allTestData = new ArrayList<>();
     }
@@ -74,6 +79,28 @@ public class TestDataCollector {
     }
 
     /**
+     * Adds all files from the given directory for token position tests. The sources can still be used for other tests,
+     * using the returned {@link TestDataContext}
+     * @param directoryName The name of the directory containing the token position tests.
+     * @return The context containing the added sources
+     * @throws IOException If the files cannot be read
+     */
+    public TestDataContext addTokenPositionTests(String directoryName) {
+        File dir = new File(this.testFileLocation, directoryName);
+        Set<TestData> allData = new HashSet<>();
+        for (File file : Objects.requireNonNull(dir.listFiles())) {
+            try {
+                TokenPositionTestData data = new TokenPositionTestData(file);
+                allData.add(data);
+                this.tokenPositionTestData.add(data);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return new TestDataContext(allData);
+    }
+
+    /**
      * @return The test data that should be checked for source coverage
      */
     public List<TestData> getSourceCoverageData() {
@@ -99,6 +126,10 @@ public class TestDataCollector {
      */
     public List<TokenListTest> getTokenSequenceTest() {
         return Collections.unmodifiableList(tokenSequenceTest);
+    }
+
+    public List<TokenPositionTestData> getTokenPositionTestData() {
+        return Collections.unmodifiableList(this.tokenPositionTestData);
     }
 
     /**

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
@@ -86,18 +86,18 @@ public class TestDataCollector {
      * @throws IOException If the files cannot be read
      */
     public TestDataContext addTokenPositionTests(String directoryName) {
-        File dir = new File(this.testFileLocation, directoryName);
-        Set<TestData> allData = new HashSet<>();
-        for (File file : Objects.requireNonNull(dir.listFiles())) {
+        File directory = new File(this.testFileLocation, directoryName);
+        Set<TestData> allTestsInDirectory = new HashSet<>();
+        for (File file : Objects.requireNonNull(directory.listFiles())) {
             try {
                 TokenPositionTestData data = new TokenPositionTestData(file);
-                allData.add(data);
+                allTestsInDirectory.add(data);
                 this.tokenPositionTestData.add(data);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
-        return new TestDataContext(allData);
+        return new TestDataContext(allTestsInDirectory);
     }
 
     /**

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -12,12 +12,20 @@ import de.jplag.Token;
 import de.jplag.testutils.TmpFileHolder;
 import de.jplag.util.FileUtils;
 
+/**
+ * Test sources with token information Reads token position test specifications form a file and provides the token
+ * information for tests. The sources cna be used as regular test sources.
+ */
 public class TokenPositionTestData implements TestData {
     private final List<String> sourceLines;
     private final List<TokenData> expectedTokens;
 
     private final String descriptor;
 
+    /**
+     * @param testFile The file containing the test specifications
+     * @throws IOException If the file cannot be read
+     */
     public TokenPositionTestData(File testFile) throws IOException {
         this.sourceLines = new ArrayList<>();
         this.expectedTokens = new ArrayList<>();
@@ -65,10 +73,20 @@ public class TokenPositionTestData implements TestData {
         return this.descriptor;
     }
 
+    /**
+     * @return A list of the expected tokens for this test source
+     */
     public List<TokenData> getExpectedTokens() {
         return expectedTokens;
     }
 
+    /**
+     * Information about a single token
+     * @param typeName The name of the token type
+     * @param line The line the token is in
+     * @param col The column the token is in
+     * @param length The length of the token
+     */
     public record TokenData(String typeName, int line, int col, int length) {
     }
 }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -9,12 +9,12 @@ import java.util.List;
 import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
-import de.jplag.testutils.TmpFileHolder;
+import de.jplag.testutils.TemporaryFileHolder;
 import de.jplag.util.FileUtils;
 
 /**
  * Test sources with token information Reads token position test specifications form a file and provides the token
- * information for tests. The sources cna be used as regular test sources.
+ * information for tests. The sources can be used as regular test sources.
  */
 public class TokenPositionTestData implements TestData {
     private final List<String> sourceLines;
@@ -44,12 +44,12 @@ public class TokenPositionTestData implements TestData {
             }
 
             if (sourceLine.charAt(0) == '$') {
-                int col = sourceLine.indexOf('|');
-                String[] parts = sourceLine.split(" ", 0);
+                int column = sourceLine.indexOf('|');
+                String[] tokenDescriptionParts = sourceLine.split(" ", 0);
 
-                String typeName = parts[parts.length - 2];
-                int length = Integer.parseInt(parts[parts.length - 1]);
-                this.expectedTokens.add(new TokenData(typeName, currentLine, col, length));
+                String typeName = tokenDescriptionParts[tokenDescriptionParts.length - 2];
+                int length = Integer.parseInt(tokenDescriptionParts[tokenDescriptionParts.length - 1]);
+                this.expectedTokens.add(new TokenData(typeName, currentLine, column, length));
             }
         }
     }
@@ -59,7 +59,7 @@ public class TokenPositionTestData implements TestData {
         File file = File.createTempFile("testSource", language.suffixes()[0]);
         FileUtils.write(file, String.join(System.lineSeparator(), sourceLines));
         List<Token> tokens = language.parse(Collections.singleton(file));
-        TmpFileHolder.tmpFiles.add(file);
+        TemporaryFileHolder.temporaryFiles.add(file);
         return tokens;
     }
 
@@ -83,10 +83,10 @@ public class TokenPositionTestData implements TestData {
     /**
      * Information about a single token
      * @param typeName The name of the token type
-     * @param line The line the token is in
-     * @param col The column the token is in
+     * @param lineNumber The line the token is in (1 based)
+     * @param columnNumber The column the token is in (1 based)
      * @param length The length of the token
      */
-    public record TokenData(String typeName, int line, int col, int length) {
+    public record TokenData(String typeName, int lineNumber, int columnNumber, int length) {
     }
 }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -1,0 +1,74 @@
+package de.jplag.testutils.datacollector;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import de.jplag.Language;
+import de.jplag.ParsingException;
+import de.jplag.Token;
+import de.jplag.testutils.TmpFileHolder;
+import de.jplag.util.FileUtils;
+
+public class TokenPositionTestData implements TestData {
+    private final List<String> sourceLines;
+    private final List<TokenData> expectedTokens;
+
+    private final String descriptor;
+
+    public TokenPositionTestData(File testFile) throws IOException {
+        this.sourceLines = new ArrayList<>();
+        this.expectedTokens = new ArrayList<>();
+        this.descriptor = "(Token position file: " + testFile.getName() + ")";
+        this.readFile(testFile);
+    }
+
+    private void readFile(File testFile) throws IOException {
+        List<String> testFileLines = FileUtils.readFileContent(testFile).lines().toList();
+        int currentLine = 0;
+
+        for (String sourceLine : testFileLines) {
+            if (sourceLine.charAt(0) == '>') {
+                this.sourceLines.add(sourceLine.substring(1));
+                currentLine++;
+            }
+
+            if (sourceLine.charAt(0) == '$') {
+                int col = sourceLine.indexOf('|');
+                String[] parts = sourceLine.split(" ", 0);
+
+                String typeName = parts[parts.length - 2];
+                int length = Integer.parseInt(parts[parts.length - 1]);
+                this.expectedTokens.add(new TokenData(typeName, currentLine, col, length));
+            }
+        }
+    }
+
+    @Override
+    public List<Token> parseTokens(Language language) throws ParsingException, IOException {
+        File file = File.createTempFile("testSource", language.suffixes()[0]);
+        FileUtils.write(file, String.join(System.lineSeparator(), sourceLines));
+        List<Token> tokens = language.parse(Collections.singleton(file));
+        TmpFileHolder.tmpFiles.add(file);
+        return tokens;
+    }
+
+    @Override
+    public String[] getSourceLines() {
+        return this.sourceLines.toArray(new String[0]);
+    }
+
+    @Override
+    public String describeTestSource() {
+        return this.descriptor;
+    }
+
+    public List<TokenData> getExpectedTokens() {
+        return expectedTokens;
+    }
+
+    public record TokenData(String typeName, int line, int col, int length) {
+    }
+}

--- a/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
@@ -73,6 +73,8 @@ public class JavaLanguageTest extends LanguageModuleTest {
 
         collector.testFile("AnonymousVariables.java").testTokenSequence(J_CLASS_BEGIN, J_METHOD_BEGIN, J_VARDEF, J_IF_BEGIN, J_IF_END, J_METHOD_END,
                 J_CLASS_END);
+
+        collector.addTokenPositionTests("tokenPositions");
     }
 
     @Override

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/VarDef_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/VarDef_1.java
@@ -1,0 +1,4 @@
+>class Test {
+>    int test;
+$    | J_VARDEF 8
+>}

--- a/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/RParserAdapter.java
@@ -83,8 +83,8 @@ public class RParserAdapter extends AbstractParser {
     /**
      * Adds a new {@link Token} to the current token list.
      * @param type the type of the new {@link Token}
-     * @param line the line of the Token in the current file
-     * @param start the start column of the Token in the line
+     * @param line the lineNumber of the Token in the current file
+     * @param start the start column of the Token in the lineNumber
      * @param length the length of the Token
      */
     /* package-private */ void addToken(TokenType type, int line, int start, int length) {


### PR DESCRIPTION
This adds the structure for token position tests.

The tests are written by adding test sources with a specific syntax, see languages/java/src/test/resources/de/jplag/java/tokenPositions/VarDef_1.java. The actual source is given with each line prefixed by '>'. Lines with '$' as a prefix contain information for one expected token each. The '|' marks the spot where the token should be extracted in the source line above. After that the token type follows and last the length of the token.