### PR TITLE
Fix documentation regarding language options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ JPlag can either be used via the CLI or directly via its Java API. For more info
 
 ### CLI
 *Note that the [legacy CLI](https://github.com/jplag/jplag/blob/legacy/README.md) is varying slightly.*
-The language can either be set with the -l parameter or as a subcommand (`jplag [jplag options] <language name> [language options]`). A subcommand takes priority over the -l option.
+The language can either be set with the -l parameter or as a subcommand (`jplag [jplag options] -l <language name> [language options]`). A subcommand takes priority over the -l option.
 Language-specific arguments can be set when using the subcommand. A list of language-specific options can be obtained by requesting the help page of a subcommand (e.g., `jplag java —h`).
 
 ```

--- a/docs/1.-How-to-Use-JPlag.md
+++ b/docs/1.-How-to-Use-JPlag.md
@@ -9,7 +9,7 @@ The language can either be set with the -l parameter or as a subcommand. If both
 When using the subcommand, language-specific arguments can be set.
 A list of language-specific options can be obtained by requesting the help page of a subcommand (e.g., "jplag java -h").
 
-To run jplag normally on a set of submissions run: `java -jar jplag.jar <language> <path/to/submissions>`
+To run jplag normally on a set of submissions run: `java -jar jplag.jar -l <language> <path/to/submissions>`
 If the language is java, it can be omitted: `java -jar jplag.jar <path/to/submissions>`
 
 To open an existing report run: `java -jar jplag.jar </path/to/report.zip>`


### PR DESCRIPTION
Since we are currently experiencing bugs with the subcommand usage regarding CLI parameter order, the documentation has been updated to refer to the language option via `-l`.