### PR TITLE
Fix html unicode hex escapes being one character short

### DIFF
--- a/report-viewer/src/components/fileDisplaying/CodeLine.vue
+++ b/report-viewer/src/components/fileDisplaying/CodeLine.vue
@@ -141,6 +141,7 @@ function getNextLinePartTillColumn(endCol: number) {
         part += props.line[lineIndex.value]
         lineIndex.value++
       }
+      part += props.line[lineIndex.value]
       lineIndex.value++
       colIndex.value++
     } else {


### PR DESCRIPTION
Currently, the semicolon of hex escapes for Unicode characters is not added to the string. Due to this, if a valid Unicode character follows them (see #2110) strange symbols can appears. Other issues may arise when non-valid characters follow.

This PR makes sure the semicolon is included in the string, and this fixes #2110 
![grafik](https://github.com/user-attachments/assets/ea151459-347c-4e55-b431-7163b0f156d0)
