### PR TITLE
Fixed token position zero in text module

### DIFF
--- a/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
+++ b/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
@@ -51,7 +51,7 @@ public class ParserAdapter extends AbstractParser {
     private void parseFile(File file) throws ParsingException {
         this.currentFile = file;
         this.currentLine = 1; // lines start at 1
-        this.currentLineBreakIndex = 0;
+        this.currentLineBreakIndex = -1;
         String content = readFile(file);
         int lastTokenEnd = 0;
         CoreDocument coreDocument = pipeline.processToCoreDocument(content);


### PR DESCRIPTION
This fixed #1903 

The error occurred because of the way the token position is calculated. It is calculated as the difference of the position of the first character of the token and the position of the last line break before that. To make this work the index of the last line break needs to be exactly 1 smaller than the first character in the line. Therefore for the first line the index must be -1, it was 0. Therefore the first token had it's position calculated as 0 - 0 which resulted in 0.