### PR TITLE
Move sorting to table headers

### DIFF
--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -29,12 +29,6 @@
         }}
       </ButtonComponent>
     </div>
-    <OptionsSelector
-      title="Sort By:"
-      :default-selected="getSortingMetric()"
-      :labels="tableSortingOptions"
-      @selection-changed="(index: number) => changeSortingMetric(index)"
-    />
   </div>
 </template>
 
@@ -43,19 +37,12 @@ import { computed } from 'vue'
 import SearchBarComponent from './SearchBarComponent.vue'
 import ToolTipComponent from './ToolTipComponent.vue'
 import ButtonComponent from './ButtonComponent.vue'
-import OptionsSelector from './optionsSelectors/OptionsSelectorComponent.vue'
 import { store } from '@/stores/store'
-import { MetricType, metricToolTips } from '@/model/MetricType'
-import type { ToolTipLabel } from '@/model/ui/ToolTip'
 
 const props = defineProps({
   searchString: {
     type: String,
     default: ''
-  },
-  enableClusterSorting: {
-    type: Boolean,
-    default: true
   },
   header: {
     type: String,
@@ -89,33 +76,6 @@ const searchStringValue = computed({
       }
     }
   }
-})
-
-function changeSortingMetric(index: number) {
-  store().uiState.comparisonTableSortingMetric =
-    index < tableSortingMetricOptions.length ? tableSortingMetricOptions[index] : MetricType.AVERAGE
-  store().uiState.comparisonTableClusterSorting = tableSortingOptions.value[index] == 'Cluster'
-}
-
-function getSortingMetric() {
-  if (store().uiState.comparisonTableClusterSorting && props.enableClusterSorting) {
-    return tableSortingOptions.value.indexOf('Cluster')
-  }
-  return tableSortingMetricOptions.indexOf(store().uiState.comparisonTableSortingMetric)
-}
-
-const tableSortingMetricOptions = [MetricType.AVERAGE, MetricType.MAXIMUM]
-const tableSortingOptions = computed(() => {
-  const options: (ToolTipLabel | string)[] = tableSortingMetricOptions.map((metric) => {
-    return {
-      displayValue: metricToolTips[metric].longName,
-      tooltip: metricToolTips[metric].tooltip
-    }
-  })
-  if (props.enableClusterSorting) {
-    options.push('Cluster')
-  }
-  return options
 })
 
 /**

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -3,11 +3,7 @@
 -->
 <template>
   <div class="flex flex-col">
-    <ComparisonTableFilter
-      v-model:search-string="searchString"
-      :enable-cluster-sorting="clusters != undefined"
-      :header="header"
-    />
+    <ComparisonTableFilter v-model:search-string="searchString" :header="header" />
 
     <div class="flex flex-col overflow-hidden">
       <div class="font-bold">
@@ -18,10 +14,22 @@
           <div class="tableCellSimilarity tableCell flex-col!">
             <div>Similarity</div>
             <div class="flex w-full flex-row">
-              <ToolTipComponent class="flex-1" :direction="displayClusters ? 'top' : 'left'">
+              <ToolTipComponent
+                class="flex-1 cursor-pointer"
+                :direction="displayClusters ? 'top' : 'left'"
+                @click="setSorting('averageSimilarity')"
+              >
                 <template #default>
                   <p class="w-full text-center">
                     {{ metricToolTips[MetricType.AVERAGE].shortName }}
+                    <FontAwesomeIcon
+                      :icon="
+                        store().uiState.comparisonTableSorting.column.id == 'averageSimilarity'
+                          ? store().uiState.comparisonTableSorting.direction.icon
+                          : faSort
+                      "
+                      class="ml-1"
+                    />
                   </p>
                 </template>
                 <template #tooltip>
@@ -31,10 +39,22 @@
                 </template>
               </ToolTipComponent>
 
-              <ToolTipComponent class="flex-1" :direction="displayClusters ? 'top' : 'left'">
+              <ToolTipComponent
+                class="flex-1 cursor-pointer"
+                :direction="displayClusters ? 'top' : 'left'"
+                @click="setSorting('maximumSimilarity')"
+              >
                 <template #default>
                   <p class="w-full text-center">
                     {{ metricToolTips[MetricType.MAXIMUM].shortName }}
+                    <FontAwesomeIcon
+                      :icon="
+                        store().uiState.comparisonTableSorting.column.id == 'maximumSimilarity'
+                          ? store().uiState.comparisonTableSorting.direction.icon
+                          : faSort
+                      "
+                      class="ml-1"
+                    />
                   </p>
                 </template>
                 <template #tooltip>
@@ -45,7 +65,21 @@
               </ToolTipComponent>
             </div>
           </div>
-          <div v-if="displayClusters" class="tableCellCluster tableCell items-center">Cluster</div>
+          <div
+            v-if="displayClusters"
+            class="tableCellCluster tableCell cursor-pointer items-center"
+            @click="setSorting('cluster')"
+          >
+            Cluster
+            <FontAwesomeIcon
+              :icon="
+                store().uiState.comparisonTableSorting.column.id == 'cluster'
+                  ? store().uiState.comparisonTableSorting.direction.icon
+                  : faSort
+              "
+              class="ml-1"
+            />
+          </div>
         </div>
       </div>
 
@@ -116,10 +150,10 @@
                   class="tableCellCluster tableCell flex flex-col! items-center"
                 >
                   <RouterLink
-                    v-if="item.clusterIndex >= 0"
+                    v-if="(item as ComparisonListElement).cluster"
                     :to="{
                       name: 'ClusterView',
-                      params: { clusterIndex: item.clusterIndex }
+                      params: { clusterIndex: item.cluster.index }
                     }"
                     class="flex w-full justify-center text-center"
                   >
@@ -129,26 +163,18 @@
                       :tool-tip-container-will-be-centered="true"
                     >
                       <template #default>
-                        {{ clusters?.[item.clusterIndex].members?.length }}
+                        {{ item.cluster.members.length }}
                         <FontAwesomeIcon
                           :icon="['fas', 'user-group']"
-                          :style="{ color: clusterIconColors[item.clusterIndex] }"
+                          :style="{ color: clusterIconColors[item.cluster.index] }"
                         />
-                        {{
-                          (
-                            (clusters?.[item.clusterIndex].averageSimilarity as number) * 100
-                          ).toFixed(2)
-                        }}%
+                        {{ ((item.cluster.averageSimilarity as number) * 100).toFixed(2) }}%
                       </template>
                       <template #tooltip>
                         <p class="text-sm whitespace-nowrap">
-                          {{ clusters?.[item.clusterIndex].members?.length }} submissions in cluster
-                          with average similarity of
-                          {{
-                            (
-                              (clusters?.[item.clusterIndex].averageSimilarity as number) * 100
-                            ).toFixed(2)
-                          }}%
+                          {{ item.cluster.members?.length }} submissions in cluster with average
+                          similarity of
+                          {{ ((item.cluster.averageSimilarity as number) * 100).toFixed(2) }}%
                         </p>
                       </template>
                     </ToolTipComponent>
@@ -175,12 +201,13 @@ import { store } from '@/stores/store'
 import { DynamicScroller, DynamicScrollerItem } from 'vue-virtual-scroller'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faUserGroup } from '@fortawesome/free-solid-svg-icons'
+import { faSort, faUserGroup } from '@fortawesome/free-solid-svg-icons'
 import { generateHues } from '@/utils/ColorUtils'
 import ToolTipComponent from './ToolTipComponent.vue'
 import { MetricType, metricToolTips } from '@/model/MetricType'
 import NameElement from './NameElement.vue'
 import ComparisonTableFilter from './ComparisonTableFilter.vue'
+import { Column, Direction, type ColumnId } from '@/model/ui/ComparisonSorting'
 
 library.add(faUserGroup)
 
@@ -312,21 +339,18 @@ function getFilteredComparisons(comparisons: ComparisonListElement[]) {
 }
 
 function getSortedComparisons(comparisons: ComparisonListElement[]) {
-  comparisons.sort(
-    (a, b) =>
-      b.similarities[store().uiState.comparisonTableSortingMetric] -
-      a.similarities[store().uiState.comparisonTableSortingMetric]
-  )
-
-  if (store().uiState.comparisonTableClusterSorting) {
-    comparisons.sort((a, b) => b.clusterIndex - a.clusterIndex)
-
-    comparisons.sort(
-      (a, b) =>
-        getClusterFor(b.clusterIndex).averageSimilarity -
-        getClusterFor(a.clusterIndex).averageSimilarity
-    )
-  }
+  const sorting = store().uiState.comparisonTableSorting
+  comparisons.sort((a, b) => {
+    const numsA = sorting.column.value(a)
+    const numsB = sorting.column.value(b)
+    for (let i = numsA.length - 1; i >= 0; i--) {
+      const comparison = sorting.direction.comparator(numsA[i], numsB[i])
+      if (comparison != 0) {
+        return comparison
+      }
+    }
+    return 0
+  })
 
   let index = 0
   comparisons.forEach((c) => {
@@ -335,14 +359,17 @@ function getSortedComparisons(comparisons: ComparisonListElement[]) {
   return comparisons
 }
 
-function getClusterFor(clusterIndex: number) {
-  if (clusterIndex < 0 || !props.clusters) {
-    return { averageSimilarity: 0 }
+function setSorting(column: ColumnId) {
+  if (store().uiState.comparisonTableSorting.column.id == column) {
+    store().uiState.comparisonTableSorting.direction =
+      store().uiState.comparisonTableSorting.direction.next
+  } else {
+    store().uiState.comparisonTableSorting.column = Column.columns[column]
+    store().uiState.comparisonTableSorting.direction = Direction.descending
   }
-  return props.clusters[clusterIndex]
 }
 
-const displayClusters = props.clusters != undefined
+const displayClusters = computed(() => props.clusters != undefined)
 
 let clusterIconHues = [] as Array<number>
 const lightmodeSaturation = 80

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -343,7 +343,7 @@ function getSortedComparisons(comparisons: ComparisonListElement[]) {
   comparisons.sort((a, b) => {
     const numsA = sorting.column.value(a)
     const numsB = sorting.column.value(b)
-    for (let i = numsA.length - 1; i >= 0; i--) {
+    for (let i = 0; i < numsA.length; i++) {
       const comparison = sorting.direction.comparator(numsA[i], numsB[i])
       if (comparison != 0) {
         return comparison

--- a/report-viewer/src/model/Cluster.ts
+++ b/report-viewer/src/model/Cluster.ts
@@ -5,7 +5,8 @@
  * @property strength - The strength of the cluster
  * @property members - The ids of the submissions in the cluster
  */
-export type Cluster = {
+export interface Cluster {
+  index: number
   averageSimilarity: number
   strength: number
   members: Array<string>

--- a/report-viewer/src/model/ComparisonListElement.ts
+++ b/report-viewer/src/model/ComparisonListElement.ts
@@ -1,3 +1,4 @@
+import type { Cluster } from './Cluster'
 import type { MetricType } from './MetricType'
 
 /**
@@ -17,5 +18,5 @@ export type ComparisonListElement = {
   firstSubmissionId: string
   secondSubmissionId: string
   similarities: Record<MetricType, number>
-  clusterIndex: number
+  cluster?: Cluster
 }

--- a/report-viewer/src/model/factories/OverviewFactory.ts
+++ b/report-viewer/src/model/factories/OverviewFactory.ts
@@ -94,7 +94,7 @@ export class OverviewFactory extends BaseFactory {
       }
       comparisons.push({
         ...comparison,
-        clusterIndex: this.getClusterIndex(
+        cluster: this.getCluster(
           clusters,
           comparison.firstSubmissionId,
           comparison.secondSubmissionId
@@ -104,22 +104,21 @@ export class OverviewFactory extends BaseFactory {
     return comparisons
   }
 
-  private static getClusterIndex(
+  private static getCluster(
     clusters: Cluster[],
     firstSubmissionId: string,
     secondSubmissionId: string
-  ) {
-    let clusterIndex = -1
-    clusters?.forEach((c: Cluster, index: number) => {
+  ): Cluster | undefined {
+    return clusters.find((c: Cluster) => {
       if (
         c.members.includes(firstSubmissionId) &&
         c.members.includes(secondSubmissionId) &&
         c.members.length > 2
       ) {
-        clusterIndex = index
+        return true
       }
+      return false
     })
-    return clusterIndex
   }
 
   private static extractClusters(json: Record<string, unknown>): Array<Cluster> {
@@ -128,8 +127,10 @@ export class OverviewFactory extends BaseFactory {
     }
 
     const clusters = [] as Array<Cluster>
-    for (const jsonCluster of json.clusters as Array<Record<string, unknown>>) {
+    const jsonClusters = json.clusters as Array<Record<string, unknown>>
+    for (const [idx, jsonCluster] of jsonClusters.entries()) {
       clusters.push({
+        index: idx,
         averageSimilarity: jsonCluster.average_similarity as number,
         strength: jsonCluster.strength as number,
         members: jsonCluster.members as Array<string>

--- a/report-viewer/src/model/ui/ComparisonSorting.ts
+++ b/report-viewer/src/model/ui/ComparisonSorting.ts
@@ -1,0 +1,79 @@
+import { faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons'
+import type { FontAwesomeIconProps } from '@fortawesome/vue-fontawesome'
+import { MetricType } from '@/model/MetricType'
+import type { ComparisonListElement } from '../ComparisonListElement'
+
+interface Direction {
+  next: Direction
+  icon: FontAwesomeIconProps
+  comparator: (a: number, b: number) => number
+}
+
+export type ColumnId = 'averageSimilarity' | 'maximumSimilarity' | 'cluster'
+
+interface Column {
+  id: ColumnId
+  /**
+   * Compile a list of values to sort by
+   * The first value is the one to sort by, the next ones are used to break ties in order of priority
+   * @param c the comparison list element to get the value from
+   * @returns List of values to take into account for sorting
+   */
+  value: (comp: ComparisonListElement) => number[]
+}
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Direction {
+  export const ascending: Direction = {
+    next: undefined as unknown as Direction, // to be set later
+    icon: faSortUp,
+    comparator: (a: number, b: number) => a - b
+  }
+  export const descending: Direction = {
+    next: ascending,
+    icon: faSortDown,
+    comparator: (a: number, b: number) => b - a
+  }
+  ascending.next = descending
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Column {
+  export const averageSimilarity: Column = {
+    id: 'averageSimilarity',
+    value: (c: ComparisonListElement) => [
+      c.similarities[MetricType.AVERAGE],
+      c.similarities[MetricType.MAXIMUM]
+    ]
+  }
+  export const maximumSimilarity: Column = {
+    id: 'maximumSimilarity',
+    value: (c: ComparisonListElement) => [
+      c.similarities[MetricType.MAXIMUM],
+      c.similarities[MetricType.AVERAGE]
+    ]
+  }
+  export const cluster: Column = {
+    id: 'cluster',
+    value: (c: ComparisonListElement) => {
+      if (c.cluster) {
+        return [
+          c.cluster.averageSimilarity,
+          c.cluster.index,
+          c.similarities[MetricType.AVERAGE],
+          c.similarities[MetricType.MAXIMUM]
+        ]
+      }
+      return [-1, -1, c.similarities[MetricType.AVERAGE], c.similarities[MetricType.MAXIMUM]]
+    }
+  }
+  export const columns: Record<ColumnId, Column> = {
+    averageSimilarity,
+    maximumSimilarity,
+    cluster
+  }
+}
+
+export interface ComparisonTableSorting {
+  column: Column
+  direction: Direction
+}

--- a/report-viewer/src/stores/state.ts
+++ b/report-viewer/src/stores/state.ts
@@ -1,5 +1,5 @@
 import type { SubmissionFile } from '@/model/File'
-import type { MetricType } from '@/model/MetricType'
+import type { ComparisonTableSorting } from '@/model/ui/ComparisonSorting'
 import type { DistributionChartConfig } from '@/model/ui/DistributionChartConfig'
 import type { FileSortingOptions } from '@/model/ui/FileSortingOptions'
 
@@ -39,8 +39,7 @@ export interface State {
 
 export interface UIState {
   useDarkMode: boolean
-  comparisonTableSortingMetric: MetricType
-  comparisonTableClusterSorting: boolean
+  comparisonTableSorting: ComparisonTableSorting
   distributionChartConfig: DistributionChartConfig
   fileSorting: FileSortingOptions
 }

--- a/report-viewer/src/stores/store.ts
+++ b/report-viewer/src/stores/store.ts
@@ -3,6 +3,7 @@ import type { State, UIState } from './state'
 import { MetricType } from '@/model/MetricType'
 import type { SubmissionFile, File } from '@/model/File'
 import { FileSortingOptions } from '@/model/ui/FileSortingOptions'
+import { Column, Direction } from '@/model/ui/ComparisonSorting'
 
 /**
  * The store is a global state management system. It is used to store the state of the application.
@@ -23,8 +24,10 @@ const store = defineStore('store', {
     },
     uiState: {
       useDarkMode: window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches,
-      comparisonTableSortingMetric: MetricType.AVERAGE,
-      comparisonTableClusterSorting: false,
+      comparisonTableSorting: {
+        column: Column.averageSimilarity,
+        direction: Direction.descending
+      },
       distributionChartConfig: {
         metric: MetricType.AVERAGE,
         xScale: 'linear',

--- a/report-viewer/tests/e2e/Comparison.spec.ts
+++ b/report-viewer/tests/e2e/Comparison.spec.ts
@@ -1,33 +1,31 @@
 import { test, expect, Page } from '@playwright/test'
 import { uploadFile } from './TestUtils'
 
-test('Test comparison table and comparsion view', async ({ page }) => {
+test.only('Test comparison table and comparsion view', async ({ page }) => {
   await uploadFile('progpedia-report.zip', page)
-
-  const comparisonContainer = page.getByText('Hide AllSort By')
 
   // check for elements in average similarity table
   await page.getByPlaceholder('Filter/Unhide Comparisons').fill('Purple')
-  const comparisonTableAverageSorted = await page.getByText(/Cluster[0-9]/).textContent()
+  const comparisonTableAverageSorted = await page.getByText(/Cluster [0-9]/).textContent()
   expect(comparisonTableAverageSorted).toContain('100Purple FishBeige Dog')
 
-  await comparisonContainer.getByText('Maximum Similarity', { exact: true }).click()
+  await page.getByText('MAX', { exact: true }).click()
   // check for elements in maximum similarity table
   await page.getByPlaceholder('Filter/Unhide Comparisons').fill('Blue')
-  const comparisonTableMaxSorted = await page.getByText(/Cluster[0-9]/).textContent()
+  const comparisonTableMaxSorted = await page.getByText(/Cluster [0-9]/).textContent()
   expect(comparisonTableMaxSorted).toContain('100Blue AntelopeLime Lynx')
 
   await page.getByPlaceholder('Filter/Unhide Comparisons').fill('')
   await page.getByText('Hide All').click()
   // check for elements being hidden
-  const comparisonTableOverviewHidden = await page.getByText('Cluster1').textContent()
+  const comparisonTableOverviewHidden = await page.getByText('Cluster 1').textContent()
   expect(comparisonTableOverviewHidden).toMatch(/1anon[0-9]+anon[0-9]+/)
   expect(comparisonTableOverviewHidden).toMatch(/3anon[0-9]+anon[0-9]+/)
   expect(comparisonTableOverviewHidden).toMatch(/4anon[0-9]+anon[0-9]+/)
 
   await page.getByPlaceholder('Filter/Unhide Comparisons').fill('Lazy Bobcat')
   // check for elements being unhidden and filtered
-  const comparisonTableOverviewFiltered = await page.getByText(/Cluster[0-9]/).textContent()
+  const comparisonTableOverviewFiltered = await page.getByText(/Cluster [0-9]/).textContent()
   expect(comparisonTableOverviewFiltered).toMatch(/[0-9]+anon[0-9]+Lazy Bobcat/)
   expect(comparisonTableOverviewFiltered).toMatch(/[0-9]+Lazy Bobcatanon[0-9]+/)
 

--- a/report-viewer/tests/e2e/Comparison.spec.ts
+++ b/report-viewer/tests/e2e/Comparison.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from '@playwright/test'
 import { uploadFile } from './TestUtils'
 
-test.only('Test comparison table and comparsion view', async ({ page }) => {
+test('Test comparison table and comparsion view', async ({ page }) => {
   await uploadFile('progpedia-report.zip', page)
 
   // check for elements in average similarity table

--- a/report-viewer/tests/e2e/OpenComparisonTest.spec.ts
+++ b/report-viewer/tests/e2e/OpenComparisonTest.spec.ts
@@ -60,7 +60,7 @@ for (const testSet of testSets) {
   test(`Can open ${testSet.datasetName}`, async ({ page }) => {
     await uploadFile(testSet.datasetName, page)
 
-    const comparisonTable = await page.getByText('Cluster1').textContent()
+    const comparisonTable = await page.getByText('Cluster 1').textContent()
 
     const lineRegEx = RegExp('1' + testSet.firstSubmissionName + testSet.secondSubmissionName)
     expect(comparisonTable).toMatch(lineRegEx)

--- a/report-viewer/tests/unit/components/comparisonTable/ComparisonTable.test.ts
+++ b/report-viewer/tests/unit/components/comparisonTable/ComparisonTable.test.ts
@@ -5,8 +5,6 @@ import { createTestingPinia } from '@pinia/testing'
 import { store } from '@/stores/store'
 import { MetricType } from '@/model/MetricType.ts'
 import { router } from '@/router'
-import OptionsSelector from '@/components/optionsSelectors/OptionsSelectorComponent.vue'
-import OptionComponent from '@/components/optionsSelectors/OptionComponent.vue'
 
 describe('ComparisonTable', async () => {
   it('Test search string filtering', async () => {
@@ -133,7 +131,7 @@ describe('ComparisonTable', async () => {
     expect(displayedComparisonsIndex3.length).toBe(1)
     expect(displayedComparisonsIndex3[0].firstSubmissionId).toBe('H')
 
-    const metricOptions = wrapper.getComponent(OptionsSelector).findAllComponents(OptionComponent)
+    const metricOptions = wrapper.get('.font-bold').findAll('.cursor-pointer')
     await metricOptions[1].trigger('click')
     wrapper.find('input').setValue('index:2')
     await flushPromises()
@@ -252,7 +250,12 @@ describe('ComparisonTable', async () => {
               [MetricType.AVERAGE]: 0.3,
               [MetricType.MAXIMUM]: 0.5
             },
-            clusterIndex: 0
+            cluster: {
+              index: 0,
+              averageSimilarity: 0.5,
+              strength: 0.5,
+              members: ['A', 'B']
+            }
           },
           {
             sortingPlace: 1,
@@ -263,7 +266,12 @@ describe('ComparisonTable', async () => {
               [MetricType.AVERAGE]: 0.5,
               [MetricType.MAXIMUM]: 1
             },
-            clusterIndex: 1
+            cluster: {
+              index: 1,
+              averageSimilarity: 0.6,
+              strength: 0.5,
+              members: ['C', 'D']
+            }
           },
           {
             sortingPlace: 1,
@@ -274,7 +282,12 @@ describe('ComparisonTable', async () => {
               [MetricType.AVERAGE]: 0.3,
               [MetricType.MAXIMUM]: 0.1
             },
-            clusterIndex: 2
+            cluster: {
+              index: 2,
+              averageSimilarity: 0.9,
+              strength: 0.5,
+              members: ['E', 'F']
+            }
           },
           {
             sortingPlace: 1,
@@ -285,21 +298,24 @@ describe('ComparisonTable', async () => {
               [MetricType.AVERAGE]: 0.9,
               [MetricType.MAXIMUM]: 0.2
             },
-            clusterIndex: -1
+            cluster: undefined
           }
         ],
         clusters: [
           {
+            index: 0,
             averageSimilarity: 0.5,
             strength: 0.5,
             members: ['A', 'B']
           },
           {
+            index: 1,
             averageSimilarity: 0.6,
             strength: 0.5,
             members: ['C', 'D']
           },
           {
+            index: 2,
             averageSimilarity: 0.9,
             strength: 0.5,
             members: ['E', 'F']
@@ -318,7 +334,7 @@ describe('ComparisonTable', async () => {
     expect(displayedComparisonsAverageSorted[2].firstSubmissionId).toBe('A')
     expect(displayedComparisonsAverageSorted[3].firstSubmissionId).toBe('E')
 
-    const metricOptions = wrapper.getComponent(OptionsSelector).findAllComponents(OptionComponent)
+    const metricOptions = wrapper.get('.font-bold').findAll('.cursor-pointer')
     await metricOptions[1].trigger('click')
     await flushPromises()
 

--- a/report-viewer/tests/unit/components/comparisonTable/ComparisonTableFilter.test.ts
+++ b/report-viewer/tests/unit/components/comparisonTable/ComparisonTableFilter.test.ts
@@ -3,10 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { describe, it, vi, expect } from 'vitest'
 import { createTestingPinia } from '@pinia/testing'
 import { store } from '@/stores/store'
-import { MetricType } from '@/model/MetricType.ts'
 import ButtonComponent from '@/components/ButtonComponent.vue'
-import OptionsSelector from '@/components/optionsSelectors/OptionsSelectorComponent.vue'
-import OptionComponent from '@/components/optionsSelectors/OptionComponent.vue'
 
 describe('ComparisonTableFilter', async () => {
   it('Test search string updating', async () => {
@@ -26,48 +23,6 @@ describe('ComparisonTableFilter', async () => {
     wrapper.find('input').setValue(searchValue)
     await flushPromises()
     expect(wrapper.props('searchString')).toBe(searchValue)
-  })
-
-  it('Test metric changes', async () => {
-    const wrapper = mount(ComparisonTableFilter, {
-      global: {
-        plugins: [createTestingPinia({ createSpy: vi.fn })]
-      }
-    })
-    setUpStore()
-
-    expect(wrapper.text()).toContain('Average')
-    expect(wrapper.text()).toContain('Maximum')
-    expect(wrapper.text()).toContain('Cluster')
-
-    const options = wrapper.getComponent(OptionsSelector).findAllComponents(OptionComponent)
-
-    expectHighlighting(0)
-
-    await options[1].trigger('click')
-    expect(store().uiState.comparisonTableSortingMetric).toBe(MetricType.MAXIMUM)
-    expect(store().uiState.comparisonTableClusterSorting).toBeFalsy()
-    expectHighlighting(1)
-
-    await options[2].trigger('click')
-    expect(store().uiState.comparisonTableSortingMetric).toBe(MetricType.AVERAGE)
-    expect(store().uiState.comparisonTableClusterSorting).toBeTruthy()
-    expectHighlighting(2)
-
-    await options[0].trigger('click')
-    expect(store().uiState.comparisonTableSortingMetric).toBe(MetricType.AVERAGE)
-    expect(store().uiState.comparisonTableClusterSorting).toBeFalsy()
-    expectHighlighting(0)
-
-    function expectHighlighting(index: number) {
-      for (let i = 0; i < options.length; i++) {
-        if (i == index) {
-          expect(options[i].classes()).toContain('bg-accent/40!')
-        } else {
-          expect(options[i].classes()).not.toContain('bg-accent/40!')
-        }
-      }
-    }
   })
 
   it('Test anonymous button', async () => {

--- a/report-viewer/tests/unit/model/factories/OverviewFactory.test.ts
+++ b/report-viewer/tests/unit/model/factories/OverviewFactory.test.ts
@@ -43,7 +43,12 @@ describe('Test JSON to Overview', () => {
           },
           sortingPlace: 0,
           id: 1,
-          clusterIndex: 0
+          cluster: {
+            averageSimilarity: 94.746956,
+            index: 0,
+            members: ['C', 'A', 'B', 'D'],
+            strength: 0
+          }
         },
         {
           firstSubmissionId: 'D',
@@ -54,7 +59,12 @@ describe('Test JSON to Overview', () => {
           },
           sortingPlace: 1,
           id: 2,
-          clusterIndex: 0
+          cluster: {
+            averageSimilarity: 94.746956,
+            index: 0,
+            members: ['C', 'A', 'B', 'D'],
+            strength: 0
+          }
         },
         {
           firstSubmissionId: 'D',
@@ -65,7 +75,12 @@ describe('Test JSON to Overview', () => {
           },
           sortingPlace: 2,
           id: 3,
-          clusterIndex: 0
+          cluster: {
+            averageSimilarity: 94.746956,
+            index: 0,
+            members: ['C', 'A', 'B', 'D'],
+            strength: 0
+          }
         },
         {
           firstSubmissionId: 'B',
@@ -76,7 +91,12 @@ describe('Test JSON to Overview', () => {
           },
           sortingPlace: 3,
           id: 4,
-          clusterIndex: 0
+          cluster: {
+            averageSimilarity: 94.746956,
+            index: 0,
+            members: ['C', 'A', 'B', 'D'],
+            strength: 0
+          }
         },
         {
           firstSubmissionId: 'B',
@@ -87,7 +107,12 @@ describe('Test JSON to Overview', () => {
           },
           sortingPlace: 4,
           id: 5,
-          clusterIndex: 0
+          cluster: {
+            averageSimilarity: 94.746956,
+            index: 0,
+            members: ['C', 'A', 'B', 'D'],
+            strength: 0
+          }
         },
         {
           firstSubmissionId: 'B',
@@ -98,7 +123,12 @@ describe('Test JSON to Overview', () => {
           },
           sortingPlace: 5,
           id: 6,
-          clusterIndex: 0
+          cluster: {
+            averageSimilarity: 94.746956,
+            index: 0,
+            members: ['C', 'A', 'B', 'D'],
+            strength: 0
+          }
         }
       ],
       _distributions: {
@@ -118,6 +148,7 @@ describe('Test JSON to Overview', () => {
       _clusters: [
         {
           averageSimilarity: 94.746956,
+          index: 0,
           strength: 0.0,
           members: ['C', 'A', 'B', 'D']
         }
@@ -132,6 +163,6 @@ describe('Outdated JSON to Overview', () => {
     store().state.files['overview.json'] = JSON.stringify(outdated)
     const result = await OverviewFactory.getOverview()
     expect(result.result).toBe('oldReport')
-    expect(result.version.compareTo(new Version(3,0,0))).toBe(0)
+    expect(result.version.compareTo(new Version(3, 0, 0))).toBe(0)
   })
 })


### PR DESCRIPTION
Removes the sorting bar of the table
Sorting is now performed by clicking the table headers.
Sort icons indicate the possible columns and the direction
![grafik](https://github.com/user-attachments/assets/e9d56934-56d0-4f10-8d5e-fbd8a92d6686)
