### PR TITLE
Ensure Ecore extensions are only registered once.

### DIFF
--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/EmfLanguage.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/EmfLanguage.java
@@ -11,6 +11,7 @@ import de.jplag.Language;
 import de.jplag.ParsingException;
 import de.jplag.Token;
 import de.jplag.emf.parser.EcoreParser;
+import de.jplag.emf.util.EMFUtil;
 
 /**
  * Language for EMF metamodels from the Eclipse Modeling Framework (EMF).
@@ -18,6 +19,10 @@ import de.jplag.emf.parser.EcoreParser;
  */
 @MetaInfServices(Language.class)
 public class EmfLanguage implements Language {
+
+    public EmfLanguage() {
+        EMFUtil.registerEcoreExtension();
+    }
 
     public static final String VIEW_FILE_SUFFIX = ".emfatic";
     public static final String FILE_ENDING = "." + EcorePackage.eNAME;

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
@@ -30,13 +30,6 @@ public class EcoreParser extends AbstractParser {
     protected AbstractMetamodelVisitor visitor;
 
     /**
-     * Creates the parser.
-     */
-    public EcoreParser() {
-        EMFUtil.registerEcoreExtension();
-    }
-
-    /**
      * Parses all tokens from a set of files.
      * @param files is the set of files.
      * @return the list of parsed tokens.


### PR DESCRIPTION
Previously, the Ecore extensions were registered in the parser upon initialization. However, we now use a single parser instance per file. Thus, this PR moves this task into the language class. Here, this will only be done once.

This PR may or may not fix the current build failure we are experiencing on develop, which I cannot reproduce outside of the CI build.