### PR TITLE
Reduce misleading of cluster edges

### DIFF
--- a/report-viewer/src/components/ClusterGraph.vue
+++ b/report-viewer/src/components/ClusterGraph.vue
@@ -165,17 +165,20 @@ const maximumSimilarity = computed(() => {
   return maximumSimilarity
 })
 
-function getClampedSimilarityFromKeyIndex(firstIndex: number, secondIndex: number) {
+function getClampedSimilarityFromKeyIndex(
+  firstIndex: number,
+  secondIndex: number,
+  min: number,
+  max: number
+) {
   const similarity = getSimilarityFromKeyIndex(firstIndex, secondIndex)
   if (similarity == 0) {
     return 0
   }
-  if (minimumSimilarity.value == maximumSimilarity.value) {
+  if (min == max) {
     return 1
   }
-  return (
-    (similarity - minimumSimilarity.value) / (maximumSimilarity.value - minimumSimilarity.value)
-  )
+  return (similarity - min) / (max - min)
 }
 
 function getEdgeAlphaFromKeyIndex(firstIndex: number, secondIndex: number) {
@@ -183,7 +186,16 @@ function getEdgeAlphaFromKeyIndex(firstIndex: number, secondIndex: number) {
   if (similarity == 0) {
     return 1
   }
-  return getClampedSimilarityFromKeyIndex(firstIndex, secondIndex) * 0.7 + 0.3
+  return (
+    getClampedSimilarityFromKeyIndex(
+      firstIndex,
+      secondIndex,
+      Math.min(minimumSimilarity.value, 0.5),
+      maximumSimilarity.value
+    ) *
+      0.7 +
+    0.3
+  )
 }
 
 function getEdgeWidth(firstIndex: number, secondIndex: number) {
@@ -191,7 +203,7 @@ function getEdgeWidth(firstIndex: number, secondIndex: number) {
   if (similarity == 0) {
     return 0.5
   }
-  return getClampedSimilarityFromKeyIndex(firstIndex, secondIndex) * 5 + 1
+  return getClampedSimilarityFromKeyIndex(firstIndex, secondIndex, 0, 1) * 5 + 1
 }
 
 function getEdgeDashStyle(firstIndex: number, secondIndex: number) {


### PR DESCRIPTION
This PR overhauls the edge still of the cluster graph, to make them misleading (for example, that an edge with a similarity of 90% can have the minimal thickness and opacity)
The edge thickness is now clamped between 0 and 100 percent instead of the min and max
The edge opacity is now mapped between the max and the smaller value of 50% or the min

<details>
<summary>More detailed math</summary>
	
Lets call the highest similarity of any comparison in the cluster $sim_{max}$ and the lowest $sim_{min}$.
Lets take a comparison with similarity $sim$.
Its thickness will be equal to:
$thickness = sim * 5 + 1$
Opacity is calculated like this:
$opacity = \frac{sim - min(sim_{min}, 0.5)}{sim_{max} - min({sim_min}, 0.5)} * 0.7 +0.3$
</details>

<details>
<summary>Comparison 1</summary>
<table>
<tr><td>Members</td><td><img src="https://github.com/user-attachments/assets/2cf7dde2-2569-4cd6-8306-a6b56aa41d21" /></td></tr>
<tr><td>Old</td><td><img src="https://github.com/user-attachments/assets/3016ca29-5d6c-4f73-8a2c-a25b74c595b2" /></td></tr>
<tr><td>New</td><td><img src="https://github.com/user-attachments/assets/1de9ccfa-db81-430b-87d1-4f30753fe6cf" /></td></tr>
</table>
</details>

<details>
<summary>Comparison 2</summary>
<table>
<tr><td>Members</td><td><img src="https://github.com/user-attachments/assets/ec1cae7c-2a78-4d72-9248-8fc8495eda37" /></td></tr>
<tr><td>Old</td><td><img src="https://github.com/user-attachments/assets/a19e112e-d881-484a-881e-a0553da0c47d" /></td></tr>
<tr><td>New</td><td><img src="https://github.com/user-attachments/assets/a61fc3b8-6693-4419-9684-4e32f02711a9" /></td></tr>
</table>
</details>

