### PR TITLE
Adjust report viewer logging rules

### DIFF
--- a/report-viewer/.eslintrc.cjs
+++ b/report-viewer/.eslintrc.cjs
@@ -14,7 +14,7 @@ module.exports = {
   },
   plugins: ['@typescript-eslint', 'vue'],
   rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
     'no-restricted-exports': ['error', { restrictDefaultExports: { direct: true } }],
     'vue/no-setup-props-reactivity-loss': 'error'
   },

--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -83,7 +83,7 @@ const hoverableEdges = computed(() => {
       const firstIndex = keys.value.indexOf(key)
       const secondIndex = keys.value.indexOf(match.matchedWith)
       if (firstIndex == -1 || secondIndex == -1) {
-        console.log(`Could not find index for ${key} or ${match.matchedWith}`)
+        console.warn(`Could not find index for ${key} or ${match.matchedWith}`)
       }
       if (firstIndex < secondIndex) {
         edges.push({

--- a/report-viewer/src/components/fileDisplaying/CodePanel.vue
+++ b/report-viewer/src/components/fileDisplaying/CodePanel.vue
@@ -137,7 +137,6 @@ function collapse() {
 }
 
 function expand() {
-  console.log('expand')
   collapsed.value = false
 }
 

--- a/report-viewer/src/components/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/src/components/fileDisplaying/FilesContainer.vue
@@ -179,11 +179,9 @@ const tokenCount = computed(() => {
 function scrollTo(file: string, line: number) {
   const fileIndex = Array.from(props.files).findIndex((f) => f.fileName === file)
   if (fileIndex !== -1) {
-    console.log(fileIndex)
     codePanels.value[fileIndex].expand()
     nextTick(() => {
       if (!scrollContainer.value) {
-        console.log('null')
         return
       }
       const childToScrollTo = codePanels.value[fileIndex].getLineRect(line) as DOMRect

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -97,7 +97,7 @@ export class ComparisonFactory extends BaseFactory {
         })
       }
     } catch (e) {
-      console.log(e)
+      console.error(e)
     }
   }
 

--- a/report-viewer/src/model/fileHandling/ZipFileHandler.ts
+++ b/report-viewer/src/model/fileHandling/ZipFileHandler.ts
@@ -8,7 +8,7 @@ import { FileHandler } from './FileHandler'
  */
 export class ZipFileHandler extends FileHandler {
   public async handleFile(file: Blob) {
-    console.log('Start handling zip file and storing necessary data...')
+    console.info('Start handling zip file and storing necessary data...')
     return jszip.loadAsync(file).then(async (zip) => {
       for (const originalFileName of Object.keys(zip.files)) {
         const unixFileName = slash(originalFileName)

--- a/report-viewer/src/viewWrapper/InformationViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/InformationViewWrapper.vue
@@ -36,5 +36,5 @@ OverviewFactory.getOverview()
 
 OptionsFactory.getCliOptions()
   .then((o) => (cliOptions.value = o))
-  .catch((error) => console.log('Could not load full options.', error))
+  .catch((error) => console.error('Could not load full options.', error))
 </script>


### PR DESCRIPTION
To make sure console.logs and other debug statements do not make it into the production code, this PR adjusts the eslint rules for logging and applies them to the code:
Do not allow any console writing excecpt when done as an error, warning or info.

This prevents debug statements from making it into the code and ensures all logs are properly marked and put there intentionally