### PR TITLE
Clean up the language interfaces

### DIFF
--- a/language-api/src/main/java/de/jplag/Language.java
+++ b/language-api/src/main/java/de/jplag/Language.java
@@ -12,7 +12,7 @@ import de.jplag.options.LanguageOptions;
 public interface Language {
 
     /**
-     * Suffixes for the files containing code of the language. An empty array means all suffixes are valid.
+     * File extensions for the files containing code of the language. An empty array means all suffixes are valid.
      */
     String[] suffixes();
 

--- a/languages/c/src/main/java/de/jplag/c/CLanguage.java
+++ b/languages/c/src/main/java/de/jplag/c/CLanguage.java
@@ -15,7 +15,8 @@ public class CLanguage implements Language {
 
     @Override
     public String[] suffixes() {
-        return new String[] {".cpp", ".CPP", ".cxx", ".CXX", ".c++", ".C++", ".c", ".C", ".cc", ".CC", ".h", ".H", ".hpp", ".HPP", ".hh", ".HH"};
+        return new String[] {".cpp", ".CPP", ".cxx", ".CXX", ".c++", ".C++", ".c", ".C", ".cc", ".CC", ".h", ".H", ".hpp", ".HPP", ".hh", ".HH",
+                ".hxx", ".HXX"};
     }
 
     @Override

--- a/languages/c/src/main/java/de/jplag/c/CLanguage.java
+++ b/languages/c/src/main/java/de/jplag/c/CLanguage.java
@@ -10,10 +10,8 @@ import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class CLanguage implements Language {
-    private static final String NAME = "C";
-    private static final String IDENTIFIER = "c";
 
     @Override
     public String[] suffixes() {
@@ -22,12 +20,12 @@ public class CLanguage implements Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "C";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "c";
     }
 
     @Override

--- a/languages/cpp/src/main/java/de/jplag/cpp/CPPLanguage.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/CPPLanguage.java
@@ -15,8 +15,6 @@ import de.jplag.Token;
  */
 @MetaInfServices(Language.class)
 public class CPPLanguage implements Language {
-    private static final String NAME = "C++";
-    private static final String IDENTIFIER = "cpp";
 
     @Override
     public String[] suffixes() {
@@ -25,12 +23,12 @@ public class CPPLanguage implements Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "C++";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "cpp";
     }
 
     @Override

--- a/languages/cpp/src/main/java/de/jplag/cpp/CPPLanguage.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/CPPLanguage.java
@@ -18,7 +18,8 @@ public class CPPLanguage implements Language {
 
     @Override
     public String[] suffixes() {
-        return new String[] {".cpp", ".CPP", ".cxx", ".CXX", ".c++", ".C++", ".c", ".C", ".cc", ".CC", ".h", ".H", ".hpp", ".HPP", ".hh", ".HH"};
+        return new String[] {".cpp", ".CPP", ".cxx", ".CXX", ".c++", ".C++", ".c", ".C", ".cc", ".CC", ".h", ".H", ".hpp", ".HPP", ".hh", ".HH",
+                ".hxx"};
     }
 
     @Override

--- a/languages/csharp/src/main/java/de/jplag/csharp/CSharpLanguage.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/CSharpLanguage.java
@@ -13,31 +13,27 @@ import de.jplag.Token;
 /**
  * C# language with full support of C# 6 features and below.
  */
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class CSharpLanguage implements Language {
-    private static final String NAME = "C#";
-    private static final String IDENTIFIER = "csharp";
-    private static final String[] FILE_ENDINGS = new String[] {".cs", ".CS"};
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
 
     @Override
     public String[] suffixes() {
-        return FILE_ENDINGS;
+        return new String[] {".cs", ".CS"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "C#";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "csharp";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 8;
     }
 
     @Override

--- a/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/DynamicEmfLanguage.java
+++ b/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/DynamicEmfLanguage.java
@@ -15,24 +15,20 @@ import de.jplag.emf.dynamic.parser.DynamicEcoreParser;
  * @author Timur Saglam
  */
 public class DynamicEmfLanguage extends EmfLanguage { // currently not included in the CLI
-    private static final String NAME = "EMF metamodels (dynamically created token set)";
-    private static final String IDENTIFIER = "emf-dynamic";
-
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 10;
 
     @Override
     public String getName() {
-        return NAME;
+        return "EMF metamodels (dynamically created token set)";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "emf-dynamic";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 10;
     }
 
     @Override

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/EmfLanguage.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/EmfLanguage.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.emf.parser.EcoreParser;
@@ -15,14 +16,11 @@ import de.jplag.emf.parser.EcoreParser;
  * Language for EMF metamodels from the Eclipse Modeling Framework (EMF).
  * @author Timur Saglam
  */
-@MetaInfServices(de.jplag.Language.class)
-public class EmfLanguage implements de.jplag.Language {
+@MetaInfServices(Language.class)
+public class EmfLanguage implements Language {
+
     public static final String VIEW_FILE_SUFFIX = ".emfatic";
     public static final String FILE_ENDING = "." + EcorePackage.eNAME;
-
-    private static final String NAME = "EMF metamodel";
-    private static final String IDENTIFIER = "emf";
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 6;
 
     @Override
     public String[] suffixes() {
@@ -31,17 +29,17 @@ public class EmfLanguage implements de.jplag.Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "EMF metamodel";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "emf";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 6;
     }
 
     @Override

--- a/languages/emf-model/src/main/java/de/jplag/emf/model/EmfModelLanguage.java
+++ b/languages/emf-model/src/main/java/de/jplag/emf/model/EmfModelLanguage.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.emf.dynamic.DynamicEmfLanguage;
@@ -17,12 +18,8 @@ import de.jplag.emf.model.parser.DynamicModelParser;
  * created token set.
  * @author Timur Saglam
  */
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class EmfModelLanguage extends DynamicEmfLanguage {
-    private static final String NAME = "EMF models (dynamically created token set)";
-    private static final String IDENTIFIER = "emf-model";
-
-    public static final String VIEW_FILE_SUFFIX = ".treeview";
 
     @Override
     public String[] suffixes() {
@@ -31,17 +28,17 @@ public class EmfModelLanguage extends DynamicEmfLanguage {
 
     @Override
     public String getName() {
-        return NAME;
+        return "EMF models (dynamically created token set)";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "emf-model";
     }
 
     @Override
     public String viewFileSuffix() {
-        return VIEW_FILE_SUFFIX;
+        return ".treeview";
     }
 
     @Override

--- a/languages/golang/src/main/java/de/jplag/golang/GoLanguage.java
+++ b/languages/golang/src/main/java/de/jplag/golang/GoLanguage.java
@@ -10,31 +10,27 @@ import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class GoLanguage implements Language {
-    private static final String NAME = "Go";
-    private static final String IDENTIFIER = "go";
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
-    private static final String[] FILE_EXTENSIONS = {".go"};
 
     @Override
     public String[] suffixes() {
-        return FILE_EXTENSIONS;
+        return new String[] {".go"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "Go";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "go";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 8;
     }
 
     @Override

--- a/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
+++ b/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
@@ -6,16 +6,15 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
 /**
  * Language for Java 9 and newer.
  */
-@MetaInfServices(de.jplag.Language.class)
-public class JavaLanguage implements de.jplag.Language {
-    private static final String NAME = "Java";
-    private static final String IDENTIFIER = "java";
+@MetaInfServices(Language.class)
+public class JavaLanguage implements Language {
 
     @Override
     public String[] suffixes() {
@@ -24,12 +23,12 @@ public class JavaLanguage implements de.jplag.Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "Java";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "java";
     }
 
     @Override

--- a/languages/javascript/src/main/java/de/jplag/javascript/JavaScriptLanguage.java
+++ b/languages/javascript/src/main/java/de/jplag/javascript/JavaScriptLanguage.java
@@ -2,20 +2,18 @@ package de.jplag.javascript;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.typescript.TypeScriptLanguage;
 
 /**
  * Represents the JavaScript Language as a variance of TypeScript
  */
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class JavaScriptLanguage extends TypeScriptLanguage {
-
-    private static final String IDENTIFIER = "javascript";
-    private static final String NAME = "JavaScript";
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "javascript";
     }
 
     @Override
@@ -25,6 +23,6 @@ public class JavaScriptLanguage extends TypeScriptLanguage {
 
     @Override
     public String getName() {
-        return NAME;
+        return "JavaScript";
     }
 }

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinLanguage.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinLanguage.java
@@ -13,32 +13,27 @@ import de.jplag.Token;
 /**
  * This represents the Kotlin language as a language supported by JPlag.
  */
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class KotlinLanguage implements Language {
-
-    private static final String NAME = "Kotlin";
-    private static final String IDENTIFIER = "kotlin";
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
-    private static final String[] FILE_EXTENSIONS = {".kt"};
 
     @Override
     public String[] suffixes() {
-        return FILE_EXTENSIONS;
+        return new String[] {".kt"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "Kotlin";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "kotlin";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 8;
     }
 
     @Override

--- a/languages/llvmir/src/main/java/de/jplag/llvmir/LLVMIRLanguage.java
+++ b/languages/llvmir/src/main/java/de/jplag/llvmir/LLVMIRLanguage.java
@@ -16,29 +16,24 @@ import de.jplag.Token;
 @MetaInfServices(Language.class)
 public class LLVMIRLanguage implements Language {
 
-    private static final String NAME = "LLVM IR";
-    private static final String IDENTIFIER = "llvmir";
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 70;
-    private static final String[] FILE_EXTENSIONS = {".ll"};
-
     @Override
     public String[] suffixes() {
-        return FILE_EXTENSIONS;
+        return new String[] {".ll"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "LLVM IR";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "llvmir";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 70;
     }
 
     @Override

--- a/languages/python-3/src/main/java/de/jplag/python3/PythonLanguage.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/PythonLanguage.java
@@ -10,10 +10,8 @@ import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class PythonLanguage implements Language {
-    private static final String NAME = "Python";
-    private static final String IDENTIFIER = "python3";
 
     @Override
     public String[] suffixes() {
@@ -22,12 +20,12 @@ public class PythonLanguage implements Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "Python";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "python3";
     }
 
     @Override

--- a/languages/rlang/src/main/java/de/jplag/rlang/RLanguage.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/RLanguage.java
@@ -13,31 +13,27 @@ import de.jplag.Token;
 /**
  * This represents the R language as a language supported by JPlag.
  */
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class RLanguage implements Language {
-    private static final String NAME = "R";
-    private static final String IDENTIFIER = "rlang";
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
-    private static final String[] FILE_EXTENSION = {".R", ".r"};
 
     @Override
     public String[] suffixes() {
-        return FILE_EXTENSION;
+        return new String[] {".R", ".r"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "R";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "rlang";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 8;
     }
 
     @Override

--- a/languages/rust/src/main/java/de/jplag/rust/RustLanguage.java
+++ b/languages/rust/src/main/java/de/jplag/rust/RustLanguage.java
@@ -6,38 +6,34 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
 /**
  * This represents the Rust language as a language supported by JPlag.
  */
-@MetaInfServices(de.jplag.Language.class)
-public class RustLanguage implements de.jplag.Language {
-
-    protected static final String[] FILE_EXTENSIONS = {".rs"};
-    private static final String NAME = "Rust";
-    private static final String IDENTIFIER = "rust";
-    private static final int MINIMUM_TOKEN_MATCH = 8;
+@MetaInfServices(Language.class)
+public class RustLanguage implements Language {
 
     @Override
     public String[] suffixes() {
-        return FILE_EXTENSIONS;
+        return new String[] {".rs"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "Rust";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "rust";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return MINIMUM_TOKEN_MATCH;
+        return 8;
     }
 
     @Override

--- a/languages/scheme/src/main/java/de/jplag/scheme/SchemeLanguage.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/SchemeLanguage.java
@@ -6,14 +6,12 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
-@MetaInfServices(de.jplag.Language.class)
-public class SchemeLanguage implements de.jplag.Language {
-
-    private static final String NAME = "Scheme";
-    private static final String IDENTIFIER = "scheme";
+@MetaInfServices(Language.class)
+public class SchemeLanguage implements Language {
 
     @Override
     public String[] suffixes() {
@@ -22,12 +20,12 @@ public class SchemeLanguage implements de.jplag.Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "Scheme";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "scheme";
     }
 
     @Override

--- a/languages/scxml/src/main/java/de/jplag/scxml/ScxmlLanguage.java
+++ b/languages/scxml/src/main/java/de/jplag/scxml/ScxmlLanguage.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.scxml.parser.ScxmlParserAdapter;
@@ -13,41 +14,29 @@ import de.jplag.scxml.parser.ScxmlParserAdapter;
 /**
  * Language for statecharts in the State Chart XML (SCXML) format.
  */
-@MetaInfServices(de.jplag.Language.class)
-public class ScxmlLanguage implements de.jplag.Language {
+@MetaInfServices(Language.class)
+public class ScxmlLanguage implements Language {
 
-    /**
-     * The file ending of SCXML statechart files.
-     */
-    public static final String FILE_ENDING = ".scxml";
-
-    /**
-     * The file ending of view files.
-     */
     public static final String VIEW_FILE_SUFFIX = ".scxmlview";
-
-    private static final String NAME = "SCXML";
-    private static final String IDENTIFIER = "scxml";
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 6;
 
     @Override
     public String[] suffixes() {
-        return new String[] {FILE_ENDING};
+        return new String[] {".scxml"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "SCXML";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "scxml";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 6;
     }
 
     @Override

--- a/languages/swift/src/main/java/de/jplag/swift/SwiftLanguage.java
+++ b/languages/swift/src/main/java/de/jplag/swift/SwiftLanguage.java
@@ -13,33 +13,27 @@ import de.jplag.Token;
 /**
  * This represents the Swift language as a language supported by JPlag.
  */
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class SwiftLanguage implements Language {
-
-    private static final String IDENTIFIER = "swift";
-
-    private static final String NAME = "Swift";
-    private static final int DEFAULT_MIN_TOKEN_MATCH = 8;
-    private static final String[] FILE_EXTENSIONS = {".swift"};
 
     @Override
     public String[] suffixes() {
-        return FILE_EXTENSIONS;
+        return new String[] {".swift"};
     }
 
     @Override
     public String getName() {
-        return NAME;
+        return "Swift";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "swift";
     }
 
     @Override
     public int minimumTokenMatch() {
-        return DEFAULT_MIN_TOKEN_MATCH;
+        return 8;
     }
 
     @Override

--- a/languages/text/src/main/java/de/jplag/text/NaturalLanguage.java
+++ b/languages/text/src/main/java/de/jplag/text/NaturalLanguage.java
@@ -20,7 +20,8 @@ public class NaturalLanguage implements Language {
 
     @Override
     public String[] suffixes() {
-        return new String[] {".TXT", ".txt", ".ASC", ".asc", ".TEX", ".tex"};
+        return new String[] {".TXT", ".txt", ".ASC", ".asc", ".TEX", ".tex", ".MD", ".md", ".RTF", ".rtf", ".CSV", ".csv", ".WIKI", ".wiki", ".JSON",
+                ".json", ".YAML", ".yaml", ".YML", ".yml", ".XML", ".xml"};
     }
 
     @Override

--- a/languages/text/src/main/java/de/jplag/text/NaturalLanguage.java
+++ b/languages/text/src/main/java/de/jplag/text/NaturalLanguage.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.kohsuke.MetaInfServices;
 
+import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 
@@ -14,11 +15,8 @@ import de.jplag.Token;
  * individual words are interpreted as token types. Whitespace and special characters are ignored. This approach works,
  * but there are better approaches for text plagiarism out there (based on NLP techniques).
  */
-@MetaInfServices(de.jplag.Language.class)
-public class NaturalLanguage implements de.jplag.Language {
-
-    private static final String IDENTIFIER = "text";
-    private static final String NAME = "Text (naive)";
+@MetaInfServices(Language.class)
+public class NaturalLanguage implements Language {
 
     @Override
     public String[] suffixes() {
@@ -27,12 +25,12 @@ public class NaturalLanguage implements de.jplag.Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "Text (naive)";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "text";
     }
 
     @Override

--- a/languages/typescript/src/main/java/de/jplag/typescript/TypeScriptLanguage.java
+++ b/languages/typescript/src/main/java/de/jplag/typescript/TypeScriptLanguage.java
@@ -13,11 +13,9 @@ import de.jplag.Token;
 /**
  * This represents the TypeScript language as a language supported by JPlag.
  */
-@MetaInfServices(de.jplag.Language.class)
+@MetaInfServices(Language.class)
 public class TypeScriptLanguage implements Language {
 
-    private static final String IDENTIFIER = "typescript";
-    private static final String NAME = "TypeScript";
     private final TypeScriptLanguageOptions options = new TypeScriptLanguageOptions();
 
     @Override
@@ -27,12 +25,12 @@ public class TypeScriptLanguage implements Language {
 
     @Override
     public String getName() {
-        return NAME;
+        return "TypeScript";
     }
 
     @Override
     public String getIdentifier() {
-        return IDENTIFIER;
+        return "typescript";
     }
 
     @Override


### PR DESCRIPTION
Cleans up the language interfaces:

- Import language utils interface directly
- Dissolve constants, does not fix Sonar code duplication annoyance
- Preserve constants for EMF/SCXML where they are actually used
- Ensures consistency across language modules
- Expand file extensions for the c, cpp, and text modules.

Thus also addresses #2159.