### PR TITLE
Increase number of exported comparisons

### DIFF
--- a/core/src/main/java/de/jplag/options/JPlagOptions.java
+++ b/core/src/main/java/de/jplag/options/JPlagOptions.java
@@ -59,7 +59,7 @@ public record JPlagOptions(@JsonSerialize(using = LanguageSerializer.class) Lang
         @JsonProperty("normalize") boolean normalize) implements JPlagOptionsBuilder.With {
 
     public static final double DEFAULT_SIMILARITY_THRESHOLD = 0;
-    public static final int DEFAULT_SHOWN_COMPARISONS = 500;
+    public static final int DEFAULT_SHOWN_COMPARISONS = 2500;
     public static final int SHOW_ALL_COMPARISONS = 0;
     public static final SimilarityMetric DEFAULT_SIMILARITY_METRIC = SimilarityMetric.AVG;
     public static final String ERROR_FOLDER = "errors";


### PR DESCRIPTION
After testing on older machines it was found, that the report viewer still runs fine with a larger number of shown comparisons.
The only time increase is in the writing of the zip