### PR TITLE
Switch GreedyStringTiling from IdentityHashMap to ConcurrentHashMap

### DIFF
--- a/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
@@ -3,10 +3,10 @@ package de.jplag.comparison;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import de.jplag.JPlagComparison;
@@ -26,9 +26,9 @@ import de.jplag.options.JPlagOptions;
 public class GreedyStringTiling {
     private final int minimumMatchLength;
     private final JPlagOptions options;
-    private final Map<Submission, Set<Token>> baseCodeMarkings = new IdentityHashMap<>();
+    private final Map<Submission, Set<Token>> baseCodeMarkings = new ConcurrentHashMap<>();
 
-    private final Map<Submission, SubsequenceHashLookupTable> cachedHashLookupTables = new IdentityHashMap<>();
+    private final Map<Submission, SubsequenceHashLookupTable> cachedHashLookupTables = new ConcurrentHashMap<>();
 
     private final TokenValueMapper tokenValueMapper;
 

--- a/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
@@ -55,7 +55,7 @@ public class GreedyStringTiling {
     /**
      * Compares the given submission with the base code submission. Marks the identified base code sections in the
      * submission such that further comparisons do not generate matches for these parts. Must be called before generating a
-     * comparison with a regular submission for the given submission.
+     * comparison with a regular submission for the given submission. THIS METHOD IS NOT THREAD-SAFE.
      * @param submission is the submission to generate base-code markings for.
      * @param baseCodeSubmission is the base code submission.
      * @return the comparison of the submission with the base code submission.
@@ -82,8 +82,8 @@ public class GreedyStringTiling {
     }
 
     /**
-     * Compares the two submissions and generates matches between them. To exclude base code from the result, call
-     * {@link #generateBaseCodeMarking} with each submission beforehand.
+     * Compares the two submissions in a thread-safe manner and generates matches between them. To exclude base code from
+     * the result, call {@link #generateBaseCodeMarking} with each submission beforehand.
      * @param firstSubmission is one of the two submissions.
      * @param secondSubmission is the other of the two submissions.
      * @return the comparison between the two submissions.

--- a/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
@@ -1,12 +1,13 @@
 package de.jplag.comparison;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import de.jplag.JPlagComparison;
@@ -26,9 +27,9 @@ import de.jplag.options.JPlagOptions;
 public class GreedyStringTiling {
     private final int minimumMatchLength;
     private final JPlagOptions options;
-    private final Map<Submission, Set<Token>> baseCodeMarkings = new ConcurrentHashMap<>();
+    private final Map<Submission, Set<Token>> baseCodeMarkings = new IdentityHashMap<>();
 
-    private final Map<Submission, SubsequenceHashLookupTable> cachedHashLookupTables = new ConcurrentHashMap<>();
+    private final Map<Submission, SubsequenceHashLookupTable> cachedHashLookupTables = Collections.synchronizedMap(new IdentityHashMap<>());
 
     private final TokenValueMapper tokenValueMapper;
 


### PR DESCRIPTION
Changed to IdentityHashMaps in GreedyStringTiling to ConcurrentHashMaps. This has been done because the comparisons are called parallel and IdentityHashMap is not thread-safe.

I checked to end-to-end tests to make sure the comparison still works as intended.

I measured the runtime impact on the progpedia dataset:
```
Benchmark 1: java -jar new.jar ACCEPTED --mode RUN --overwrite
  Time (mean ± σ):      1.631 s ±  0.029 s    [User: 9.458 s, System: 0.837 s]
  Range (min … max):    1.579 s …  1.709 s    20 runs

Benchmark 2: java -jar old.jar ACCEPTED --mode RUN --overwrite
  Time (mean ± σ):      1.640 s ±  0.026 s    [User: 9.599 s, System: 0.846 s]
  Range (min … max):    1.592 s …  1.681 s    20 runs

Summary
  java -jar new.jar ACCEPTED --mode RUN --overwrite ran
    1.01 ± 0.02 times faster than java -jar old.jar ACCEPTED --mode RUN --overwrite
```