### PR TITLE
Use name when processing search bar input

### DIFF
--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -83,7 +83,7 @@ const searchStringValue = computed({
     }
 
     for (const submissionId of store().getSubmissionIds) {
-      const submissionParts = submissionId.toLowerCase().split(/ +/g)
+      const submissionParts = store().submissionDisplayName(submissionId).toLowerCase().split(/ +/g)
       if (submissionParts.every((part) => searchParts.includes(part))) {
         store().state.anonymous.delete(submissionId)
       }

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -236,9 +236,9 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
 
   return comparisons.filter((c) => {
     // name search
-    const id1 = c.firstSubmissionId.toLowerCase()
-    const id2 = c.secondSubmissionId.toLowerCase()
-    if (searches.some((s) => id1.includes(s) || id2.includes(s))) {
+    const name1 = store().submissionDisplayName(c.firstSubmissionId).toLowerCase()
+    const name2 = store().submissionDisplayName(c.secondSubmissionId).toLowerCase()
+    if (searches.some((s) => name1.includes(s) || name2.includes(s))) {
       return true
     }
 


### PR DESCRIPTION
Uses submission display name instead of submission ID when deanonymizing and filtering with the search bar of the comparison table
fixes #1946 