### PR TITLE
Added token position tests for annotations

### DIFF
--- a/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
@@ -247,7 +248,7 @@ public abstract class LanguageModuleTest {
     @MethodSource("getAllTestData")
     @DisplayName("Test that the tokens map to ascending line numbers")
     final void testMonotoneTokenOrder(TestData data) throws ParsingException, IOException {
-        List<Token> tokens = parseTokens(data);
+        List<Token> tokens = parseTokens(data).stream().filter(it -> !getIgnoredTokensForMonotoneTokenOrder().contains(it.getType())).toList();
 
         for (int i = 0; i < tokens.size() - 2; i++) {
             Token first = tokens.get(i);
@@ -337,5 +338,9 @@ public abstract class LanguageModuleTest {
      */
     protected File getTestFileLocation() {
         return new File(DEFAULT_TEST_CODE_PATH_BASE.toFile(), this.language.getIdentifier());
+    }
+
+    protected List<TokenType> getIgnoredTokensForMonotoneTokenOrder() {
+        return Collections.emptyList();
     }
 }

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -147,7 +147,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         } else if (node.getKind() == Tree.Kind.RECORD) {
             addToken(JavaTokenType.J_RECORD_BEGIN, start, 1, semantics);
         } else if (node.getKind() == Tree.Kind.ANNOTATION_TYPE) {
-            addToken(JavaTokenType.J_ANNO_T_BEGIN, start - 2 /*@ is final modifier for annotations*/, (start - 2) + 11 + nameLength, semantics);
+            addToken(JavaTokenType.J_ANNO_T_BEGIN, start - 2 /* @ is final modifier for annotations */, (start - 2) + 11 + nameLength, semantics);
         } else if (node.getKind() == Tree.Kind.CLASS) {
             addToken(JavaTokenType.J_CLASS_BEGIN, start, 5, semantics);
         }

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -147,7 +147,9 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         } else if (node.getKind() == Tree.Kind.RECORD) {
             addToken(JavaTokenType.J_RECORD_BEGIN, start, 1, semantics);
         } else if (node.getKind() == Tree.Kind.ANNOTATION_TYPE) {
-            addToken(JavaTokenType.J_ANNO_T_BEGIN, start - 2 /* @ is final modifier for annotations */, (start - 2) + 11 + nameLength, semantics);
+            // The start position for the is calculated that way, because the @ is the final element in the modifier list for
+            // annotations
+            addToken(JavaTokenType.J_ANNO_T_BEGIN, start - 2, (start - 2) + 11 + nameLength, semantics);
         } else if (node.getKind() == Tree.Kind.CLASS) {
             addToken(JavaTokenType.J_CLASS_BEGIN, start, 5, semantics);
         }

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -136,7 +136,8 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
             }
         }
 
-        long start = positions.getStartPosition(ast, node);
+        long start = positions.getEndPosition(ast, node.getModifiers()) + 1;
+        long nameLength = node.getSimpleName().length();
         long end = positions.getEndPosition(ast, node) - 1;
         CodeSemantics semantics = CodeSemantics.createControl();
         if (node.getKind() == Tree.Kind.ENUM) {
@@ -146,7 +147,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         } else if (node.getKind() == Tree.Kind.RECORD) {
             addToken(JavaTokenType.J_RECORD_BEGIN, start, 1, semantics);
         } else if (node.getKind() == Tree.Kind.ANNOTATION_TYPE) {
-            addToken(JavaTokenType.J_ANNO_T_BEGIN, start, 10, semantics);
+            addToken(JavaTokenType.J_ANNO_T_BEGIN, start - 2 /*@ is final modifier for annotations*/, (start - 2) + 11 + nameLength, semantics);
         } else if (node.getKind() == Tree.Kind.CLASS) {
             addToken(JavaTokenType.J_CLASS_BEGIN, start, 5, semantics);
         }
@@ -508,7 +509,8 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     @Override
     public Void visitAnnotation(AnnotationTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
-        addToken(JavaTokenType.J_ANNO, start, 1, new CodeSemantics());
+        String annotationName = node.getAnnotationType().toString();
+        addToken(JavaTokenType.J_ANNO, start, annotationName.length() + 1, new CodeSemantics());
         return super.visitAnnotation(node, null);
     }
 

--- a/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
@@ -29,9 +29,12 @@ import static de.jplag.java.JavaTokenType.J_TRY_BEGIN;
 import static de.jplag.java.JavaTokenType.J_TRY_END;
 import static de.jplag.java.JavaTokenType.J_VARDEF;
 
+import de.jplag.TokenType;
 import de.jplag.testutils.LanguageModuleTest;
 import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
+
+import java.util.List;
 
 public class JavaLanguageTest extends LanguageModuleTest {
     public JavaLanguageTest() {
@@ -83,5 +86,10 @@ public class JavaLanguageTest extends LanguageModuleTest {
         collector.ignoreMultipleLines("/*", "*/");
         collector.ignoreLinesByPrefix("})");
         collector.ignoreByCondition(line -> line.contains("else") && !line.contains("if"));
+    }
+
+    @Override
+    protected List<TokenType> getIgnoredTokensForMonotoneTokenOrder() {
+        return List.of(JavaTokenType.J_ANNO);
     }
 }

--- a/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
@@ -29,12 +29,12 @@ import static de.jplag.java.JavaTokenType.J_TRY_BEGIN;
 import static de.jplag.java.JavaTokenType.J_TRY_END;
 import static de.jplag.java.JavaTokenType.J_VARDEF;
 
+import java.util.List;
+
 import de.jplag.TokenType;
 import de.jplag.testutils.LanguageModuleTest;
 import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
-
-import java.util.List;
 
 public class JavaLanguageTest extends LanguageModuleTest {
     public JavaLanguageTest() {

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_1.java
@@ -1,0 +1,3 @@
+>@SuppressWarnings
+$| J_ANNO 17
+>class Anno {}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_2.java
@@ -1,0 +1,3 @@
+>@SuppressWarnings("SomeWarning")
+$| J_ANNO 17
+>class Anno {}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_3.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_3.java
@@ -1,0 +1,6 @@
+>class Anno {
+>    @Deprecated
+$    | J_ANNO 11
+>    public void testFunction() {
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_4.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Anno_4.java
@@ -1,0 +1,7 @@
+>import javax.annotation.processing.Generated;
+>
+>class Anno {
+>    public void testMethod(@Generated String param) {
+$                           | J_ANNO 10
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_1.java
@@ -1,0 +1,3 @@
+>public @interface MyAnnotation {}
+$| J_ANNO_T_BEGIN 30
+$                                | J_ANNO_T_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_1.java
@@ -1,3 +1,3 @@
 >public @interface MyAnnotation {}
-$| J_ANNO_T_BEGIN 30
+$       | J_ANNO_T_BEGIN 23
 $                                | J_ANNO_T_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_2.java
@@ -1,0 +1,4 @@
+>public @interface MyAnnotation {
+$| J_ANNO_T_BEGIN 30
+>}
+$| J_ANNO_T_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/JAnnoTBegin-End_2.java
@@ -1,4 +1,4 @@
 >public @interface MyAnnotation {
-$| J_ANNO_T_BEGIN 30
+$       | J_ANNO_T_BEGIN 23
 >}
 $| J_ANNO_T_END 1


### PR DESCRIPTION
Added some token position tests for annotations. The tests currently fail, because I decided on different lengths than the java module currently reports.

The lengths I assume for these test:

-Annotation: from @ to end of annotation name
-Annotation type begin: from the first modifier to the end of the name
All other tokens lengths are the same as in the current implementation 

There are also some considerations for the module:

Most of the annotation token types seem to be unused. Maybe we should remove them?
I guess ANNO_M was supposed to be annotation members. They are currently extracted as Method tokens. Do we want to keep it like that?
Annotation arguments are currently not extracted at all. Do we want some tokens for that?