### PR TITLE
Fix clicking on match opening wrong match

### DIFF
--- a/report-viewer/src/components/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/src/components/fileDisplaying/FilesContainer.vue
@@ -177,7 +177,7 @@ const tokenCount = computed(() => {
  * @param line Line to scroll to.
  */
 function scrollTo(file: string, line: number) {
-  const fileIndex = Array.from(props.files).findIndex((f) => f.fileName === file)
+  const fileIndex = sortedFiles.value.findIndex((f) => f.fileName === file)
   if (fileIndex !== -1) {
     codePanels.value[fileIndex].expand()
     nextTick(() => {


### PR DESCRIPTION
There was a bug introduced when adding file sorting, that sometimes the wrong file was opened for a match.

The reason for this was that the index search was performed on the unsorted list, but the opening of the comparisons was done on a sorted list