### PR TITLE
Improve the JPlag API

### DIFF
--- a/core/src/main/java/de/jplag/JPlagComparison.java
+++ b/core/src/main/java/de/jplag/JPlagComparison.java
@@ -13,7 +13,8 @@ import java.util.List;
  */
 public record JPlagComparison(Submission firstSubmission, Submission secondSubmission, List<Match> matches, List<Match> ignoredMatches) {
     /**
-     * Initializes a new comparison.
+     * Constructs a new comparison between two submissions. The match lists are wrapped as unmodifiable to preserve
+     * immutability.
      * @param firstSubmission is the first of the two submissions.
      * @param secondSubmission is the second of the two submissions.
      * @param matches is the list of all matches between the two submissions.

--- a/core/src/main/java/de/jplag/JPlagComparison.java
+++ b/core/src/main/java/de/jplag/JPlagComparison.java
@@ -27,7 +27,7 @@ public record JPlagComparison(Submission firstSubmission, Submission secondSubmi
 
     /**
      * Get the total number of matched tokens for this comparison, which is the sum of the lengths of all subsequence
-     * matches.
+     * matches. This excludes ignored matches.
      */
     public int getNumberOfMatchedTokens() {
         return matches.stream().mapToInt(Match::length).sum();
@@ -54,8 +54,8 @@ public record JPlagComparison(Submission firstSubmission, Submission secondSubmi
     }
 
     /**
-     * Computes the average or symmetric similarity between the two submissions. The similarity is adjusted based on whether
-     * both submissions contain base code matches.
+     * Computes the average (or symmetric) similarity between the two submissions. The similarity is adjusted based on
+     * whether both submissions contain base code matches.
      * @return Average similarity in interval [0, 1]. 0 means zero percent structural similarity, 1 means 100 percent
      * structural similarity.
      */
@@ -66,9 +66,9 @@ public record JPlagComparison(Submission firstSubmission, Submission secondSubmi
     }
 
     /**
-     * @return Similarity of the first submission in interval [0, 1]. The similarity is adjusted based on whether both
-     * submissions contain base code matches. 0 means zero percent structural similarity, 1 means 100 percent structural
-     * similarity.
+     * @return Similarity of the first submission to the second in interval [0, 1]. The similarity is adjusted based on
+     * whether both submissions contain base code matches. 0 means zero percent structural similarity, 1 means 100 percent
+     * structural similarity.
      */
     public final double similarityOfFirst() {
         int divisor = firstSubmission.getSimilarityDivisor();
@@ -76,9 +76,9 @@ public record JPlagComparison(Submission firstSubmission, Submission secondSubmi
     }
 
     /**
-     * @return Similarity of the second submission in interval [0, 1]. The similarity is adjusted based on whether both
-     * submissions contain base code matches. 0 means zero percent structural similarity, 1 means 100 percent structural
-     * similarity.
+     * @return Similarity of the second submission to the first in interval [0, 1]. The similarity is adjusted based on
+     * whether both submissions contain base code matches. 0 means zero percent structural similarity, 1 means 100 percent
+     * structural similarity.
      */
     public final double similarityOfSecond() {
         int divisor = secondSubmission.getSimilarityDivisor();

--- a/core/src/main/java/de/jplag/JPlagComparison.java
+++ b/core/src/main/java/de/jplag/JPlagComparison.java
@@ -4,10 +4,12 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * This record represents the whole result of a comparison between two submissions.
+ * This record represents results of a structural comparison between two submissions.
  * @param firstSubmission is the first of the two submissions.
  * @param secondSubmission is the second of the two submissions.
- * @param matches is the unmodifiable list of all matches between the two submissions.
+ * @param matches is the unmodifiable list of all subsequence matches between the two submissions.
+ * @param ignoredMatches is the unmodifiable list of ignored matches whose length is below the minimum token match
+ * threshold.
  */
 public record JPlagComparison(Submission firstSubmission, Submission secondSubmission, List<Match> matches, List<Match> ignoredMatches) {
     /**
@@ -24,49 +26,62 @@ public record JPlagComparison(Submission firstSubmission, Submission secondSubmi
     }
 
     /**
-     * Get the total number of matched tokens for this comparison.
+     * Get the total number of matched tokens for this comparison, which is the sum of the lengths of all subsequence
+     * matches.
      */
     public int getNumberOfMatchedTokens() {
         return matches.stream().mapToInt(Match::length).sum();
     }
 
     /**
-     * @return Maximum similarity in interval [0, 1]. O means no similarity, 1 means maximum similarity.
+     * Returns the maximum similarity score, which is either the similarity of the first submission to the second or vice
+     * versa. The similarity is adjusted based on whether both submissions contain base code matches.
+     * @return Maximum similarity in interval [0, 1]. 0 means zero percent structural similarity, 1 means 100 percent
+     * structural similarity.
      */
     public final double maximalSimilarity() {
         return Math.max(similarityOfFirst(), similarityOfSecond());
     }
 
     /**
-     * @return Minimum similarity in interval [0, 1]. O means no similarity, 1 means maximum similarity.
+     * Returns the minimum similarity score, which is either the similarity of the first submission to the second or vice
+     * versa.
+     * @return Minimum similarity in interval [0, 1]. 0 means zero percent structural similarity, 1 means 100 percent
+     * structural similarity.
      */
     public final double minimalSimilarity() {
         return Math.min(similarityOfFirst(), similarityOfSecond());
     }
 
     /**
-     * @return Average similarity in interval [0, 1]. O means no similarity, 1 means maximum similarity.
+     * Computes the average or symmetric similarity between the two submissions. The similarity is adjusted based on whether
+     * both submissions contain base code matches.
+     * @return Average similarity in interval [0, 1]. 0 means zero percent structural similarity, 1 means 100 percent
+     * structural similarity.
      */
     public final double similarity() {
-        boolean subtractBaseCode = firstSubmission.hasBaseCodeMatches() && secondSubmission.hasBaseCodeMatches();
-        int divisorA = firstSubmission.getSimilarityDivisor(subtractBaseCode);
-        int divisorB = secondSubmission.getSimilarityDivisor(subtractBaseCode);
+        int divisorA = firstSubmission.getSimilarityDivisor();
+        int divisorB = secondSubmission.getSimilarityDivisor();
         return 2 * similarity(divisorA + divisorB);
     }
 
     /**
-     * @return Similarity of the first submission in interval [0, 1]. O means no similarity, 1 means maximum similarity.
+     * @return Similarity of the first submission in interval [0, 1]. The similarity is adjusted based on whether both
+     * submissions contain base code matches. 0 means zero percent structural similarity, 1 means 100 percent structural
+     * similarity.
      */
     public final double similarityOfFirst() {
-        int divisor = firstSubmission.getSimilarityDivisor(true);
+        int divisor = firstSubmission.getSimilarityDivisor();
         return similarity(divisor);
     }
 
     /**
-     * @return Similarity of the second submission in interval [0, 1]. O means no similarity, 1 means maximum similarity.
+     * @return Similarity of the second submission in interval [0, 1]. The similarity is adjusted based on whether both
+     * submissions contain base code matches. 0 means zero percent structural similarity, 1 means 100 percent structural
+     * similarity.
      */
     public final double similarityOfSecond() {
-        int divisor = secondSubmission.getSimilarityDivisor(true);
+        int divisor = secondSubmission.getSimilarityDivisor();
         return similarity(divisor);
     }
 

--- a/core/src/main/java/de/jplag/JPlagResult.java
+++ b/core/src/main/java/de/jplag/JPlagResult.java
@@ -10,7 +10,15 @@ import de.jplag.options.JPlagOptions;
 import de.jplag.options.SimilarityMetric;
 
 /**
- * Encapsulates the results of a comparison of a set of source code submissions.
+ * Encapsulates the results of a pairwise comparison of program structure among a set of source code submissions.
+ * <p>
+ * Provides access to:
+ * <ul>
+ * <li>Pairwise comparison results sorted by similarity</li>
+ * <li>Similarity distribution data</li>
+ * <li>Execution duration and configuration options</li>
+ * <li>Optional clustering results over submissions</li>
+ * </ul>
  */
 public class JPlagResult {
 
@@ -45,6 +53,11 @@ public class JPlagResult {
         this.comparisons = this.getComparisons(limit);
     }
 
+    /**
+     * Sets the clustering results for the current set of submissions. This can be used to attach the output of one or more
+     * clustering algorithms to this result object.
+     * @param clustering is the list of clustering results.
+     */
     public void setClusteringResult(List<ClusteringResult<Submission>> clustering) {
         this.clusteringResult = clustering;
     }
@@ -122,6 +135,11 @@ public class JPlagResult {
         return calculateDistributionFor(comparisons, JPlagComparison::maximalSimilarity);
     }
 
+    /**
+     * Returns the clustering results associated with this comparison run, if any. This may include results from one or more
+     * clustering algorithms.
+     * @return the list of clustering results, or {@code null} if no clustering has been performed or set.
+     */
     public List<ClusteringResult<Submission>> getClusteringResult() {
         return this.clusteringResult;
     }
@@ -143,7 +161,11 @@ public class JPlagResult {
     }
 
     /**
-     * Note: Before, comparisons with a similarity below the given threshold were also included in the similarity matrix.
+     * Calculates the similarity distribution across all provided comparisons using the default similarity metric. The
+     * distribution is a 100-element array where each index {@code i} corresponds to the number of comparisons with
+     * similarity in the range [i%, i+1%).
+     * @param comparisons the list of comparisons to analyze.
+     * @return an array of size 100 representing the similarity distribution.
      */
     private int[] calculateSimilarityDistribution(List<JPlagComparison> comparisons) {
         return calculateDistributionFor(comparisons, JPlagComparison::similarity);

--- a/core/src/main/java/de/jplag/JPlagResult.java
+++ b/core/src/main/java/de/jplag/JPlagResult.java
@@ -58,7 +58,7 @@ public class JPlagResult {
      * clustering algorithms to this result object.
      * @param clustering is the list of clustering results.
      */
-    public void setClusteringResult(List<ClusteringResult<Submission>> clustering) {
+    /* package-private */ void setClusteringResult(List<ClusteringResult<Submission>> clustering) {
         this.clusteringResult = clustering;
     }
 

--- a/core/src/main/java/de/jplag/JPlagResult.java
+++ b/core/src/main/java/de/jplag/JPlagResult.java
@@ -11,15 +11,10 @@ import de.jplag.options.SimilarityMetric;
 
 /**
  * Encapsulates the results of a pairwise comparison of program structure among a set of source code submissions.
- * <p>
- * Provides access to:
- * <ul>
- * <li>Pairwise comparison results sorted by similarity</li>
- * <li>Similarity distribution data</li>
- * <li>Execution duration and configuration options</li>
- * <li>Optional clustering results over submissions</li>
- * </ul>
+ * Provides access to pairwise comparison results sorted by similarity, similarity distribution data, clustering results
+ * over submissions, execution duration, and configuration options.
  */
+
 public class JPlagResult {
 
     private List<JPlagComparison> comparisons; // comparisons whose similarity was about the specified threshold

--- a/core/src/main/java/de/jplag/Match.java
+++ b/core/src/main/java/de/jplag/Match.java
@@ -1,7 +1,8 @@
 package de.jplag;
 
 /**
- * Represents two sections of two submissions that are similar.
+ * Represents two code fragments in two submissions that are structurally similar. These sections are identical token
+ * subsequences.
  * @param startOfFirst is the index of the first token of the match in the first submission.
  * @param startOfSecond is the index of the first token of the match in the second submission.
  * @param length is the length of these similar sections (number of tokens).

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -48,7 +48,8 @@ public class Submission implements Comparable<Submission> {
 
     /**
      * Creates a submission.
-     * @param name Identification of the submission (directory or filename).
+     * @param name is the identifier of the submission (directory or filename). May include parent directory name if JPlag
+     * is executed with multiple root directories.
      * @param submissionRootFile is the submission file, or the root of the submission itself.
      * @param isNew states whether the submission must be checked for plagiarism.
      * @param files are the files of the submissions, if the root is a single file it should just contain one file.
@@ -102,7 +103,9 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * Provides the submission name.
+     * Provides the submission name. If the submission is a single program file, it is the file name. If the submissions
+     * contains multiple program files it is the directory name. If JPlag is executed with multiple root directories the
+     * name starts the root directory identifier, e.g. <code>rootName/submissionName</code>.
      * @return name of the submission (directory or file name).
      */
     public String getName() {
@@ -117,7 +120,7 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * @return the unique file of the submission, which is either in a root folder or a subfolder of root folder when the
+     * @return the unique root of the submission, which is either in a root folder or a subfolder of root folder when the
      * subdirectory option is used.
      */
     public File getRoot() {

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -128,12 +128,11 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * @param subtractBaseCode If true subtract basecode matches if possible.
      * @return Similarity divisor for the submission.
      */
-    int getSimilarityDivisor(boolean subtractBaseCode) {
+    int getSimilarityDivisor() {
         int divisor = getNumberOfTokens() - getFiles().size();
-        if (subtractBaseCode && baseCodeComparison != null) {
+        if (baseCodeComparison != null) {
             divisor -= baseCodeComparison.getNumberOfMatchedTokens();
         }
         return divisor;

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -146,8 +146,17 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * @return true if a comparison between the submission and the base code is available.
+     * @return true if a comparison between the submission and the base code is available. Does not imply if there are
+     * matches to the base code.
      */
+    public boolean hasBaseCodeComparison() {
+        return baseCodeComparison != null;
+    }
+
+    /**
+     * @deprecated Use {@link hasBaseCodeComparison} instead.
+     */
+    @Deprecated(since = "6.1.0", forRemoval = true)
     public boolean hasBaseCodeMatches() {
         return baseCodeComparison != null;
     }

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -28,8 +28,8 @@ import de.jplag.normalization.TokenSequenceNormalizer;
 import de.jplag.options.JPlagOptions;
 
 /**
- * This class represents a single submission, which can either be a single file or a directory containing multiple
- * files. It encapsulates the details and processing logic required to handle the submission files, including parsing,
+ * This class represents a single submission, which is either a single file or a directory containing multiple files. It
+ * encapsulates the details and processing logic required to handle the submission files, including parsing,
  * tokenization, and normalization.
  */
 public class Submission implements Comparable<Submission> {
@@ -50,7 +50,7 @@ public class Submission implements Comparable<Submission> {
      * Creates a submission.
      * @param name is the identifier of the submission (directory or filename). May include parent directory name if JPlag
      * is executed with multiple root directories.
-     * @param submissionRootFile is the submission file, or the root of the submission itself.
+     * @param submissionRootFile is the submission file or the root of the submission itself.
      * @param isNew states whether the submission must be checked for plagiarism.
      * @param files are the files of the submissions, if the root is a single file it should just contain one file.
      * @param language is the language of the submission.
@@ -103,9 +103,9 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * Provides the submission name. If the submission is a single program file, it is the file name. If the submissions
-     * contains multiple program files it is the directory name. If JPlag is executed with multiple root directories the
-     * name starts the root directory identifier, e.g. <code>rootName/submissionName</code>.
+     * Provides the submission name. If the submission is a single program file, it is the file name. If the submission
+     * contains multiple program files, it is the directory name. If JPlag is executed with multiple root directories, the
+     * name starts the root directory identifier, e.g., <code>rootName/submissionName</code>.
      * @return name of the submission (directory or file name).
      */
     public String getName() {
@@ -222,7 +222,7 @@ public class Submission implements Comparable<Submission> {
     /**
      * Parse files of the submission.
      * @param debugParser specifies if the submission should be copied upon parsing errors.
-     * @param normalize specifies if the tokens sequences should be normalized.
+     * @param normalize specifies if the token sequences should be normalized.
      * @param minimalTokens specifies the minimum number of tokens required of a valid submission.
      * @return Whether parsing was successful.
      * @throws LanguageException if the language parser is not able to parse at all.
@@ -290,7 +290,7 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * @return Submission containing shallow copies of its fields.
+     * @return A shallow copy of this submission with the same name, root, files, etc.
      */
     public Submission copy() {
         Submission copy = new Submission(name, submissionRootFile, isNew, files, language);

--- a/core/src/test/java/de/jplag/BaseCodeTest.java
+++ b/core/src/test/java/de/jplag/BaseCodeTest.java
@@ -2,6 +2,7 @@ package de.jplag;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 
@@ -55,6 +56,21 @@ public class BaseCodeTest extends TestBase {
     void testBasecodePathComparison() throws ExitException {
         JPlagResult result = runJPlag("basecode", it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, "basecode-base")));
         assertEquals(3, result.getNumberOfSubmissions()); // "basecode/base" is now a user submission.
+    }
+
+    @Test
+    @DisplayName("test case where only one submission in a comparison has basecode matches")
+    void testPartialBasecode() throws ExitException {
+        JPlagResult result = runJPlag("basecode-partial", it -> it.withBaseCodeSubmissionDirectory(new File(BASE_PATH, "basecode-base")));
+        assertEquals(2, result.getNumberOfSubmissions());
+        assertEquals(1, result.getAllComparisons().size());
+        JPlagComparison comparison = result.getAllComparisons().getFirst();
+
+        assertTrue(comparison.firstSubmission().hasBaseCodeMatches());
+        assertTrue(comparison.secondSubmission().hasBaseCodeMatches());
+        assertEquals(0, Math.min(comparison.firstSubmission().getBaseCodeComparison().similarity(),
+                comparison.secondSubmission().getBaseCodeComparison().similarity()));
+        assertEquals(0.742857, comparison.similarity(), DELTA);
     }
 
     @Test

--- a/core/src/test/resources/de/jplag/samples/basecode-partial/A/TerrainType.java
+++ b/core/src/test/resources/de/jplag/samples/basecode-partial/A/TerrainType.java
@@ -1,0 +1,27 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+/**
+ * Enumeration for the terrain type. Is used to specify the terrain of a tile on its different positions.
+ * @author Timur Saglam
+ */
+public enum TerrainType {
+    CASTLE,
+    ROAD,
+    MONASTERY,
+    FIELDS,
+    OTHER;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(0) + toString().substring(1).toLowerCase();
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/basecode-partial/B/TerrainType.java
+++ b/core/src/test/resources/de/jplag/samples/basecode-partial/B/TerrainType.java
@@ -1,0 +1,22 @@
+package carcassonne.model.terrain;
+
+import java.util.List;
+
+public enum TerrainType {
+    FOO;
+
+    private static final int CONST_0 = 0;
+    private static final int CONST_1 = 1;
+
+    /**
+     * Generates a list of the basic terrain types, which is every terrain except {@link Other}.
+     * @return a list of CASTLE, ROAD, MONASTERY, FIELDS.
+     */
+    public static List<TerrainType> basicTerrain() {
+        return List.of(CASTLE, ROAD, MONASTERY, FIELDS);
+    }
+
+    public String toReadableString() {
+        return toString().charAt(CONST_0) + toString().substring(CONST_1).toLowerCase();
+    }
+}


### PR DESCRIPTION
improves several aspects of the JPlag API:

- Remove redundant code in the similarity calculation (and add a test case to ensure correctness)
- Correct naming of `Submission::hasBaseCodeMatches` (only checks if there is a basecode comparison, which does not imply that there are matches)
- Make the setter for clustering results package private
- Specify submission naming scheme
- Improve documentation of the similarity scores, JPlagComparison, JPlagResult and Match
