### PR TITLE
Include file names and paths in ANTLR error messages.

### DIFF
--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
@@ -7,6 +7,7 @@ import java.util.Set;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CodePointCharStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.Parser;
@@ -59,7 +60,8 @@ public abstract class AbstractAntlrParserAdapter<T extends Parser> extends Abstr
     private void parseFile(File file, TokenCollector collector) throws ParsingException {
         collector.enterFile(file);
         try (Reader reader = FileUtils.openFileReader(file)) {
-            Lexer lexer = this.createLexer(CharStreams.fromReader(reader));
+            CodePointCharStream stream = CharStreams.fromReader(reader, file.getAbsolutePath());  // Specify source to retain file in ANTLR errors.
+            Lexer lexer = this.createLexer(stream);
             CommonTokenStream tokenStream = new CommonTokenStream(lexer);
             T parser = this.createParser(tokenStream);
             parser.removeErrorListeners();

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AntlrLoggerErrorListener.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AntlrLoggerErrorListener.java
@@ -11,11 +11,11 @@ import org.slf4j.LoggerFactory;
  */
 public class AntlrLoggerErrorListener extends BaseErrorListener {
     private static final Logger logger = LoggerFactory.getLogger(AntlrLoggerErrorListener.class);
-    private static final String ERROR_TEMPLATE = "ANTLR error - line {}:{} {}";
+    private static final String ERROR_TEMPLATE = "ANTLR error - in {} line {}:{} {}";
 
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg,
             RecognitionException e) {
-        logger.error(ERROR_TEMPLATE, line, charPositionInLine, msg);
+        logger.error(ERROR_TEMPLATE, recognizer.getInputStream().getSourceName(), line, charPositionInLine, msg);
     }
 }


### PR DESCRIPTION
Currently, the ANTLR error messages regarding syntax errors are not very helpful, as there is no indication to which file or submission they belong:

```bash
[ERROR] AntlrLoggerErrorListener - ANTLR error - line 10:13 extraneous input 'y' expecting {NEWLINE, ';'}
```

With this PR, the path to each erroneous file is included in the message:

```bash
[ERROR] AntlrLoggerErrorListener - ANTLR error - in /Users/name/data/plag_totally_broken.py line 10:13 extraneous input 'y' expecting {NEWLINE, ';'}
```

This PR thus includes two changes:

- Include source name in `AntlrLoggerErrorListener`
- Ensure source name is provided in `AbstractAntlrParserAdapter::parseFile`
