### PR TITLE
Reviewable version of 6.0.0 deploy report-viewer

### DIFF
--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -41,9 +41,8 @@
         <Button class="mx-auto w-fit text-xl" @click="continueWithLocal()"> View Example </Button>
       </div>
       <div class="text-xl font-bold text-error">
-        The hosted report viewer is no longer being updated. It does not support the latest features
-        of JPlag. <br />
-        The report viewer of version 6.0.0 or newer is started from the cli directly.
+        The hosted report viewer is no longer being updated and does not support the latest features of JPlag. <br />
+        Starting with JPlag version 6.0.0, the report viewer is launched directly in your browser when running JPlag.
       </div>
       <div v-if="errors.length > 0" class="text-error">
         <p>{{ getErrorText() }}</p>

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -40,6 +40,11 @@
       <div v-else-if="exampleFiles" class="pt-5">
         <Button class="mx-auto w-fit text-xl" @click="continueWithLocal()"> View Example </Button>
       </div>
+      <div class="text-xl font-bold text-error">
+        The hosted report viewer is no longer being updated. It does not support the latest features
+        of JPlag. <br />
+        The report viewer of version 6.0.0 or newer is started from the cli directly.
+      </div>
       <div v-if="errors.length > 0" class="text-error">
         <p>{{ getErrorText() }}</p>
         <p>For more details check the console.</p>


### PR DESCRIPTION
> [!warning]
> Do not merge this PR
> It is not meant to be merged into main. It only exists to enable review 

With version 6.0.0 there will no longer be an updated deployed version of the report viewer.
The build version of this branch should be pushed to the gh-pages branch on release of the 6.0.0 version.

The currently deployed version should be modified to notify the user about the newer version and the fact, that the report viewer will no longer be updated

![Image](https://github.com/user-attachments/assets/574e24bf-8cbb-4a9e-a4d5-392638e667b4)