### PR TITLE
Use default vite port

### DIFF
--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --port 8080",
+    "dev": "vite",
     "build": "run-p type-check build-only",
     "preview": "vite preview",
     "test:unit": "vitest",

--- a/report-viewer/playwright.config.ts
+++ b/report-viewer/playwright.config.ts
@@ -37,7 +37,7 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:8080',
+    baseURL: 'http://localhost:4173',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -106,8 +106,8 @@ const config: PlaywrightTestConfig = {
      * Use the preview server on CI for more realistic testing.
     Playwright will re-use the local server if there is already a dev-server running.
      */
-    command: 'vite preview --port 8080',
-    port: 8080,
+    command: 'vite preview',
+    port: 4173,
     reuseExistingServer: !process.env.CI
   }
 }


### PR DESCRIPTION
After the change from webpack to vite we still kept the old `8080` port. Vite per default uses `5173` for dev and `4173` for preview. This PR updates to those ports