### PR TITLE
Multi Language Program Support

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -118,6 +118,11 @@
             <artifactId>llvmir</artifactId>
             <version>${revision}</version>
         </dependency>
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>multi-language</artifactId>
+            <version>${revision}</version>
+        </dependency>
         <!-- CLI -->
         <dependency>
             <groupId>org.kohsuke.metainf-services</groupId>

--- a/cli/src/main/java/de/jplag/cli/options/LanguageCandidates.java
+++ b/cli/src/main/java/de/jplag/cli/options/LanguageCandidates.java
@@ -2,6 +2,8 @@ package de.jplag.cli.options;
 
 import java.util.ArrayList;
 
+import de.jplag.LanguageLoader;
+
 /**
  * Helper class for picocli to find all available languages.
  */

--- a/cli/src/main/java/de/jplag/cli/options/LanguageConverter.java
+++ b/cli/src/main/java/de/jplag/cli/options/LanguageConverter.java
@@ -1,6 +1,7 @@
 package de.jplag.cli.options;
 
 import de.jplag.Language;
+import de.jplag.LanguageLoader;
 
 import picocli.CommandLine;
 

--- a/cli/src/main/java/de/jplag/cli/picocli/CliInputHandler.java
+++ b/cli/src/main/java/de/jplag/cli/picocli/CliInputHandler.java
@@ -14,9 +14,9 @@ import java.util.Random;
 import java.util.stream.Collectors;
 
 import de.jplag.Language;
+import de.jplag.LanguageLoader;
 import de.jplag.cli.CliException;
 import de.jplag.cli.options.CliOptions;
-import de.jplag.cli.options.LanguageLoader;
 import de.jplag.options.LanguageOption;
 import de.jplag.options.LanguageOptions;
 

--- a/cli/src/test/java/de/jplag/cli/LanguageTest.java
+++ b/cli/src/test/java/de/jplag/cli/LanguageTest.java
@@ -40,7 +40,7 @@ class LanguageTest extends CliTest {
     @Test
     void testLoading() {
         var languages = LanguageLoader.getAllAvailableLanguages();
-        assertEquals(19, languages.size(), "Loaded Languages: " + languages.keySet());
+        assertEquals(20, languages.size(), "Loaded Languages: " + languages.keySet());
     }
 
     @ParameterizedTest

--- a/cli/src/test/java/de/jplag/cli/LanguageTest.java
+++ b/cli/src/test/java/de/jplag/cli/LanguageTest.java
@@ -18,9 +18,11 @@ import de.jplag.cli.options.CliOptions;
 import de.jplag.cli.test.CliArgument;
 import de.jplag.cli.test.CliTest;
 import de.jplag.exceptions.ExitException;
+import de.jplag.multilang.MultiLanguage;
 import de.jplag.options.JPlagOptions;
 
 class LanguageTest extends CliTest {
+    private static final List<Class<? extends Language>> ignoredLanguages = List.of(MultiLanguage.class);
 
     @Test
     void testDefaultLanguage() throws ExitException, IOException {
@@ -58,6 +60,7 @@ class LanguageTest extends CliTest {
     }
 
     public static Collection<Language> getAllLanguages() {
-        return LanguageLoader.getAllAvailableLanguages().values();
+        return LanguageLoader.getAllAvailableLanguages().values().stream().filter(language -> !ignoredLanguages.contains(language.getClass()))
+                .toList();
     }
 }

--- a/cli/src/test/java/de/jplag/cli/LanguageTest.java
+++ b/cli/src/test/java/de/jplag/cli/LanguageTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import de.jplag.Language;
+import de.jplag.LanguageLoader;
 import de.jplag.cli.options.CliOptions;
-import de.jplag.cli.options.LanguageLoader;
 import de.jplag.cli.test.CliArgument;
 import de.jplag.cli.test.CliTest;
 import de.jplag.exceptions.ExitException;

--- a/endtoend-testing/src/main/java/de/jplag/endtoend/helper/LanguageDeserializer.java
+++ b/endtoend-testing/src/main/java/de/jplag/endtoend/helper/LanguageDeserializer.java
@@ -3,7 +3,7 @@ package de.jplag.endtoend.helper;
 import java.io.IOException;
 
 import de.jplag.Language;
-import de.jplag.cli.options.LanguageLoader;
+import de.jplag.LanguageLoader;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;

--- a/language-api/src/main/java/de/jplag/LanguageLoader.java
+++ b/language-api/src/main/java/de/jplag/LanguageLoader.java
@@ -1,4 +1,4 @@
-package de.jplag.cli.options;
+package de.jplag;
 
 import java.util.Collections;
 import java.util.Map;
@@ -10,8 +10,6 @@ import java.util.TreeSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import de.jplag.Language;
 
 /**
  * This class contains methods to load {@link Language Languages}.

--- a/language-api/src/main/java/de/jplag/options/DefaultLanguageOption.java
+++ b/language-api/src/main/java/de/jplag/options/DefaultLanguageOption.java
@@ -20,7 +20,7 @@ public class DefaultLanguageOption<T> implements LanguageOption<T> {
         this.hasValue = true;
     }
 
-    DefaultLanguageOption(OptionType<T> type, String description, String name) {
+    DefaultLanguageOption(OptionType<T> type, String name, String description) {
         this(type, name, description, null);
         this.hasValue = false;
     }

--- a/language-api/src/main/java/de/jplag/options/LanguageOptions.java
+++ b/language-api/src/main/java/de/jplag/options/LanguageOptions.java
@@ -56,7 +56,7 @@ public abstract class LanguageOptions {
      * @return The new option
      */
     protected <T> LanguageOption<T> createOption(OptionType<T> type, String name, String description) {
-        LanguageOption<T> option = new DefaultLanguageOption<>(type, description, name);
+        LanguageOption<T> option = new DefaultLanguageOption<>(type, name, description);
         this.options.add(option);
         return option;
     }

--- a/language-api/src/main/java/de/jplag/options/LanguageOptions.java
+++ b/language-api/src/main/java/de/jplag/options/LanguageOptions.java
@@ -56,7 +56,7 @@ public abstract class LanguageOptions {
      * @return The new option
      */
     protected <T> LanguageOption<T> createOption(OptionType<T> type, String name, String description) {
-        LanguageOption<T> option = new DefaultLanguageOption<>(type, name, description);
+        LanguageOption<T> option = new DefaultLanguageOption<>(type, description, name);
         this.options.add(option);
         return option;
     }

--- a/languages/multi-language/pom.xml
+++ b/languages/multi-language/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>de.jplag</groupId>
+        <artifactId>languages</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <artifactId>multi-language</artifactId>
+
+    <dependencies></dependencies>
+
+</project>

--- a/languages/multi-language/pom.xml
+++ b/languages/multi-language/pom.xml
@@ -8,6 +8,19 @@
     </parent>
     <artifactId>multi-language</artifactId>
 
-    <dependencies></dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>java</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>cpp</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguage.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguage.java
@@ -1,0 +1,55 @@
+package de.jplag.multilang;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.kohsuke.MetaInfServices;
+
+import de.jplag.Language;
+import de.jplag.LanguageLoader;
+import de.jplag.ParsingException;
+import de.jplag.Token;
+import de.jplag.options.LanguageOptions;
+
+@MetaInfServices(Language.class)
+public class MultiLanguage implements Language {
+    private final MultiLanguageOptions options;
+
+    public MultiLanguage() {
+        this.options = new MultiLanguageOptions();
+    }
+
+    @Override
+    public String[] suffixes() {
+        return LanguageLoader.getAllAvailableLanguages().values().stream().filter(it -> !(it == this)).flatMap(it -> Arrays.stream(it.suffixes()))
+                .toArray(String[]::new);
+    }
+
+    @Override
+    public String getName() {
+        return "multi-language";
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "multi";
+    }
+
+    @Override
+    public int minimumTokenMatch() {
+        return this.options.getLanguages().stream().mapToInt(Language::minimumTokenMatch).min().orElse(9);
+    }
+
+    @Override
+    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+        MultiLanguageParser parser = new MultiLanguageParser(this.options);
+        return parser.parseFiles(files, normalize);
+    }
+
+    @Override
+    public LanguageOptions getOptions() {
+        return this.options;
+    }
+}

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguage.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguage.java
@@ -23,7 +23,7 @@ public class MultiLanguage implements Language {
 
     @Override
     public String[] suffixes() {
-        return LanguageLoader.getAllAvailableLanguages().values().stream().filter(it -> !(it == this)).flatMap(it -> Arrays.stream(it.suffixes()))
+        return LanguageLoader.getAllAvailableLanguages().values().stream().filter(it -> it != this).flatMap(it -> Arrays.stream(it.suffixes()))
                 .toArray(String[]::new);
     }
 

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
@@ -11,20 +11,24 @@ import de.jplag.options.OptionType;
 
 public class MultiLanguageOptions extends LanguageOptions {
     private static final String ERROR_LANGUAGE_NOT_FOUND = "The selected language %s could not be found";
-    private static final String ERROR_NOT_ENOUGH_LANGUAGES = "To use multi language specify at least 2 languages";
+    private static final String ERROR_NOT_ENOUGH_LANGUAGES = "To use multi language specify at least 1 language";
 
-    public LanguageOption<String> languageNames = createOption(OptionType.string(), "langs",
+    public LanguageOption<String> languageNames = createOption(OptionType.string(), "languages",
             "The languages that should be used. This is a ',' separated list");
     private List<Language> languages = null;
 
     public List<Language> getLanguages() {
         if (this.languages == null) {
+            if (languageNames.getValue() == null) {
+                throw new IllegalArgumentException(ERROR_NOT_ENOUGH_LANGUAGES);
+            }
+
             List<Language> languages = Arrays.stream(languageNames.getValue().split(","))
                     .map(name -> LanguageLoader.getLanguage(name)
                             .orElseThrow(() -> new IllegalArgumentException(String.format(ERROR_LANGUAGE_NOT_FOUND, name))))
                     .filter(language -> !language.getClass().equals(MultiLanguage.class)).toList();
 
-            if (languages.size() <= 1) {
+            if (languages.isEmpty()) {
                 throw new IllegalArgumentException(ERROR_NOT_ENOUGH_LANGUAGES);
             }
 

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
@@ -1,0 +1,36 @@
+package de.jplag.multilang;
+
+import java.util.Arrays;
+import java.util.List;
+
+import de.jplag.Language;
+import de.jplag.LanguageLoader;
+import de.jplag.options.LanguageOption;
+import de.jplag.options.LanguageOptions;
+import de.jplag.options.OptionType;
+
+public class MultiLanguageOptions extends LanguageOptions {
+    private static final String ERROR_LANGUAGE_NOT_FOUND = "The selected language %s could not be found";
+    private static final String ERROR_NOT_ENOUGH_LANGUAGES = "To use multi language specify at least 2 languages";
+
+    public LanguageOption<String> languageNames = createOption(OptionType.string(), "langs",
+            "The languages that should be used. This is a ',' separated list");
+    private List<Language> languages = null;
+
+    public List<Language> getLanguages() {
+        if (this.languages == null) {
+            List<Language> languages = Arrays.stream(languageNames.getValue().split(","))
+                    .map(name -> LanguageLoader.getLanguage(name)
+                            .orElseThrow(() -> new IllegalArgumentException(String.format(ERROR_LANGUAGE_NOT_FOUND, name))))
+                    .filter(language -> !language.getClass().equals(MultiLanguage.class)).toList();
+
+            if (languages.size() <= 1) {
+                throw new IllegalArgumentException(ERROR_NOT_ENOUGH_LANGUAGES);
+            }
+
+            this.languages = languages;
+        }
+
+        return this.languages;
+    }
+}

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
@@ -12,9 +12,9 @@ import de.jplag.options.OptionType;
 public class MultiLanguageOptions extends LanguageOptions {
     private static final String ERROR_LANGUAGE_NOT_FOUND = "The selected language %s could not be found";
     private static final String ERROR_NOT_ENOUGH_LANGUAGES = "To use multi language specify at least 1 language";
+    private static final String OPTION_DESCRIPTION_LANGUAGES = "The languages that should be used. This is a ',' separated list";
 
-    public LanguageOption<String> languageNames = createOption(OptionType.string(), "languages",
-            "The languages that should be used. This is a ',' separated list");
+    public LanguageOption<String> languageNames = createOption(OptionType.string(), "languages", OPTION_DESCRIPTION_LANGUAGES);
     private List<Language> languages = null;
 
     public List<Language> getLanguages() {

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageOptions.java
@@ -14,7 +14,7 @@ public class MultiLanguageOptions extends LanguageOptions {
     private static final String ERROR_NOT_ENOUGH_LANGUAGES = "To use multi language specify at least 1 language";
     private static final String OPTION_DESCRIPTION_LANGUAGES = "The languages that should be used. This is a ',' separated list";
 
-    public LanguageOption<String> languageNames = createOption(OptionType.string(), "languages", OPTION_DESCRIPTION_LANGUAGES);
+    private final LanguageOption<String> languageNames = createOption(OptionType.string(), "languages", OPTION_DESCRIPTION_LANGUAGES);
     private List<Language> languages = null;
 
     public List<Language> getLanguages() {
@@ -23,18 +23,20 @@ public class MultiLanguageOptions extends LanguageOptions {
                 throw new IllegalArgumentException(ERROR_NOT_ENOUGH_LANGUAGES);
             }
 
-            List<Language> languages = Arrays.stream(languageNames.getValue().split(","))
+            this.languages = Arrays.stream(languageNames.getValue().split(","))
                     .map(name -> LanguageLoader.getLanguage(name)
                             .orElseThrow(() -> new IllegalArgumentException(String.format(ERROR_LANGUAGE_NOT_FOUND, name))))
                     .filter(language -> !language.getClass().equals(MultiLanguage.class)).toList();
 
-            if (languages.isEmpty()) {
+            if (this.languages.isEmpty()) {
                 throw new IllegalArgumentException(ERROR_NOT_ENOUGH_LANGUAGES);
             }
-
-            this.languages = languages;
         }
 
         return this.languages;
+    }
+
+    public LanguageOption<String> getLanguageNames() {
+        return this.languageNames;
     }
 }

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageParser.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageParser.java
@@ -1,0 +1,36 @@
+package de.jplag.multilang;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import de.jplag.Language;
+import de.jplag.ParsingException;
+import de.jplag.Token;
+
+public class MultiLanguageParser {
+    private final List<Language> languages;
+
+    public MultiLanguageParser(MultiLanguageOptions options) {
+        this.languages = options.getLanguages();
+    }
+
+    public List<Token> parseFiles(Set<File> files, boolean normalize) throws ParsingException {
+        List<Token> results = new ArrayList<>();
+        for (File file : files) {
+            Optional<Language> language = findLanguageForFile(file);
+            if (language.isPresent()) {
+                results.addAll(language.get().parse(Set.of(file), normalize));
+            }
+        }
+        return results;
+    }
+
+    private Optional<Language> findLanguageForFile(File file) {
+        return this.languages.stream().filter(language -> Arrays.stream(language.suffixes()).anyMatch(suffix -> file.getName().endsWith(suffix)))
+                .findFirst();
+    }
+}

--- a/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
+++ b/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
@@ -44,7 +44,7 @@ public class MultilangTest {
     @Test
     void testMultiLanguageParsing() throws ParsingException {
         MultiLanguage languageModule = new MultiLanguage();
-        ((MultiLanguageOptions) languageModule.getOptions()).languageNames.setValue("java,cpp");
+        ((MultiLanguageOptions) languageModule.getOptions()).getLanguageNames().setValue("java,cpp");
 
         Set<File> sources = new TreeSet<>(List.of(javaCode, cppCode)); // Using TreeSet to ensure order of entries
         List<Token> tokens = languageModule.parse(sources, false);
@@ -63,7 +63,7 @@ public class MultilangTest {
     @Test
     void testInvalidLanguage() {
         MultiLanguage languageModule = new MultiLanguage();
-        ((MultiLanguageOptions) languageModule.getOptions()).languageNames.setValue("thisIsNotALanguage");
+        ((MultiLanguageOptions) languageModule.getOptions()).getLanguageNames().setValue("thisIsNotALanguage");
 
         Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
             languageModule.parse(Set.of(javaCode, cppCode), false);

--- a/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
+++ b/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
@@ -23,7 +23,7 @@ import de.jplag.java.JavaTokenType;
 import de.jplag.multilang.MultiLanguage;
 import de.jplag.multilang.MultiLanguageOptions;
 
-public class MultilangTest {
+class MultilangTest {
     private static File testDataDirectory;
     private static File javaCode;
     private static File cppCode;

--- a/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
+++ b/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
@@ -1,0 +1,79 @@
+package de.java.multilang;
+
+import static de.jplag.SharedTokenType.FILE_END;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import de.jplag.ParsingException;
+import de.jplag.Token;
+import de.jplag.TokenType;
+import de.jplag.cpp.CPPTokenType;
+import de.jplag.java.JavaTokenType;
+import de.jplag.multilang.MultiLanguage;
+import de.jplag.multilang.MultiLanguageOptions;
+
+public class MultilangTest {
+    private static File testDataDirectory;
+    private static File javaCode;
+    private static File cppCode;
+
+    private static List<TokenType> expectedTokens = List.of(CPPTokenType.FUNCTION_BEGIN, CPPTokenType.RETURN, CPPTokenType.FUNCTION_END, FILE_END,
+            JavaTokenType.J_CLASS_BEGIN, JavaTokenType.J_CLASS_END, FILE_END);
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        testDataDirectory = Files.createTempDirectory("multiLanguageTestData").toFile();
+        cppCode = new File(testDataDirectory, "CppCode.cpp");
+        javaCode = new File(testDataDirectory, "JavaCode.java");
+
+        MultilangTest.class.getResourceAsStream("/de/jplag/multilang/testDataSet/CppCode.cpp").transferTo(new FileOutputStream(cppCode));
+        MultilangTest.class.getResourceAsStream("/de/jplag/multilang/testDataSet/JavaCode.java").transferTo(new FileOutputStream(javaCode));
+    }
+
+    @Test
+    void testMultiLanguageParsing() throws ParsingException {
+        MultiLanguage languageModule = new MultiLanguage();
+        ((MultiLanguageOptions) languageModule.getOptions()).languageNames.setValue("java,cpp");
+
+        Set<File> sources = new TreeSet<>(List.of(javaCode, cppCode)); // Using TreeSet to ensure order of entries
+        List<Token> tokens = languageModule.parse(sources, false);
+
+        Assertions.assertEquals(expectedTokens, tokens.stream().map(Token::getType).toList());
+    }
+
+    @Test
+    void testNoLanguagesConfigured() {
+        MultiLanguage languageModule = new MultiLanguage();
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
+            languageModule.parse(Set.of(javaCode, cppCode), false);
+        });
+    }
+
+    @Test
+    void testInvalidLanguage() {
+        MultiLanguage languageModule = new MultiLanguage();
+        ((MultiLanguageOptions) languageModule.getOptions()).languageNames.setValue("thisIsNotALanguage");
+
+        Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
+            languageModule.parse(Set.of(javaCode, cppCode), false);
+        });
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        javaCode.delete();
+        cppCode.delete();
+        testDataDirectory.delete();
+    }
+}

--- a/languages/multi-language/src/test/resources/de/jplag/multilang/testDataSet/CppCode.cpp
+++ b/languages/multi-language/src/test/resources/de/jplag/multilang/testDataSet/CppCode.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/languages/multi-language/src/test/resources/de/jplag/multilang/testDataSet/JavaCode.java
+++ b/languages/multi-language/src/test/resources/de/jplag/multilang/testDataSet/JavaCode.java
@@ -1,0 +1,3 @@
+public class JavaCode {
+
+}

--- a/languages/pom.xml
+++ b/languages/pom.xml
@@ -29,6 +29,7 @@
         <module>typescript</module>
         <module>javascript</module>
         <module>llvmir</module>
+        <module>multi-language</module>
     </modules>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR adds the capability to parse multiple languages with JPlag in on run.

A new language module is added, which identifies a module for each file and delegates the parsing to that module. The resulting tokens are concatenated and passed back to JPlag. This does not allow comparing different languages with each other, but it allows for projects that contain multiple languages (multi-language projects).

The languages are discovered on runtime using the same mechanism as the cli. This made it necessary to move the LanguageLoader class from the cli module to the language-api module.
The language modules are identified using the suffixes defined in the individual language modules. This matches the way JPlag already identifies code files in a submission.
The user has to select all language modules that should be used manually using a language specific option.

If multiple language modules are selected for the same suffix, a module is chosen arbitrarily.


Future considerations:
* Change Cli to allow configuration for multiple language-modules. Right now it's not possible to set language specific options for the selected languages. Changing that would be a major change to the cli though.
* Allow implicitly selecting all languages. This would make JPlag easier to use, since a user would not have to select a language module anymore, but makes handing language modules with the same suffix harder
* Find a better way to identify the correct language module. This could be done by adding priorities to language modules, or by adding function to analyze the contents of a file before.


Usage example:
```
jplag multi --languages java,cpp <path to submissions>
```