### PR TITLE
Give results as local in e2e test

### DIFF
--- a/report-viewer/tests/e2e/Cluster.spec.ts
+++ b/report-viewer/tests/e2e/Cluster.spec.ts
@@ -2,8 +2,6 @@ import { test, expect } from '@playwright/test'
 import { uploadFile } from './TestUtils'
 
 test('Test cluster view', async ({ page }) => {
-  await page.goto('/')
-
   await uploadFile('result_small_cluster.zip', page)
 
   // check for all clusters being shown

--- a/report-viewer/tests/e2e/Comparison.spec.ts
+++ b/report-viewer/tests/e2e/Comparison.spec.ts
@@ -2,8 +2,6 @@ import { test, expect, Page } from '@playwright/test'
 import { uploadFile } from './TestUtils'
 
 test('Test comparison table and comparsion view', async ({ page }) => {
-  await page.goto('/')
-
   await uploadFile('progpedia-report.zip', page)
 
   const comparisonContainer = page.getByText('Hide AllSort By')

--- a/report-viewer/tests/e2e/Distribution.spec.ts
+++ b/report-viewer/tests/e2e/Distribution.spec.ts
@@ -3,8 +3,6 @@ import { uploadFile } from './TestUtils'
 
 test('Test distribution diagram', async ({ page }) => {
   test.slow()
-  await page.goto('/')
-
   await uploadFile('progpedia-report.zip', page)
 
   const options = getTestCombinations()

--- a/report-viewer/tests/e2e/Information.spec.ts
+++ b/report-viewer/tests/e2e/Information.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test'
 import { uploadFile } from './TestUtils'
 
 test('Test information page', async ({ page }) => {
-  await page.goto('/')
   await uploadFile('progpedia-report.zip', page)
 
   // check displayed information on overview page

--- a/report-viewer/tests/e2e/OpenComparisonTest.spec.ts
+++ b/report-viewer/tests/e2e/OpenComparisonTest.spec.ts
@@ -58,8 +58,6 @@ const testSets: DataSet[] = [
 
 for (const testSet of testSets) {
   test(`Can open ${testSet.datasetName}`, async ({ page }) => {
-    await page.goto('/')
-
     await uploadFile(testSet.datasetName, page)
 
     const comparisonTable = await page.getByText('Cluster1').textContent()

--- a/report-viewer/tests/e2e/OpenOldReport.spec.ts
+++ b/report-viewer/tests/e2e/OpenOldReport.spec.ts
@@ -16,7 +16,6 @@ const oldVersionZips = [
 
 for (const oldVersion of oldVersionZips) {
   test(`Test old version redirect for v${oldVersion.version}`, async ({ page }) => {
-    await page.goto('/')
     await uploadFile(oldVersion.zipName, page, '/old/' + oldVersion.version)
 
     const bodyContent = await page.locator('body').textContent()
@@ -34,7 +33,6 @@ for (const oldVersion of oldVersionZips) {
 }
 
 test('Test unsupported old version', async ({ page }) => {
-  await page.goto('/')
   await uploadFile('progpedia-report-v4_0_0.zip', page, '/old/4.0.0')
 
   const bodyContent = await page.locator('body').textContent()

--- a/report-viewer/tests/e2e/OpenOldReport.spec.ts
+++ b/report-viewer/tests/e2e/OpenOldReport.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, Page, test } from '@playwright/test'
 import { uploadFile } from './TestUtils'
 
 const oldVersionZips = [
@@ -16,7 +16,7 @@ const oldVersionZips = [
 
 for (const oldVersion of oldVersionZips) {
   test(`Test old version redirect for v${oldVersion.version}`, async ({ page }) => {
-    await uploadFile(oldVersion.zipName, page, '/old/' + oldVersion.version)
+    await uploadFile(oldVersion.zipName, page, getWaitForOldPageFunction(oldVersion.version))
 
     const bodyContent = await page.locator('body').textContent()
     expect(bodyContent).toContain(
@@ -33,7 +33,7 @@ for (const oldVersion of oldVersionZips) {
 }
 
 test('Test unsupported old version', async ({ page }) => {
-  await uploadFile('progpedia-report-v4_0_0.zip', page, '/old/4.0.0')
+  await uploadFile('progpedia-report-v4_0_0.zip', page, getWaitForOldPageFunction('4.0.0'))
 
   const bodyContent = await page.locator('body').textContent()
   expect(bodyContent).toContain(
@@ -45,3 +45,9 @@ test('Test unsupported old version', async ({ page }) => {
     'Opening reports generated with version 4.0.0 is not supported by this report viewer.'
   )
 })
+
+function getWaitForOldPageFunction(version: string) {
+  return async (page: Page) => {
+    await page.waitForURL(`/old/${version}`)
+  }
+}

--- a/report-viewer/tests/e2e/README.md
+++ b/report-viewer/tests/e2e/README.md
@@ -52,7 +52,6 @@ If you want to add new tests we suggest doing the following tests:
      - The test should start like this
        ```typescript
        test('Name of the test', async ({ page }) => {
-         await page.goto('/')
          await uploadFile('YOUR_DATASET_NAME-report.zip', page)
          // Your test code
        });

--- a/report-viewer/tests/e2e/TestUtils.ts
+++ b/report-viewer/tests/e2e/TestUtils.ts
@@ -6,7 +6,12 @@ import { Page } from '@playwright/test'
  * Expects to be on the file upload page.
  * @param fileName
  */
-export async function uploadFile(fileName: string, page: Page, expectedURL: string = '/overview') {
+export async function uploadFile(
+  fileName: string,
+  page: Page,
+  waitCondition: (page: Page) => Promise<void> = async (page) =>
+    await page.locator('text="JPlag Report"').waitFor({ state: 'visible' })
+) {
   page.route('**/results.zip', async (route) => {
     await route.fulfill({
       // fullfill with the file
@@ -19,5 +24,5 @@ export async function uploadFile(fileName: string, page: Page, expectedURL: stri
 
   await page.goto('/')
 
-  await page.waitForURL(expectedURL)
+  await waitCondition(page)
 }

--- a/report-viewer/tests/e2e/TestUtils.ts
+++ b/report-viewer/tests/e2e/TestUtils.ts
@@ -1,4 +1,4 @@
-import { Page, expect } from '@playwright/test'
+import { Page } from '@playwright/test'
 
 /**
  * Selects a file in the file chooser and uploads it.
@@ -7,13 +7,17 @@ import { Page, expect } from '@playwright/test'
  * @param fileName
  */
 export async function uploadFile(fileName: string, page: Page, expectedURL: string = '/overview') {
-  expect(page).toHaveURL('/')
+  page.route('**/results.zip', async (route) => {
+    await route.fulfill({
+      // fullfill with the file
+      path: `./tests/e2e/assets/${fileName}`,
+      headers: {
+        'Content-Type': 'application/zip'
+      }
+    })
+  })
 
-  // upload file through file chooser
-  const fileChooserPromise = page.waitForEvent('filechooser')
-  await page.getByText('Drag and Drop zip/Json file on this page').click()
-  const fileChooser = await fileChooserPromise
-  await fileChooser.setFiles(`tests/e2e/assets/${fileName}`)
+  await page.goto('/')
 
   await page.waitForURL(expectedURL)
 }


### PR DESCRIPTION
Updates the e2e tests to now use provide the files through the request for a local result file instead of the file chooser option