### PR TITLE
Enforce mimum merges when using match merging.

### DIFF
--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -25,6 +25,8 @@ import de.jplag.options.JPlagOptions;
  */
 public class MatchMerging {
     private final JPlagOptions options;
+    private final static int MINIMUM_REQUIRED_MERGES = 3;
+    private int numberOfMerges;
 
     /**
      * Instantiates the match merging algorithm for a comparison result and a set of specific options.
@@ -47,13 +49,18 @@ public class MatchMerging {
         List<JPlagComparison> comparisonsMerged = new ArrayList<>();
 
         ProgressBarLogger.iterate(ProgressBarType.MATCH_MERGING, comparisons, comparison -> {
+            numberOfMerges = 0;
             Submission leftSubmission = comparison.firstSubmission().copy();
             Submission rightSubmission = comparison.secondSubmission().copy();
             List<Match> globalMatches = new ArrayList<>(comparison.matches());
             globalMatches.addAll(comparison.ignoredMatches());
             globalMatches = mergeNeighbors(globalMatches, leftSubmission, rightSubmission);
             globalMatches = globalMatches.stream().filter(it -> it.length() >= options.minimumTokenMatch()).toList();
-            comparisonsMerged.add(new JPlagComparison(leftSubmission, rightSubmission, globalMatches, new ArrayList<>()));
+            if (numberOfMerges >= MINIMUM_REQUIRED_MERGES) {
+                comparisonsMerged.add(new JPlagComparison(leftSubmission, rightSubmission, globalMatches, new ArrayList<>()));
+            } else {
+                comparisonsMerged.add(comparison);
+            }
         });
 
         long durationInMillis = System.currentTimeMillis() - timeBeforeStartInMillis;
@@ -111,6 +118,7 @@ public class MatchMerging {
                 globalMatches = removeToken(globalMatches, leftSubmission, rightSubmission, upperNeighbor, tokenBetweenLeft, tokensBetweenRight);
                 neighbors = computeNeighbors(globalMatches);
                 i = 0;
+                numberOfMerges++;
             } else {
                 i++;
             }


### PR DESCRIPTION
For pairs of unrelated programs, match merging may increase the similarity as it is a heuristic-based approach to revert the effects of obfuscation. To reduce this effect on false positives, this PR introduces a threshold for the minimum number of merges. Below this threshold, the merged matches are discarded, and the original matches are used. Resolves #2077. 

TODO:
- [ ] Adapt tests
- [ ] Introduce CLI parameter
- [ ] tune default value