### PR TITLE
Fix language export and import in report

### DIFF
--- a/core/src/main/java/de/jplag/reporting/jsonfactory/serializer/LanguageSerializer.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/serializer/LanguageSerializer.java
@@ -27,6 +27,6 @@ public class LanguageSerializer extends StdSerializer<Language> {
 
     @Override
     public void serialize(Language language, JsonGenerator generator, SerializerProvider provider) throws IOException {
-        generator.writeString(language.getName());
+        generator.writeString(language.getIdentifier());
     }
 }

--- a/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/ReportObjectFactory.java
@@ -149,7 +149,7 @@ public class ReportObjectFactory {
                 missingComparisons);
         OverviewReport overviewReport = new OverviewReport(REPORT_VIEWER_VERSION, folders.stream().map(File::getPath).toList(), // submissionFolderPath
                 baseCodePath, // baseCodeFolderPath
-                result.getOptions().language().getIdentifier(), // language
+                result.getOptions().language(), // language
                 result.getOptions().fileSuffixes(), // fileExtensions
                 submissionNameToIdMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey)), // submissionIds
                 submissionNameToNameToComparisonFileName, // result.getOptions().getMinimumTokenMatch(),

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/OverviewReport.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/OverviewReport.java
@@ -4,10 +4,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import de.jplag.Language;
 import de.jplag.reporting.jsonfactory.serializer.LanguageSerializer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 public record OverviewReport(
 

--- a/core/src/main/java/de/jplag/reporting/reportobject/model/OverviewReport.java
+++ b/core/src/main/java/de/jplag/reporting/reportobject/model/OverviewReport.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import de.jplag.Language;
+import de.jplag.reporting.jsonfactory.serializer.LanguageSerializer;
 
 public record OverviewReport(
 
@@ -14,7 +17,7 @@ public record OverviewReport(
 
         @JsonProperty("base_code_folder_path") String baseCodeFolderPath,
 
-        @JsonProperty("language") String language,
+        @JsonSerialize(using = LanguageSerializer.class) Language language,
 
         @JsonProperty("file_extensions") List<String> fileExtensions,
 

--- a/report-viewer/src/model/Language.ts
+++ b/report-viewer/src/model/Language.ts
@@ -21,7 +21,8 @@ enum ParserLanguage {
   SCXML = 'scxml',
   LLVM = 'llvmir',
   JAVASCRIPT = 'javascript',
-  TYPESCRIPT = 'typescript'
+  TYPESCRIPT = 'typescript',
+  MULTI_LANGUAGE = 'multi'
 }
 
 type Language = ParserLanguage | 'unknown language'

--- a/report-viewer/src/model/factories/OptionsFactory.ts
+++ b/report-viewer/src/model/factories/OptionsFactory.ts
@@ -1,5 +1,5 @@
 import type { CliClusterOptions, CliMergingOptions, CliOptions } from '../CliOptions'
-import { ParserLanguage } from '../Language'
+import { getLanguageParser } from '../Language'
 import { MetricType } from '../MetricType'
 import { BaseFactory } from './BaseFactory'
 
@@ -10,7 +10,7 @@ export class OptionsFactory extends BaseFactory {
 
   private static extractOptions(json: Record<string, unknown>): CliOptions {
     return {
-      language: json['language'] as ParserLanguage,
+      language: getLanguageParser(json['language'] as string),
       minTokenMatch: json['min_token_match'] as number,
       submissionDirectories: json['submission_directories'] as string[],
       oldDirectories: json['old_directories'] as string[],


### PR DESCRIPTION
Identifier of language is used everywhere now.
Extracts the language with the propper method in the report viewer.
Adds the multi language module in the report viewer