### PR TITLE
Added names to token position tests

### DIFF
--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -21,6 +21,7 @@ public class TokenPositionTestData implements TestData {
     private final List<TokenData> expectedTokens;
 
     private final String descriptor;
+    private final String fileName;
 
     /**
      * @param testFile The file containing the test specifications
@@ -30,6 +31,7 @@ public class TokenPositionTestData implements TestData {
         this.sourceLines = new ArrayList<>();
         this.expectedTokens = new ArrayList<>();
         this.descriptor = "(Token position file: " + testFile.getName() + ")";
+        this.fileName = testFile.getName();
         this.readFile(testFile);
     }
 
@@ -88,5 +90,10 @@ public class TokenPositionTestData implements TestData {
      * @param length The length of the token
      */
     public record TokenData(String typeName, int lineNumber, int columnNumber, int length) {
+    }
+
+    @Override
+    public String toString() {
+        return this.fileName;
     }
 }


### PR DESCRIPTION
This PR adds a toString method to TokenPositionTestData, so JUnit shows a human readable name for each test.

This is the new output:
[1] Anno_2.java
[2] Anno_3.java
[3] JAnnoTBegin-End_1.java
[4] JAnnoTBegin-End_2.java
[5] VarDef_1.java
[6] Anno_4.java
[7] Anno_1.java

This is the old output (See #1960):
[1] de.jplag.testutils.datacollector.TokenPositionTestData@2fd6b6c7
[2] de.jplag.testutils.datacollector.TokenPositionTestData@5bfa9431
[3] de.jplag.testutils.datacollector.TokenPositionTestData@5db250b4
[4] de.jplag.testutils.datacollector.TokenPositionTestData@223f3642
[5] de.jplag.testutils.datacollector.TokenPositionTestData@38c5cc4c
[6] de.jplag.testutils.datacollector.TokenPositionTestData@37918c79
[7] de.jplag.testutils.datacollector.TokenPositionTestData@78e94dcf