### PR TITLE
Add all dependencies to coverage report

### DIFF
--- a/.github/workflows/scripts/checkCoverage.py
+++ b/.github/workflows/scripts/checkCoverage.py
@@ -1,0 +1,41 @@
+import os
+import xml.etree.ElementTree as ET
+
+def get_all_pom_files():
+    pom_files = []
+    for root, dirs, files in os.walk("../../.."):
+        for file in files:
+            if file == "pom.xml":
+                pom_files.append(os.path.join(root, file))
+    return pom_files
+
+# get content from a file as a string
+def get_file_content(file):
+    with open(file, "r") as f:
+        return f.read()
+
+# extract xml field artifact id from string
+def extract_artifact_id(xml):
+    root = ET.fromstring(xml)
+    return root.find("{http://maven.apache.org/POM/4.0.0}artifactId").text
+
+artifact_ids = [extract_artifact_id(get_file_content(file)) for file in get_all_pom_files()]
+print("All artifacts: " + str(artifact_ids))
+filtered_artifact_ids = [artifact_id for artifact_id in artifact_ids if "aggregator" not in artifact_id.lower() and "coverage-report" not in artifact_id.lower()]
+
+coverage_report_pom = ""
+with open("../../../coverage-report/pom.xml", "r") as f:
+    coverage_report_pom = f.read()
+xml = ET.fromstring(coverage_report_pom)
+coverage_report_artifacts = [dependency.find("{http://maven.apache.org/POM/4.0.0}artifactId").text for dependency in xml.find("{http://maven.apache.org/POM/4.0.0}dependencies").findall("{http://maven.apache.org/POM/4.0.0}dependency")]
+print("Coverage report artifacts: " + str(coverage_report_artifacts))
+
+only_in_coverage_report = [artifact_id for artifact_id in coverage_report_artifacts if artifact_id not in filtered_artifact_ids]
+print("Only in coverage report: " + str(only_in_coverage_report))
+not_in_coverage_report = [artifact_id for artifact_id in filtered_artifact_ids if artifact_id not in coverage_report_artifacts]
+print("Not in coverage report: " + str(not_in_coverage_report))
+
+if len(not_in_coverage_report) > 0:
+    raise Exception("Some artifacts are not in the coverage report: " + str(not_in_coverage_report))
+if len(only_in_coverage_report) > 0:
+    raise Exception("Some artifacts are only in the coverage report: " + str(only_in_coverage_report))

--- a/.github/workflows/scripts/checkCoverage.py
+++ b/.github/workflows/scripts/checkCoverage.py
@@ -19,9 +19,10 @@ def extract_artifact_id(xml):
     root = ET.fromstring(xml)
     return root.find("{http://maven.apache.org/POM/4.0.0}artifactId").text
 
+excluded_artifacts = ["coverage-report", "aggregator", "languages"]
 artifact_ids = [extract_artifact_id(get_file_content(file)) for file in get_all_pom_files()]
 print("All artifacts: " + str(artifact_ids))
-filtered_artifact_ids = [artifact_id for artifact_id in artifact_ids if "aggregator" not in artifact_id.lower() and "coverage-report" not in artifact_id.lower()]
+filtered_artifact_ids = [artifact_id for artifact_id in artifact_ids if artifact_id not in excluded_artifacts]
 
 coverage_report_pom = ""
 with open("../../../coverage-report/pom.xml", "r") as f:

--- a/.github/workflows/verify-coverage-report.yml
+++ b/.github/workflows/verify-coverage-report.yml
@@ -1,0 +1,27 @@
+name: Check that all dependencies are in coverage report
+
+on:
+    push:
+    paths:
+      - ".github/workflows/verify-coverage-report.yml"
+      - "./scripts/checkCoverage.py"
+      - "**/pom.xml"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/verify-coverage-report..yml"
+      - "./scripts/checkCoverage.py"
+      - "**/pom.xml"
+
+jobs:
+  check_coverage:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v4
+      
+    - name: Run script
+      working-directory: .github/workflows/scripts
+      run: |
+        python checkCoverage.py

--- a/.github/workflows/verify-coverage-report.yml
+++ b/.github/workflows/verify-coverage-report.yml
@@ -1,7 +1,8 @@
 name: Check that all dependencies are in coverage report
 
 on:
-    push:
+  workflow_dispatch:
+  push:
     paths:
       - ".github/workflows/verify-coverage-report.yml"
       - "./scripts/checkCoverage.py"

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -136,6 +136,16 @@
             <artifactId>llvmir</artifactId>
             <version>${revision}</version>
         </dependency>
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>javascript</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>multi-language</artifactId>
+            <version>${revision}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Adds all the missing dependencies to the coverage report
Currently, not added are the `coverage-report` itself, `aggregator` (root pom.xml) and `languages` 

This PR also adds a script that gets run anytime somebody changes something about any pom.xml (for example, adding one) it checks that all poms except the above-mentioned ones are included.
The check also fails, when the coverage report has dependecies that do not exist.