### PR TITLE
Hotfix: Prevent combining SMM with basecode

### DIFF
--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import de.jplag.clustering.ClusteringFactory;
 import de.jplag.comparison.LongestCommonSubsquenceSearch;
 import de.jplag.exceptions.ExitException;
+import de.jplag.exceptions.BasecodeException;
 import de.jplag.exceptions.RootDirectoryException;
 import de.jplag.exceptions.SubmissionException;
 import de.jplag.merging.MatchMerging;

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -66,6 +66,11 @@ public class JPlag {
      */
     public static JPlagResult run(JPlagOptions options) throws ExitException {
         checkForConfigurationConsistency(options);
+        
+        //Hotfix
+        if (options.mergingOptions().enabled() && options.hasBaseCode()) {
+            throw new ExitException("Subsequence match merging does currently not work with basecode. We are working on it.")
+        }
 
         // Parse and validate submissions.
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -12,8 +12,8 @@ import org.slf4j.LoggerFactory;
 
 import de.jplag.clustering.ClusteringFactory;
 import de.jplag.comparison.LongestCommonSubsquenceSearch;
-import de.jplag.exceptions.ExitException;
 import de.jplag.exceptions.BasecodeException;
+import de.jplag.exceptions.ExitException;
 import de.jplag.exceptions.RootDirectoryException;
 import de.jplag.exceptions.SubmissionException;
 import de.jplag.merging.MatchMerging;

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -68,7 +68,8 @@ public class JPlag {
     public static JPlagResult run(JPlagOptions options) throws ExitException {
         checkForConfigurationConsistency(options);
 
-        // Hotfix
+        // Hotfix for issue #2268, where the report creation throws an index out of bounds exception due to the incompatibility
+        // of SMM with basecode.
         if (options.mergingOptions().enabled() && options.hasBaseCode()) {
             throw new BasecodeException("Subsequence match merging does currently not work with basecode. We are working on it.");
         }

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -66,8 +66,8 @@ public class JPlag {
      */
     public static JPlagResult run(JPlagOptions options) throws ExitException {
         checkForConfigurationConsistency(options);
-        
-        //Hotfix
+
+        // Hotfix
         if (options.mergingOptions().enabled() && options.hasBaseCode()) {
             throw new BasecodeException("Subsequence match merging does currently not work with basecode. We are working on it.");
         }

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -69,7 +69,7 @@ public class JPlag {
         
         //Hotfix
         if (options.mergingOptions().enabled() && options.hasBaseCode()) {
-            throw new ExitException("Subsequence match merging does currently not work with basecode. We are working on it.");
+            throw new BasecodeException("Subsequence match merging does currently not work with basecode. We are working on it.");
         }
 
         // Parse and validate submissions.

--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -69,7 +69,7 @@ public class JPlag {
         
         //Hotfix
         if (options.mergingOptions().enabled() && options.hasBaseCode()) {
-            throw new ExitException("Subsequence match merging does currently not work with basecode. We are working on it.")
+            throw new ExitException("Subsequence match merging does currently not work with basecode. We are working on it.");
         }
 
         // Parse and validate submissions.


### PR DESCRIPTION
This PR introduces a hotfix for #2268 and prevents combining subsequence match merging from being used with basecode.