### PR TITLE
Fix filtering by metric

### DIFF
--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -256,7 +256,7 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
       [MetricType.MAXIMUM]: []
     }
     metricSearches.forEach((s) => {
-      const regexResult = /^(?:(avg|max):)?([<>]=?[0-9]+%?$)/.exec(s)
+      const regexResult = /^(?:(avg|max):)([<>]=?[0-9]+%?$)/.exec(s)
       if (regexResult) {
         const metricName = regexResult[1]
         let metric = MetricType.AVERAGE


### PR DESCRIPTION
When no metric was specified when filtering by metric the intended behaviour is that it filters over all metrics. 
Due to a bug the filtering did not work at all when no metric was specified.