### PR TITLE
Demo starts on Overview

### DIFF
--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -40,10 +40,7 @@
           Continue with local files
         </Button>
       </div>
-      <LoadingCircle v-else-if="loadingFiles" class="space-y-5 pt-5" />
-      <div v-else-if="exampleFiles" class="pt-5">
-        <Button class="mx-auto w-fit text-xl" @click="continueWithLocal()"> View Example </Button>
-      </div>
+      <LoadingCircle v-else-if="loadingFiles || exampleFiles" class="space-y-5 pt-5" />
       <div v-if="errors.length > 0" class="text-error">
         <p>{{ getErrorText() }}</p>
         <p>For more details check the console.</p>
@@ -236,4 +233,8 @@ onErrorCaptured((error) => {
   registerError(error, 'unknown')
   return false
 })
+
+if (exampleFiles.value) {
+  continueWithLocal()
+}
 </script>


### PR DESCRIPTION
Since with the default local mode, the user will directly start on the demo screen, the demo will now also load the Overview instead of having the demo page