### PR TITLE
Improve short submission error.

### DIFF
--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -247,7 +247,7 @@ public class Submission implements Comparable<Submission> {
 
         if (tokenList.size() < minimalTokens) {
             // print the number of tokens without the file-end token to help users choose the right parameters:
-            logger.error("Submission {} contains {} tokens, which below the minimum match length {}!", name, tokenList.size() - 1, minimalTokens);
+            logger.error("Submission {} contains {} tokens, which is below the minimum match length {}!", name, tokenList.size() - 1, minimalTokens);
             state = TOO_SMALL;
             return false;
         }

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -246,7 +246,8 @@ public class Submission implements Comparable<Submission> {
         }
 
         if (tokenList.size() < minimalTokens) {
-            logger.error("Submission {} contains {} tokens, which below the minimum match length {}!", name, tokenList.size(), minimalTokens);
+            // print the number of tokens without the file-end token to help users choose the right parameters:
+            logger.error("Submission {} contains {} tokens, which below the minimum match length {}!", name, tokenList.size() - 1, minimalTokens);
             state = TOO_SMALL;
             return false;
         }


### PR DESCRIPTION
Improves the following error:

`[ERROR] Submission - Submission first.c contains 8 tokens, which is below the minimum match length 12!`

Before this PR, the number of actual tokens included the end-of-file token.
If a user reads this error and sets the min token match value via `-t` to 8, JPlag will accept the file but will calculate 0% similarity, as there are actually only 7 tokens that can be matched (the comparison algorithm uses the end-of-file tokens as pivot tokens).

With this PR, the end-of-file token is deducted.