### PR TITLE
Add link for how to use Jplag

### DIFF
--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -41,6 +41,7 @@
         </Button>
         <a
           href="https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag"
+          target="_blank"
           class="text-link-dark underline dark:text-link"
         >
           How to use JPlag

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -39,6 +39,12 @@
         <Button v-if="localFiles" class="mx-auto mt-8 w-fit" @click="continueWithLocal">
           Continue with local files
         </Button>
+        <a
+          href="https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag"
+          class="text-link-dark underline dark:text-link"
+        >
+          How to use JPlag
+        </a>
       </div>
       <LoadingCircle v-else-if="loadingFiles || exampleFiles" class="space-y-5 pt-5" />
       <div v-if="errors.length > 0" class="text-error">


### PR DESCRIPTION
Adds a link to the wiki page on how to use jplag onto the landing page.

We should discuss if we want to have the link somewhere else too, since when opening a report the user does not see this page anymore.

<details>
  <summary>View</summary>
	<img src="https://github.com/user-attachments/assets/e4defd3b-a843-4167-849f-5193324d6499" />

</details>
