### PR TITLE
Fix token count extraction in demo

### DIFF
--- a/report-viewer/src/model/factories/BaseFactory.ts
+++ b/report-viewer/src/model/factories/BaseFactory.ts
@@ -14,16 +14,16 @@ export class BaseFactory {
    * @throws Error if the file could not be found
    */
   protected static async getFile(path: string): Promise<string> {
-    if (import.meta.env.MODE == 'demo') {
-      await new ZipFileHandler().handleFile(await this.getLocalFile('example.zip'))
-      return this.getFileFromStore(path)
-    }
     if (store().state.localModeUsed) {
       return await (await this.getLocalFile(`/files/${path}`)).text()
     } else if (store().state.zipModeUsed) {
       return this.getFileFromStore(path)
     } else if (await this.useLocalZipMode()) {
       await new ZipFileHandler().handleFile(await this.getLocalFile(this.zipFileName))
+      store().setLoadingType('zip')
+      return this.getFileFromStore(path)
+    } else if (import.meta.env.MODE == 'demo') {
+      await new ZipFileHandler().handleFile(await this.getLocalFile('example.zip'))
       store().setLoadingType('zip')
       return this.getFileFromStore(path)
     }

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -190,7 +190,7 @@ async function loadQueryFile(url: URL) {
  * Handles click on Continue with local files.
  */
 function continueWithLocal() {
-  store().state.uploadedFileName = exampleFiles.value ? 'progpedia.zip' : BaseFactory.zipFileName
+  store().state.uploadedFileName = BaseFactory.zipFileName
   store().setLoadingType('local')
   navigateToOverview()
 }
@@ -224,6 +224,7 @@ onErrorCaptured((error) => {
 })
 
 if (exampleFiles.value) {
-  continueWithLocal()
+  store().state.uploadedFileName = 'progpedia.zip'
+  navigateToOverview()
 }
 </script>


### PR DESCRIPTION
The token count was not correctly extracted in the demo mode.

This happened due to overwriting previously written data when always reloading the zip