### PR TITLE
Dont display basecode in all files

### DIFF
--- a/report-viewer/src/components/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/src/components/fileDisplaying/FilesContainer.vue
@@ -26,7 +26,9 @@
           :highlight-language="highlightLanguage"
           @match-selected="(match: Match) => $emit('matchSelected', match)"
           class="mt-1 first:mt-0"
-          :base-code-matches="baseCodeMatches"
+          :base-code-matches="
+            baseCodeMatches.filter((match) => slash(match.fileName) === file.fileName)
+          "
         />
       </VueDraggableNext>
     </ScrollableComponent>
@@ -50,6 +52,7 @@ import { FileSortingOptions } from '@/model/ui/FileSortingOptions'
 import { store } from '@/stores/store'
 import type { BaseCodeMatch } from '@/model/BaseCodeReport'
 import type { Match } from '@/model/Match'
+import slash from 'slash'
 
 library.add(faCompressAlt)
 

--- a/report-viewer/src/model/MatchInSingleFile.ts
+++ b/report-viewer/src/model/MatchInSingleFile.ts
@@ -56,4 +56,12 @@ export class MatchInSingleFile {
       return this._match.endInSecond.column
     }
   }
+
+  get fileName(): string {
+    if (this._index === 1) {
+      return this._match.firstFile
+    } else {
+      return this._match.secondFile
+    }
+  }
 }


### PR DESCRIPTION
There is a bug where the base code highlighting is applied to all files.

This PR fixes that