### PR TITLE
Ensure proper usage of .jplag ending

### DIFF
--- a/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
+++ b/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
@@ -45,7 +45,7 @@ public class ReportViewer implements HttpHandler {
         this.routingTree = new RoutingTree();
 
         this.routingTree.insertRouting("", new RoutingResources(REPORT_VIEWER_RESOURCE_PREFIX).or(new RoutingAlias(INDEX_PATH)));
-        this.routingTree.insertRouting(RESULT_PATH, new RoutingStaticFile(zipFile, ContentType.ZIP));
+        this.routingTree.insertRouting(RESULT_PATH, new RoutingStaticFile(zipFile, ContentType.RESULT_FILE));
         for (String version : OLD_VERSION_DIRECTORIES) {
             this.routingTree.insertRouting(version, new RoutingResources(version).or(new RoutingAlias(version + "/" + INDEX_PATH)));
         }

--- a/cli/src/test/java/de/jplag/cli/ModeTest.java
+++ b/cli/src/test/java/de/jplag/cli/ModeTest.java
@@ -18,46 +18,46 @@ class ModeTest extends CliTest {
     @Test
     void testViewWithPositionalFile() throws IOException, ExitException {
         CliInputHandler inputHandler = this
-                .runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.SUBMISSION_DIRECTORIES, new String[] {"result.zip"}))
+                .runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.SUBMISSION_DIRECTORIES, new String[] {"result.jplag"}))
                 .inputHandler();
-        assertEquals(new File("result.zip"), inputHandler.getFileForViewMode());
+        assertEquals(new File("result.jplag"), inputHandler.getFileForViewMode());
     }
 
     @Test
     void testViewWithOldFile() throws IOException, ExitException {
         CliInputHandler inputHandler = this
-                .runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.OLD_SUBMISSION_DIRECTORIES, new String[] {"result.zip"}))
+                .runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.OLD_SUBMISSION_DIRECTORIES, new String[] {"result.jplag"}))
                 .inputHandler();
-        assertEquals(new File("result.zip"), inputHandler.getFileForViewMode());
+        assertEquals(new File("result.jplag"), inputHandler.getFileForViewMode());
     }
 
     @Test
     void testViewWithNewFile() throws IOException, ExitException {
         CliInputHandler inputHandler = this
-                .runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.NEW_SUBMISSION_DIRECTORIES, new String[] {"result.zip"}))
+                .runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.NEW_SUBMISSION_DIRECTORIES, new String[] {"result.jplag"}))
                 .inputHandler();
-        assertEquals(new File("result.zip"), inputHandler.getFileForViewMode());
+        assertEquals(new File("result.jplag"), inputHandler.getFileForViewMode());
     }
 
     @Test
     void testViewWithResultFile() throws IOException, ExitException {
-        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.RESULT_FILE, "result.zip"))
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.RESULT_FILE, "result.jplag"))
                 .inputHandler();
-        assertEquals(new File("result.zip"), inputHandler.getFileForViewMode());
+        assertEquals(new File("result.jplag"), inputHandler.getFileForViewMode());
     }
 
     @Test
     void testViewWithMultipleFiles() {
         assertThrowsExactly(CliException.class, () -> {
-            this.runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.RESULT_FILE, "result.zip")
-                    .with(CliArgument.NEW_SUBMISSION_DIRECTORIES, new String[] {"test.zip"})).inputHandler();
+            this.runCli(args -> args.with(CliArgument.MODE, "view").with(CliArgument.RESULT_FILE, "result.jplag")
+                    .with(CliArgument.NEW_SUBMISSION_DIRECTORIES, new String[] {"test.jplag"})).inputHandler();
         });
     }
 
     @Test
     void testImplicitView() throws IOException, ExitException {
-        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.RESULT_FILE, "result.zip")).inputHandler();
-        assertEquals(new File("result.zip"), inputHandler.getFileForViewMode());
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.RESULT_FILE, "result.jplag")).inputHandler();
+        assertEquals(new File("result.jplag"), inputHandler.getFileForViewMode());
     }
 
     @Test


### PR DESCRIPTION
Updates the Mode Tests to use the .jplag ending
Updates the report viewer to use the proper content type.