### PR TITLE
Make design more responsive

### DIFF
--- a/report-viewer/src/App.vue
+++ b/report-viewer/src/App.vue
@@ -1,12 +1,14 @@
 <template>
   <div :class="{ dark: store().uiState.useDarkMode }">
     <div
-      class="bg-background-light dark:bg-background-dark max-h-fit min-h-screen max-w-screen text-black dark:text-amber-50"
+      class="bg-background-light dark:bg-background-dark flex max-h-screen min-h-screen max-w-screen flex-col overflow-scroll text-black dark:text-amber-50"
     >
-      <RouterView class="max-h-screen overflow-hidden print:max-h-none print:overflow-visible" />
+      <RouterView
+        class="min-h-screen w-screen p-2 pb-0! md:h-screen md:max-h-screen md:p-5 print:overflow-visible"
+      />
 
       <Button
-        class="absolute right-2 bottom-2 flex h-12 w-12 items-center justify-center text-center print:hidden"
+        class="fixed right-2 bottom-2 flex h-12 w-12 items-center justify-center text-center print:hidden"
         @click="store().changeUseDarkMode()"
       >
         <FontAwesomeIcon

--- a/report-viewer/src/App.vue
+++ b/report-viewer/src/App.vue
@@ -1,10 +1,10 @@
 <template>
   <div :class="{ dark: store().uiState.useDarkMode }">
     <div
-      class="bg-background-light dark:bg-background-dark flex max-h-screen min-h-screen max-w-screen flex-col overflow-scroll text-black dark:text-amber-50"
+      class="bg-background-light dark:bg-background-dark flex max-h-screen min-h-screen max-w-screen flex-col overflow-scroll text-black dark:text-amber-50 print:max-h-none print:w-full print:max-w-full print:overflow-visible"
     >
       <RouterView
-        class="min-h-screen w-screen p-2 pb-0! md:h-screen md:max-h-screen md:p-5 print:overflow-visible"
+        class="print:min-h-none min-h-screen w-screen p-2 pb-0! md:h-screen md:max-h-screen md:p-5 print:max-h-none print:w-full print:overflow-visible print:p-0"
       />
 
       <Button

--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -4,7 +4,7 @@
       class="flex flex-col flex-wrap gap-x-8 gap-y-2 overflow-hidden md:flex-row md:items-center"
     >
       <h2>{{ header }}</h2>
-      <ToolTipComponent direction="left" class="max-w-full grow md:min-w-[50%]">
+      <ToolTipComponent direction="left" class="max-w-full grow md:min-w-[40%]">
         <template #default>
           <SearchBarComponent v-model="searchStringValue" placeholder="Filter/Unhide Comparisons" />
         </template>

--- a/report-viewer/src/components/ComparisonTableFilter.vue
+++ b/report-viewer/src/components/ComparisonTableFilter.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="space-y-2">
-    <div class="flex flex-row flex-wrap items-center gap-x-8 gap-y-2">
+    <div
+      class="flex flex-col flex-wrap gap-x-8 gap-y-2 overflow-hidden md:flex-row md:items-center"
+    >
       <h2>{{ header }}</h2>
-      <ToolTipComponent direction="left" class="min-w-[50%] grow">
+      <ToolTipComponent direction="left" class="max-w-full grow md:min-w-[50%]">
         <template #default>
           <SearchBarComponent v-model="searchStringValue" placeholder="Filter/Unhide Comparisons" />
         </template>

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -9,159 +9,167 @@
       :header="header"
     />
 
-    <div class="flex flex-col overflow-hidden">
-      <div class="font-bold">
-        <!-- Header -->
-        <div class="tableRow">
-          <div class="tableCellNumber tableCell"></div>
-          <div class="tableCellName tableCell items-center">Submissions in Comparison</div>
-          <div class="tableCellSimilarity tableCell flex-col!">
-            <div>Similarity</div>
-            <div class="flex w-full flex-row">
-              <ToolTipComponent class="flex-1" :direction="displayClusters ? 'top' : 'left'">
-                <template #default>
-                  <p class="w-full text-center">
-                    {{ metricToolTips[MetricType.AVERAGE].shortName }}
-                  </p>
-                </template>
-                <template #tooltip>
-                  <p class="text-sm whitespace-pre">
-                    {{ metricToolTips[MetricType.AVERAGE].tooltip }}
-                  </p>
-                </template>
-              </ToolTipComponent>
+    <div class="flex flex-1 flex-col overflow-hidden">
+      <div class="flex h-full max-h-full flex-col overflow-x-scroll">
+        <div class="flex h-full max-h-full min-w-fit flex-col overflow-hidden">
+          <div class="min-w-fit font-bold">
+            <!-- Header -->
+            <div class="tableRow">
+              <div class="tableCellNumber tableCell"></div>
+              <div class="tableCellName tableCell items-center">Submissions in Comparison</div>
+              <div class="tableCellSimilarity tableCell flex-col!">
+                <div>Similarity</div>
+                <div class="flex w-full flex-row">
+                  <ToolTipComponent class="flex-1" :direction="displayClusters ? 'top' : 'left'">
+                    <template #default>
+                      <p class="w-full text-center">
+                        {{ metricToolTips[MetricType.AVERAGE].shortName }}
+                      </p>
+                    </template>
+                    <template #tooltip>
+                      <p class="text-sm whitespace-pre">
+                        {{ metricToolTips[MetricType.AVERAGE].tooltip }}
+                      </p>
+                    </template>
+                  </ToolTipComponent>
 
-              <ToolTipComponent class="flex-1" :direction="displayClusters ? 'top' : 'left'">
-                <template #default>
-                  <p class="w-full text-center">
-                    {{ metricToolTips[MetricType.MAXIMUM].shortName }}
-                  </p>
-                </template>
-                <template #tooltip>
-                  <p class="text-sm whitespace-pre">
-                    {{ metricToolTips[MetricType.MAXIMUM].tooltip }}
-                  </p>
-                </template>
-              </ToolTipComponent>
-            </div>
-          </div>
-          <div v-if="displayClusters" class="tableCellCluster tableCell items-center">Cluster</div>
-        </div>
-      </div>
-
-      <!-- Body -->
-      <div class="flex grow flex-col overflow-hidden">
-        <DynamicScroller
-          v-if="topComparisons.length > 0"
-          ref="dynamicScroller"
-          :items="displayedComparisons"
-          :min-item-size="48"
-          ><template #default="{ item, index, active }">
-            <DynamicScrollerItem
-              :item="item"
-              :active="active"
-              :size-dependencies="[
-                item.firstSubmissionId,
-                item.secondSubmissionId,
-                store().isAnonymous(item.firstSubmissionId),
-                store().isAnonymous(item.secondSubmissionId)
-              ]"
-              :data-index="index"
-            >
-              <!-- Row -->
-              <div
-                class="tableRow"
-                :class="{
-                  'bg-container-secondary-light dark:bg-container-secondary-dark': item.id % 2 == 1,
-                  'bg-accent/30!': isHighlightedRow(item)
-                }"
-              >
-                <RouterLink
-                  :to="{
-                    name: 'ComparisonView',
-                    params: {
-                      comparisonFileName: store().getComparisonFileName(
-                        item.firstSubmissionId,
-                        item.secondSubmissionId
-                      )
-                    }
-                  }"
-                  class="flex grow cursor-pointer flex-row"
-                >
-                  <!-- Index in sorted list -->
-                  <div class="tableCellNumber tableCell">
-                    <div class="w-full text-center">{{ item.sortingPlace + 1 }}</div>
-                  </div>
-
-                  <!-- Names -->
-                  <div class="tableCellName tableCell">
-                    <NameElement :id="item.firstSubmissionId" class="h-full w-1/2 px-2" />
-                    <NameElement :id="item.secondSubmissionId" class="h-full w-1/2 px-2" />
-                  </div>
-
-                  <!-- Similarities -->
-                  <div class="tableCellSimilarity tableCell">
-                    <div class="w-1/2">
-                      {{ (item.similarities[MetricType.AVERAGE] * 100).toFixed(2) }}%
-                    </div>
-                    <div class="w-1/2">
-                      {{ (item.similarities[MetricType.MAXIMUM] * 100).toFixed(2) }}%
-                    </div>
-                  </div>
-                </RouterLink>
-
-                <!-- Clusters -->
-                <div
-                  v-if="displayClusters"
-                  class="tableCellCluster tableCell flex flex-col! items-center"
-                >
-                  <RouterLink
-                    v-if="item.clusterIndex >= 0"
-                    :to="{
-                      name: 'ClusterView',
-                      params: { clusterIndex: item.clusterIndex }
-                    }"
-                    class="flex w-full justify-center text-center"
-                  >
-                    <ToolTipComponent
-                      class="w-fit"
-                      direction="left"
-                      :tool-tip-container-will-be-centered="true"
-                    >
-                      <template #default>
-                        {{ clusters?.[item.clusterIndex].members?.length }}
-                        <FontAwesomeIcon
-                          :icon="['fas', 'user-group']"
-                          :style="{ color: clusterIconColors[item.clusterIndex] }"
-                        />
-                        {{
-                          (
-                            (clusters?.[item.clusterIndex].averageSimilarity as number) * 100
-                          ).toFixed(2)
-                        }}%
-                      </template>
-                      <template #tooltip>
-                        <p class="text-sm whitespace-nowrap">
-                          {{ clusters?.[item.clusterIndex].members?.length }} submissions in cluster
-                          with average similarity of
-                          {{
-                            (
-                              (clusters?.[item.clusterIndex].averageSimilarity as number) * 100
-                            ).toFixed(2)
-                          }}%
-                        </p>
-                      </template>
-                    </ToolTipComponent>
-                  </RouterLink>
+                  <ToolTipComponent class="flex-1" :direction="displayClusters ? 'top' : 'left'">
+                    <template #default>
+                      <p class="w-full text-center">
+                        {{ metricToolTips[MetricType.MAXIMUM].shortName }}
+                      </p>
+                    </template>
+                    <template #tooltip>
+                      <p class="text-sm whitespace-pre">
+                        {{ metricToolTips[MetricType.MAXIMUM].tooltip }}
+                      </p>
+                    </template>
+                  </ToolTipComponent>
                 </div>
               </div>
-            </DynamicScrollerItem>
-          </template>
+              <div v-if="displayClusters" class="tableCellCluster tableCell items-center">
+                Cluster
+              </div>
+            </div>
+          </div>
 
-          <template #after>
-            <slot name="footer"></slot>
-          </template>
-        </DynamicScroller>
+          <!-- Body -->
+          <div class="flex w-full grow flex-col overflow-hidden">
+            <DynamicScroller
+              v-if="topComparisons.length > 0"
+              ref="dynamicScroller"
+              :items="displayedComparisons"
+              :min-item-size="48"
+              ><template #default="{ item, index, active }">
+                <DynamicScrollerItem
+                  :item="item"
+                  :active="active"
+                  :size-dependencies="[
+                    item.firstSubmissionId,
+                    item.secondSubmissionId,
+                    store().isAnonymous(item.firstSubmissionId),
+                    store().isAnonymous(item.secondSubmissionId)
+                  ]"
+                  :data-index="index"
+                  class="min-w-fit"
+                >
+                  <!-- Row -->
+                  <div
+                    class="tableRow min-w-fit"
+                    :class="{
+                      'bg-container-secondary-light dark:bg-container-secondary-dark':
+                        item.id % 2 == 1,
+                      'bg-accent/30!': isHighlightedRow(item)
+                    }"
+                  >
+                    <RouterLink
+                      :to="{
+                        name: 'ComparisonView',
+                        params: {
+                          comparisonFileName: store().getComparisonFileName(
+                            item.firstSubmissionId,
+                            item.secondSubmissionId
+                          )
+                        }
+                      }"
+                      class="flex grow cursor-pointer flex-row"
+                    >
+                      <!-- Index in sorted list -->
+                      <div class="tableCellNumber tableCell">
+                        <div class="w-full text-center">{{ item.sortingPlace + 1 }}</div>
+                      </div>
+
+                      <!-- Names -->
+                      <div class="tableCellName tableCell">
+                        <NameElement :id="item.firstSubmissionId" class="h-full w-1/2 px-2" />
+                        <NameElement :id="item.secondSubmissionId" class="h-full w-1/2 px-2" />
+                      </div>
+
+                      <!-- Similarities -->
+                      <div class="tableCellSimilarity tableCell">
+                        <div class="w-1/2">
+                          {{ (item.similarities[MetricType.AVERAGE] * 100).toFixed(2) }}%
+                        </div>
+                        <div class="w-1/2">
+                          {{ (item.similarities[MetricType.MAXIMUM] * 100).toFixed(2) }}%
+                        </div>
+                      </div>
+                    </RouterLink>
+
+                    <!-- Clusters -->
+                    <div
+                      v-if="displayClusters"
+                      class="tableCellCluster tableCell flex flex-col! items-center"
+                    >
+                      <RouterLink
+                        v-if="item.clusterIndex >= 0"
+                        :to="{
+                          name: 'ClusterView',
+                          params: { clusterIndex: item.clusterIndex }
+                        }"
+                        class="flex w-full justify-center text-center"
+                      >
+                        <ToolTipComponent
+                          class="w-fit"
+                          direction="left"
+                          :tool-tip-container-will-be-centered="true"
+                        >
+                          <template #default>
+                            {{ clusters?.[item.clusterIndex].members?.length }}
+                            <FontAwesomeIcon
+                              :icon="['fas', 'user-group']"
+                              :style="{ color: clusterIconColors[item.clusterIndex] }"
+                            />
+                            {{
+                              (
+                                (clusters?.[item.clusterIndex].averageSimilarity as number) * 100
+                              ).toFixed(2)
+                            }}%
+                          </template>
+                          <template #tooltip>
+                            <p class="text-sm whitespace-nowrap">
+                              {{ clusters?.[item.clusterIndex].members?.length }} submissions in
+                              cluster with average similarity of
+                              {{
+                                (
+                                  (clusters?.[item.clusterIndex].averageSimilarity as number) * 100
+                                ).toFixed(2)
+                              }}%
+                            </p>
+                          </template>
+                        </ToolTipComponent>
+                      </RouterLink>
+                    </div>
+                  </div>
+                </DynamicScrollerItem>
+              </template>
+
+              <template #after>
+                <slot name="footer"></slot>
+              </template>
+            </DynamicScroller>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -402,18 +410,18 @@ watch(
 }
 
 .tableCellNumber {
-  @apply w-12 shrink-0;
+  @apply w-12 min-w-12 shrink-0;
 }
 
 .tableCellSimilarity {
-  @apply w-40 shrink-0;
+  @apply w-40 min-w-40 shrink-0;
 }
 
 .tableCellCluster {
-  @apply w-32 shrink-0;
+  @apply w-32 min-w-32 shrink-0;
 }
 
 .tableCellName {
-  @apply grow;
+  @apply min-w-36 grow;
 }
 </style>

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -42,7 +42,7 @@
                   </ToolTipComponent>
 
                   <ToolTipComponent
-                    class="flex-1cursor-pointer"
+                    class="flex-1 cursor-pointer"
                     :direction="displayClusters ? 'top' : 'left'"
                     @click="setSorting('maximumSimilarity')"
                   >

--- a/report-viewer/src/components/ScrollableComponent.vue
+++ b/report-viewer/src/components/ScrollableComponent.vue
@@ -2,8 +2,8 @@
   Offers a un-styled scrollable container
 -->
 <template>
-  <div ref="root" class="overflow-y-auto print:overflow-y-visible">
-    <div class="max-h-0 min-h-full print:max-h-none">
+  <div ref="root" class="overflow-y-visible md:overflow-y-auto print:overflow-y-visible">
+    <div class="md:max-h-0 md:min-h-full print:max-h-none">
       <slot></slot>
     </div>
   </div>

--- a/report-viewer/src/components/ScrollableComponent.vue
+++ b/report-viewer/src/components/ScrollableComponent.vue
@@ -3,7 +3,7 @@
 -->
 <template>
   <div ref="root" class="overflow-y-visible md:overflow-y-auto print:overflow-y-visible">
-    <div class="md:max-h-0 md:min-h-full print:max-h-none">
+    <div class="md:max-h-0 md:min-h-full print:max-h-none print:min-h-fit">
       <slot></slot>
     </div>
   </div>

--- a/report-viewer/src/components/VersionRepositoryReference.vue
+++ b/report-viewer/src/components/VersionRepositoryReference.vue
@@ -1,8 +1,7 @@
 <template>
   <div
     :class="{
-      'absolute bottom-1 left-5 space-x-2 text-xs text-black dark:text-white print:hidden':
-        overrideStyle
+      'space-x-2 pb-1 text-xs text-black dark:text-white print:hidden': overrideStyle
     }"
   >
     <span

--- a/report-viewer/src/components/fileDisplaying/CodePanel.vue
+++ b/report-viewer/src/components/fileDisplaying/CodePanel.vue
@@ -2,7 +2,7 @@
   Panel which displays a submission files with its line of code.
 -->
 <template>
-  <Interactable class="mx-2 shadow-sm! print:mx-0! print:border-0! print:p-0!">
+  <Interactable class="shadow-sm! md:mx-2 print:mx-0! print:border-0! print:p-0!">
     <div class="flex px-2 font-bold print:whitespace-pre-wrap" @click="collapsed = !collapsed">
       <ToolTipComponent v-if="getFileDisplayName(file) != file.fileName" direction="right">
         <template #default

--- a/report-viewer/src/components/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/src/components/fileDisplaying/FilesContainer.vue
@@ -3,13 +3,13 @@
 -->
 <template>
   <Container class="flex flex-col print:px-1!">
-    <div class="mr-2 mb-2 flex items-center space-x-5">
+    <div class="mr-2 mb-2 flex flex-col gap-x-5 gap-y-2 md:flex-row md:items-center">
       <h3 class="grow text-left text-lg font-bold">
         Files of
         {{ fileOwnerDisplayName }}:
       </h3>
       <div class="text-gray-600 dark:text-gray-300">{{ tokenCount }} total tokens</div>
-      <Button class="space-x-2 print:hidden" @click="collapseAll()"
+      <Button class="w-fit space-x-2 md:w-full print:hidden" @click="collapseAll()"
         ><FontAwesomeIcon :icon="['fas', 'compress-alt']" />
         <p>Collapse All</p></Button
       >

--- a/report-viewer/src/components/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/src/components/fileDisplaying/FilesContainer.vue
@@ -3,7 +3,7 @@
 -->
 <template>
   <Container class="flex flex-col print:px-1!">
-    <div class="mr-2 mb-2 flex flex-col gap-x-5 gap-y-2 md:flex-row md:items-center">
+    <div class="mb-2 flex flex-col gap-x-5 gap-y-2 md:mr-2 md:flex-row md:items-center">
       <h3 class="grow text-left text-lg font-bold">
         Files of
         {{ fileOwnerDisplayName }}:
@@ -13,7 +13,7 @@
         ><FontAwesomeIcon :icon="['fas', 'expand-alt']" />
         <p>Expand All</p></Button
       >
-      <Button v-else class="w-fit space-x-2 md:w-full print:hidden" @click="collapseAll()"
+      <Button v-else class="w-full space-x-2 md:w-fit print:hidden" @click="collapseAll()"
         ><FontAwesomeIcon :icon="['fas', 'compress-alt']" />
         <p>Collapse All</p></Button
       >

--- a/report-viewer/src/components/fileDisplaying/MatchList.vue
+++ b/report-viewer/src/components/fileDisplaying/MatchList.vue
@@ -3,7 +3,7 @@
 -->
 <template>
   <div
-    class="flex h-fit max-w-full min-w-0 flex-row space-x-1 overflow-x-hidden text-xs print:hidden"
+    class="flex h-fit max-w-full min-w-0 flex-row flex-wrap space-x-1 gap-y-1 overflow-x-hidden text-xs md:flex-nowrap print:hidden"
   >
     <ToolTipComponent direction="right">
       <template #default>

--- a/report-viewer/src/components/optionsSelectors/OptionsSelectorComponent.vue
+++ b/report-viewer/src/components/optionsSelectors/OptionsSelectorComponent.vue
@@ -2,7 +2,9 @@
   Component for selecting one of multiple options.
 -->
 <template>
-  <div class="flex h-fit flex-row items-center text-center text-xs">
+  <div
+    class="flex h-fit flex-row flex-wrap items-center gap-y-1 text-center text-xs md:flex-nowrap"
+  >
     <div v-if="title != ''" class="mr-3 text-base">
       {{ title }}
     </div>

--- a/report-viewer/src/viewWrapper/ClusterViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/ClusterViewWrapper.vue
@@ -4,7 +4,7 @@
       v-if="overview"
       :overview="overview"
       :cluster="overview.clusters[clusterIndex]"
-      class="flex-1"
+      class="flex-1 print:flex-none"
     />
     <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />

--- a/report-viewer/src/viewWrapper/ClusterViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/ClusterViewWrapper.vue
@@ -1,10 +1,12 @@
 <template>
-  <div>
-    <ClusterView v-if="overview" :overview="overview" :cluster="overview.clusters[clusterIndex]" />
-    <div
-      v-else
-      class="absolute top-0 right-0 bottom-0 left-0 flex flex-col items-center justify-center"
-    >
+  <div class="flex flex-col gap-1 md:overflow-hidden">
+    <ClusterView
+      v-if="overview"
+      :overview="overview"
+      :cluster="overview.clusters[clusterIndex]"
+      class="flex-1"
+    />
+    <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />
     </div>
 

--- a/report-viewer/src/viewWrapper/ComparisonViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/ComparisonViewWrapper.vue
@@ -1,16 +1,14 @@
 <template>
-  <div>
+  <div class="flex flex-col gap-1 md:overflow-hidden">
     <ComparisonView
       v-if="comparison && language && firstBaseCodeMatches && secondBaseCodeMatches"
       :comparison="comparison"
       :language="language"
       :first-base-code-matches="firstBaseCodeMatches"
       :second-base-code-matches="secondBaseCodeMatches"
+      class="flex-1"
     />
-    <div
-      v-else
-      class="absolute top-0 right-0 bottom-0 left-0 flex flex-col items-center justify-center"
-    >
+    <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />
     </div>
 

--- a/report-viewer/src/viewWrapper/ComparisonViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/ComparisonViewWrapper.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="flex flex-col gap-1 md:overflow-hidden">
+  <div class="flex flex-col gap-1 md:overflow-hidden print:w-full">
     <ComparisonView
       v-if="comparison && language && firstBaseCodeMatches && secondBaseCodeMatches"
       :comparison="comparison"
       :language="language"
       :first-base-code-matches="firstBaseCodeMatches"
       :second-base-code-matches="secondBaseCodeMatches"
-      class="flex-1"
+      class="flex-1 print:w-full print:flex-none"
     />
     <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />

--- a/report-viewer/src/viewWrapper/InformationViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/InformationViewWrapper.vue
@@ -1,10 +1,12 @@
 <template>
-  <div>
-    <InformationView v-if="overview && cliOptions" :overview="overview" :options="cliOptions" />
-    <div
-      v-else
-      class="absolute top-0 right-0 bottom-0 left-0 flex flex-col items-center justify-center"
-    >
+  <div class="flex flex-col gap-1 md:overflow-hidden">
+    <InformationView
+      v-if="overview && cliOptions"
+      :overview="overview"
+      :options="cliOptions"
+      class="flex-1"
+    />
+    <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />
     </div>
 

--- a/report-viewer/src/viewWrapper/InformationViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/InformationViewWrapper.vue
@@ -4,7 +4,7 @@
       v-if="overview && cliOptions"
       :overview="overview"
       :options="cliOptions"
-      class="flex-1"
+      class="flex-1 print:flex-none"
     />
     <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />

--- a/report-viewer/src/viewWrapper/OverviewViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/OverviewViewWrapper.vue
@@ -1,10 +1,7 @@
 <template>
-  <div>
-    <OverviewView v-if="overview" :overview="overview" />
-    <div
-      v-else
-      class="absolute top-0 right-0 bottom-0 left-0 flex flex-col items-center justify-center"
-    >
+  <div class="flex flex-col gap-1 md:overflow-hidden">
+    <OverviewView v-if="overview" :overview="overview" class="flex-1" />
+    <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />
     </div>
 

--- a/report-viewer/src/viewWrapper/OverviewViewWrapper.vue
+++ b/report-viewer/src/viewWrapper/OverviewViewWrapper.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col gap-1 md:overflow-hidden">
-    <OverviewView v-if="overview" :overview="overview" class="flex-1" />
+    <OverviewView v-if="overview" :overview="overview" class="flex-1 print:flex-none" />
     <div v-else class="flex flex-1 flex-col items-center justify-center">
       <LoadingCircle class="mx-auto" />
     </div>

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -1,19 +1,17 @@
 <template>
-  <div class="absolute top-0 right-0 bottom-0 left-0 flex flex-col print:space-y-5">
-    <div class="relative top-0 right-0 left-0 flex space-x-5 p-5 pb-0 print:p-0">
-      <Container class="grow overflow-hidden">
-        <h2>Cluster</h2>
-        <div class="flex flex-row items-center space-x-5">
-          <TextInformation label="Average Similarity"
-            >{{ (cluster.averageSimilarity * 100).toFixed(2) }}%</TextInformation
-          >
-        </div>
-      </Container>
-    </div>
+  <div
+    class="grid grid-cols-1 grid-rows-[auto_600px_90vh] gap-5 md:grid-cols-[2fr_1fr] md:grid-rows-[auto_1fr] md:overflow-hidden"
+  >
+    <Container class="col-start-1 row-start-1 md:col-end-3 md:row-end-2">
+      <h2>Cluster</h2>
+      <div class="flex flex-row items-center space-x-5">
+        <TextInformation label="Average Similarity"
+          >{{ (cluster.averageSimilarity * 100).toFixed(2) }}%</TextInformation
+        >
+      </div>
+    </Container>
 
-    <div
-      class="relative right-0 bottom-0 left-0 flex grow justify-between space-x-5 px-5 pt-5 pb-7 print:grow-0 print:flex-col print:space-y-5 print:space-x-0 print:p-0"
-    >
+    <div class="col-start-1 row-start-2 flex flex-col overflow-hidden">
       <Container
         v-if="cluster.members.length >= 35 || !canShowRadarChart"
         class="flex max-h-0 min-h-full flex-1 flex-col overflow-hidden print:max-h-none print:min-h-0 print:flex-none"
@@ -54,36 +52,36 @@
           <ClusterRadarChart :cluster="clusterListElement" class="grow" />
         </template>
       </TabbedContainer>
-
-      <TabbedContainer
-        class="flex max-h-0 min-h-full w-1/3 flex-col space-y-2 print:hidden"
-        :tabs="comparisonTableOptions"
-        :first-bottom-tooltip-index="1"
-      >
-        <template #Members>
-          <ComparisonsTable
-            :top-comparisons="comparisons"
-            class="max-h-0 min-h-full flex-1 overflow-hidden"
-            header="Comparisons of Cluster Members:"
-            :highlighted-row-ids="highlightedElement ?? undefined"
-          >
-            <template v-if="comparisons.length < maxAmountOfComparisonsInCluster" #footer>
-              <p class="w-full pt-1 text-center font-bold">
-                Not all comparisons inside the cluster are shown. To see more, re-run JPlag with a
-                higher maximum number argument.
-              </p>
-            </template>
-          </ComparisonsTable>
-        </template>
-        <template #Related-Comparisons>
-          <ComparisonsTable
-            :top-comparisons="relatedComparisons"
-            class="max-h-0 min-h-full flex-1 overflow-hidden"
-            header="Comparisons related to the Cluster:"
-          />
-        </template>
-      </TabbedContainer>
     </div>
+
+    <TabbedContainer
+      class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2"
+      :tabs="comparisonTableOptions"
+      :first-bottom-tooltip-index="1"
+    >
+      <template #Members>
+        <ComparisonsTable
+          :top-comparisons="comparisons"
+          class="max-h-0 min-h-full flex-1 overflow-hidden"
+          header="Comparisons of Cluster Members:"
+          :highlighted-row-ids="highlightedElement ?? undefined"
+        >
+          <template v-if="comparisons.length < maxAmountOfComparisonsInCluster" #footer>
+            <p class="w-full pt-1 text-center font-bold">
+              Not all comparisons inside the cluster are shown. To see more, re-run JPlag with a
+              higher maximum number argument.
+            </p>
+          </template>
+        </ComparisonsTable>
+      </template>
+      <template #Related-Comparisons>
+        <ComparisonsTable
+          :top-comparisons="relatedComparisons"
+          class="max-h-0 min-h-full flex-1 overflow-hidden"
+          header="Comparisons related to the Cluster:"
+        />
+      </template>
+    </TabbedContainer>
   </div>
 </template>
 

--- a/report-viewer/src/views/ClusterView.vue
+++ b/report-viewer/src/views/ClusterView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid grid-cols-1 grid-rows-[auto_600px_90vh] gap-5 md:grid-cols-[2fr_1fr] md:grid-rows-[auto_1fr] md:overflow-hidden"
+    class="grid grid-cols-1 grid-rows-[auto_600px_90vh] gap-5 md:grid-cols-[2fr_1fr] md:grid-rows-[auto_1fr] md:overflow-hidden print:grid-cols-1 print:grid-rows-[auto_1fr]"
   >
     <Container class="col-start-1 row-start-1 md:col-end-3 md:row-end-2">
       <h2>Cluster</h2>
@@ -55,7 +55,7 @@
     </div>
 
     <TabbedContainer
-      class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2"
+      class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2 print:hidden"
       :tabs="comparisonTableOptions"
       :first-bottom-tooltip-index="1"
     >

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -2,114 +2,108 @@
   A view displaying the .json file of a comparison from a JPlag report.
 -->
 <template>
-  <div class="absolute top-0 right-0 bottom-0 left-0 flex flex-col">
-    <div class="relative top-0 right-0 left-0 flex space-x-5 p-5 pb-0 print:p-0">
-      <Container class="grow overflow-hidden print:min-h-fit print:overflow-visible">
-        <h2>
-          Comparison:
-          {{ store().getDisplayName(comparison.firstSubmissionId) }}
-          -
-          {{ store().getDisplayName(comparison.secondSubmissionId) }}
-          <ToolTipComponent direction="left" class="float-right print:hidden">
-            <template #tooltip>
-              <p class="text-sm whitespace-pre">
-                Printing works best in landscape mode on Chromium based browsers
+  <div
+    class="grid grid-cols-1 grid-rows-[min-content_auto_auto] gap-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:overflow-hidden"
+  >
+    <Container class="col-start-1 row-start-1 md:col-end-3 md:row-end-2">
+      <h2>
+        Comparison:
+        {{ store().getDisplayName(comparison.firstSubmissionId) }}
+        -
+        {{ store().getDisplayName(comparison.secondSubmissionId) }}
+        <ToolTipComponent direction="left" class="float-right hidden md:block print:hidden">
+          <template #tooltip>
+            <p class="text-sm whitespace-pre">
+              Printing works best in landscape mode on Chromium based browsers
+            </p>
+          </template>
+          <template #default>
+            <Button class="hidden h-10 w-10 md:block" @click="print()">
+              <FontAwesomeIcon class="text-2xl" :icon="['fas', 'print']" />
+            </Button>
+          </template>
+        </ToolTipComponent>
+      </h2>
+      <div class="flex flex-col gap-x-10 gap-y-2 md:flex-row">
+        <TextInformation label="Average Similarity" class="font-bold"
+          >{{ (comparison.similarities[MetricType.AVERAGE] * 100).toFixed(2) }}%</TextInformation
+        >
+        <TextInformation
+          :label="`Similarity ${store().getDisplayName(comparison.firstSubmissionId)}`"
+          tooltip-side="right"
+        >
+          <template #default>{{ (comparison.firstSimilarity * 100).toFixed(2) }}%</template>
+          <template #tooltip
+            ><div class="text-sm whitespace-pre">
+              <p>
+                Percentage of code from
+                {{ store().getDisplayName(comparison.firstSubmissionId) }} that was found in the
+                code of {{ store().getDisplayName(comparison.secondSubmissionId) }}.
               </p>
-            </template>
-            <template #default>
-              <Button class="h-10 w-10" @click="print()">
-                <FontAwesomeIcon class="text-2xl" :icon="['fas', 'print']" />
-              </Button>
-            </template>
-          </ToolTipComponent>
-        </h2>
-        <div class="flex flex-row space-x-10">
-          <TextInformation label="Average Similarity" class="font-bold"
-            >{{ (comparison.similarities[MetricType.AVERAGE] * 100).toFixed(2) }}%</TextInformation
+              <p>
+                The numbers might not be symmetric, due to the submissions having different lengths.
+              </p>
+            </div></template
           >
-          <TextInformation
-            :label="`Similarity ${store().getDisplayName(comparison.firstSubmissionId)}`"
-            tooltip-side="right"
-          >
-            <template #default>{{ (comparison.firstSimilarity * 100).toFixed(2) }}%</template>
-            <template #tooltip
-              ><div class="text-sm whitespace-pre">
-                <p>
-                  Percentage of code from
-                  {{ store().getDisplayName(comparison.firstSubmissionId) }} that was found in the
-                  code of {{ store().getDisplayName(comparison.secondSubmissionId) }}.
-                </p>
-                <p>
-                  The numbers might not be symmetric, due to the submissions having different
-                  lengths.
-                </p>
-              </div></template
-            >
-          </TextInformation>
-          <TextInformation
-            :label="`Similarity ${store().getDisplayName(comparison.secondSubmissionId)}`"
-            tooltip-side="right"
-            ><template #default>{{ (comparison.secondSimilarity * 100).toFixed(2) }}%</template>
-            <template #tooltip
-              ><div class="text-sm whitespace-pre">
-                <p>
-                  Percentage of code from
-                  {{ store().getDisplayName(comparison.secondSubmissionId) }} that was found in the
-                  code of {{ store().getDisplayName(comparison.firstSubmissionId) }}.
-                </p>
-                <p>
-                  The numbers might not be symmetric, due to the submissions having different
-                  lengths.
-                </p>
-              </div></template
-            ></TextInformation
-          >
-        </div>
-        <MatchList
-          :id1="firstId"
-          :id2="secondId"
-          :matches="comparison.allMatches"
-          :basecode-in-first="firstBaseCodeMatches"
-          :basecode-in-second="secondBaseCodeMatches"
-          @match-selected="showMatch"
-        />
-        <OptionsSelectorComponent
-          ref="sortingOptionSelector"
-          class="mt-2"
-          title="File Sorting:"
-          :labels="sortingOptions.map((o) => fileSortingTooltips[o])"
-          :default-selected="sortingOptions.indexOf(store().uiState.fileSorting)"
-          @selection-changed="(index: number) => changeFileSorting(index)"
-        />
-      </Container>
-    </div>
-    <div ref="styleholder"></div>
-    <div
-      class="relative right-0 bottom-0 left-0 flex grow justify-between space-x-5 px-5 pt-5 pb-7 print:space-x-1 print:p-0 print:pt-2!"
-    >
-      <FilesContainer
-        ref="panel1"
-        :files="filesOfFirst"
-        :matches="comparison.matchesInFirstSubmission"
-        :file-owner-display-name="store().getDisplayName(comparison.firstSubmissionId)"
-        :highlight-language="language"
-        :base-code-matches="firstBaseCodeMatches"
-        class="max-h-0 min-h-full flex-1 overflow-hidden print:max-h-none print:overflow-y-visible"
-        @match-selected="showMatchInSecond"
-        @files-moved="filesMoved()"
+        </TextInformation>
+        <TextInformation
+          :label="`Similarity ${store().getDisplayName(comparison.secondSubmissionId)}`"
+          tooltip-side="right"
+          ><template #default>{{ (comparison.secondSimilarity * 100).toFixed(2) }}%</template>
+          <template #tooltip
+            ><div class="text-sm whitespace-pre">
+              <p>
+                Percentage of code from
+                {{ store().getDisplayName(comparison.secondSubmissionId) }} that was found in the
+                code of {{ store().getDisplayName(comparison.firstSubmissionId) }}.
+              </p>
+              <p>
+                The numbers might not be symmetric, due to the submissions having different lengths.
+              </p>
+            </div></template
+          ></TextInformation
+        >
+      </div>
+      <MatchList
+        :id1="firstId"
+        :id2="secondId"
+        :matches="comparison.allMatches"
+        :basecode-in-first="firstBaseCodeMatches"
+        :basecode-in-second="secondBaseCodeMatches"
+        @match-selected="showMatch"
       />
-      <FilesContainer
-        ref="panel2"
-        :files="filesOfSecond"
-        :matches="comparison.matchesInSecondSubmissions"
-        :file-owner-display-name="store().getDisplayName(comparison.secondSubmissionId)"
-        :highlight-language="language"
-        :base-code-matches="secondBaseCodeMatches"
-        class="max-h-0 min-h-full flex-1 overflow-hidden print:max-h-none print:overflow-y-visible"
-        @match-selected="showMatchInFirst"
-        @files-moved="filesMoved()"
+      <OptionsSelectorComponent
+        ref="sortingOptionSelector"
+        class="mt-2"
+        title="File Sorting:"
+        :labels="sortingOptions.map((o) => fileSortingTooltips[o])"
+        :default-selected="sortingOptions.indexOf(store().uiState.fileSorting)"
+        @selection-changed="(index: number) => changeFileSorting(index)"
       />
-    </div>
+    </Container>
+
+    <FilesContainer
+      ref="panel1"
+      :files="filesOfFirst"
+      :matches="comparison.matchesInFirstSubmission"
+      :file-owner-display-name="store().getDisplayName(comparison.firstSubmissionId)"
+      :highlight-language="language"
+      :base-code-matches="firstBaseCodeMatches"
+      class="col-start-1 row-start-2 flex flex-col overflow-hidden"
+      @match-selected="showMatchInSecond"
+      @files-moved="filesMoved()"
+    />
+    <FilesContainer
+      ref="panel2"
+      :files="filesOfSecond"
+      :matches="comparison.matchesInSecondSubmissions"
+      :file-owner-display-name="store().getDisplayName(comparison.secondSubmissionId)"
+      :highlight-language="language"
+      :base-code-matches="secondBaseCodeMatches"
+      class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2"
+      @match-selected="showMatchInFirst"
+      @files-moved="filesMoved()"
+    />
   </div>
 </template>
 

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -74,7 +74,7 @@
       />
       <OptionsSelectorComponent
         ref="sortingOptionSelector"
-        class="mt-2"
+        class="mt-2 print:hidden"
         title="File Sorting:"
         :labels="sortingOptions.map((o) => fileSortingTooltips[o])"
         :default-selected="sortingOptions.indexOf(store().uiState.fileSorting)"

--- a/report-viewer/src/views/InformationView.vue
+++ b/report-viewer/src/views/InformationView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="absolute top-0 right-0 bottom-0 left-0 flex flex-row space-x-5 p-5 pb-7 print:flex-col print:space-y-2 print:space-x-0 print:p-0"
+    class="grid grid-cols-1 grid-rows-[auto_auto] gap-5 md:grid-cols-2 md:grid-rows-1 md:overflow-hidden"
   >
     <Container class="infoContainer print:border-none!">
       <h2>Run Options:</h2>
@@ -161,6 +161,6 @@ onErrorCaptured((error) => {
 @reference "../style.css";
 
 .infoContainer {
-  @apply flex max-h-0 min-h-full flex-1 flex-col overflow-hidden print:max-h-none print:min-h-0 print:flex-none;
+  @apply flex flex-col overflow-hidden print:max-h-none print:min-h-0 print:flex-none;
 }
 </style>

--- a/report-viewer/src/views/InformationView.vue
+++ b/report-viewer/src/views/InformationView.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid grid-cols-1 grid-rows-[auto_auto] gap-5 md:grid-cols-2 md:grid-rows-1 md:overflow-hidden"
+    class="grid grid-cols-1 grid-rows-[auto_auto] gap-5 md:grid-cols-2 md:grid-rows-1 md:overflow-hidden print:grid-cols-1 print:grid-rows-[auto_auto]"
   >
     <Container class="infoContainer print:border-none!">
       <h2>Run Options:</h2>
@@ -161,6 +161,6 @@ onErrorCaptured((error) => {
 @reference "../style.css";
 
 .infoContainer {
-  @apply flex flex-col overflow-hidden print:max-h-none print:min-h-0 print:flex-none;
+  @apply flex flex-col overflow-hidden print:min-h-fit print:overflow-visible;
 }
 </style>

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -2,100 +2,92 @@
   A view displaying the overview file of a JPlag report.
 -->
 <template>
-  <div class="absolute top-0 right-0 bottom-0 left-0 flex flex-col">
-    <div class="relative top-0 right-0 left-0 flex space-x-5 p-5 pb-0">
-      <Container class="grow">
-        <h2>JPlag Report</h2>
-        <div
-          class="flex flex-row items-center space-x-5 print:flex-col print:items-start print:space-x-0"
-        >
-          <TextInformation label="Submission Directory" class="flex-auto">{{
-            submissionPathValue
-          }}</TextInformation>
-          <TextInformation label="Result name" class="flex-auto">{{
-            store().state.uploadedFileName
-          }}</TextInformation>
-          <TextInformation label="Total Submissions" class="flex-auto">{{
-            store().getSubmissionIds.length
-          }}</TextInformation>
+  <div
+    class="grid grid-cols-1 grid-rows-[auto_800px_90vh] gap-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:overflow-hidden"
+  >
+    <Container class="col-start-1 row-start-1 md:col-end-3 md:row-end-2">
+      <h2>JPlag Report</h2>
+      <div class="flex flex-col gap-5 md:flex-row md:items-center">
+        <TextInformation label="Submission Directory" class="flex-auto">{{
+          submissionPathValue
+        }}</TextInformation>
+        <TextInformation label="Result name" class="flex-auto">{{
+          store().state.uploadedFileName
+        }}</TextInformation>
+        <TextInformation label="Total Submissions" class="flex-auto">{{
+          store().getSubmissionIds.length
+        }}</TextInformation>
 
-          <TextInformation label="Shown/Total Comparisons" class="flex-auto">
-            <template #default
-              >{{ overview.shownComparisons }} / {{ overview.totalComparisons }}</template
-            >
-            <template #tooltip>
-              <div class="text-sm whitespace-pre">
-                <TextInformation label="Shown Comparisons">{{
-                  overview.shownComparisons
+        <TextInformation label="Shown/Total Comparisons" class="flex-auto">
+          <template #default
+            >{{ overview.shownComparisons }} / {{ overview.totalComparisons }}</template
+          >
+          <template #tooltip>
+            <div class="text-sm whitespace-pre">
+              <TextInformation label="Shown Comparisons">{{
+                overview.shownComparisons
+              }}</TextInformation>
+              <TextInformation label="Total Comparisons">{{
+                overview.totalComparisons
+              }}</TextInformation>
+              <div v-if="overview.missingComparisons > 0">
+                <TextInformation label="Missing Comparisons">{{
+                  overview.missingComparisons
                 }}</TextInformation>
-                <TextInformation label="Total Comparisons">{{
-                  overview.totalComparisons
-                }}</TextInformation>
-                <div v-if="overview.missingComparisons > 0">
-                  <TextInformation label="Missing Comparisons">{{
-                    overview.missingComparisons
-                  }}</TextInformation>
-                  <p>
-                    To include more comparisons in the report modify the number of shown comparisons
-                    in the CLI.
-                  </p>
-                </div>
-              </div>
-            </template>
-          </TextInformation>
-
-          <TextInformation label="Min Token Match" class="flex-auto">
-            <template #default>
-              {{ overview.matchSensitivity }}
-            </template>
-            <template #tooltip>
-              <div class="text-sm whitespace-pre">
                 <p>
-                  Tunes the comparison sensitivity by adjusting the minimum token required to be
-                  counted as a matching section.
+                  To include more comparisons in the report modify the number of shown comparisons
+                  in the CLI.
                 </p>
-                <p>It can be adjusted in the CLI.</p>
               </div>
-            </template>
-          </TextInformation>
-
-          <ToolTipComponent direction="left" class="grow-0 print:hidden">
-            <template #default>
-              <Button @click="router.push({ name: 'InfoView' })"> More </Button>
-            </template>
-            <template #tooltip>
-              <p class="text-sm whitespace-pre">More information about the CLI run of JPlag</p>
-            </template>
-          </ToolTipComponent>
-        </div>
-      </Container>
-    </div>
-
-    <div
-      class="relative right-0 bottom-0 left-0 flex grow space-x-5 px-5 pt-5 pb-7 print:flex-col print:space-y-5 print:space-x-0"
-    >
-      <Container
-        class="flex max-h-0 min-h-full flex-1 flex-col print:max-h-none print:min-h-fit print:flex-none"
-      >
-        <h2>Distribution of Comparisons:</h2>
-        <DistributionDiagram :distributions="overview.distribution" class="grow" />
-      </Container>
-
-      <Container class="flex max-h-0 min-h-full flex-1 flex-col print:hidden">
-        <ComparisonsTable
-          :clusters="overview.clusters"
-          :top-comparisons="overview.topComparisons"
-          class="min-h-0 flex-1 print:min-h-full print:grow"
-        >
-          <template v-if="overview.topComparisons.length < overview.totalComparisons" #footer>
-            <p class="w-full pt-1 text-center font-bold">
-              Not all comparisons are shown. To see more, re-run JPlag with a higher maximum number
-              argument.
-            </p>
+            </div>
           </template>
-        </ComparisonsTable>
-      </Container>
-    </div>
+        </TextInformation>
+
+        <TextInformation label="Min Token Match" class="flex-auto">
+          <template #default>
+            {{ overview.matchSensitivity }}
+          </template>
+          <template #tooltip>
+            <div class="text-sm whitespace-pre">
+              <p>
+                Tunes the comparison sensitivity by adjusting the minimum token required to be
+                counted as a matching section.
+              </p>
+              <p>It can be adjusted in the CLI.</p>
+            </div>
+          </template>
+        </TextInformation>
+
+        <ToolTipComponent direction="left" class="grow-0 print:hidden">
+          <template #default>
+            <Button @click="router.push({ name: 'InfoView' })"> More </Button>
+          </template>
+          <template #tooltip>
+            <p class="text-sm whitespace-pre">More information about the CLI run of JPlag</p>
+          </template>
+        </ToolTipComponent>
+      </div>
+    </Container>
+
+    <Container class="col-start-1 row-start-2 flex flex-col overflow-hidden">
+      <h2>Distribution of Comparisons:</h2>
+      <DistributionDiagram :distributions="overview.distribution" class="grow" />
+    </Container>
+
+    <Container class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2">
+      <ComparisonsTable
+        :clusters="overview.clusters"
+        :top-comparisons="overview.topComparisons"
+        class="min-h-0 max-w-full flex-1 print:min-h-full print:grow"
+      >
+        <template v-if="overview.topComparisons.length < overview.totalComparisons" #footer>
+          <p class="w-full pt-1 text-center font-bold">
+            Not all comparisons are shown. To see more, re-run JPlag with a higher maximum number
+            argument.
+          </p>
+        </template>
+      </ComparisonsTable>
+    </Container>
   </div>
 </template>
 

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -7,7 +7,7 @@
   >
     <Container class="col-start-1 row-start-1 md:col-end-3 md:row-end-2">
       <h2>JPlag Report</h2>
-      <div class="flex flex-col gap-5 md:flex-row md:items-center">
+      <div class="flex flex-col gap-x-5 gap-y-2 md:flex-row md:items-center">
         <TextInformation label="Submission Directory" class="flex-auto">{{
           submissionPathValue
         }}</TextInformation>

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -3,11 +3,13 @@
 -->
 <template>
   <div
-    class="grid grid-cols-1 grid-rows-[auto_800px_90vh] gap-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:overflow-hidden"
+    class="grid grid-cols-1 grid-rows-[auto_800px_90vh] gap-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:overflow-hidden print:grid-cols-1 print:grid-rows-[auto_auto]"
   >
     <Container class="col-start-1 row-start-1 md:col-end-3 md:row-end-2">
       <h2>JPlag Report</h2>
-      <div class="flex flex-col gap-x-5 gap-y-2 md:flex-row md:items-center">
+      <div
+        class="flex flex-col gap-x-5 gap-y-2 md:flex-row md:items-center print:flex-col print:items-start"
+      >
         <TextInformation label="Submission Directory" class="flex-auto">{{
           submissionPathValue
         }}</TextInformation>
@@ -69,12 +71,14 @@
       </div>
     </Container>
 
-    <Container class="col-start-1 row-start-2 flex flex-col overflow-hidden">
+    <Container class="col-start-1 row-start-2 flex flex-col overflow-hidden print:overflow-visible">
       <h2>Distribution of Comparisons:</h2>
-      <DistributionDiagram :distributions="overview.distribution" class="grow" />
+      <DistributionDiagram :distributions="overview.distribution" class="grow print:flex-none" />
     </Container>
 
-    <Container class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2">
+    <Container
+      class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2 print:hidden"
+    >
       <ComparisonsTable
         :clusters="overview.clusters"
         :top-comparisons="overview.topComparisons"


### PR DESCRIPTION
This PR improves the report viewer in two key ways:
1. Mobile layout: Added a custom layout for mobile devices, fixing the previously broken appearance. This is especially relevant for the demo (e.g., when advertising JPlag via QR codes).
2. Responsive design and zoom: Improved scaling responiveness for small windows and enabled proper browser zooming, enhancing readability on projectors or older devices.
