### PR TITLE
Fix usage of deprecated methods in non-deprecated code

### DIFF
--- a/cli/src/main/java/de/jplag/cli/JPlagOptionsBuilder.java
+++ b/cli/src/main/java/de/jplag/cli/JPlagOptionsBuilder.java
@@ -52,7 +52,7 @@ public class JPlagOptionsBuilder {
             return jPlagOptions.withBaseCodeSubmissionDirectory(baseCodeDirectory);
         }
         logger.error("Using legacy partial base code API. Please migrate to new full path base code API.");
-        return jPlagOptions.withBaseCodeSubmissionName(baseCodePath);
+        return jPlagOptions.withBaseCodeSubmissionDirectory(baseCodeDirectory);
     }
 
     private JPlagOptions initializeJPlagOptions(Set<File> submissionDirectories, Set<File> oldSubmissionDirectories, List<String> suffixes)

--- a/core/src/test/java/de/jplag/BaseCodeTest.java
+++ b/core/src/test/java/de/jplag/BaseCodeTest.java
@@ -66,8 +66,8 @@ public class BaseCodeTest extends TestBase {
         assertEquals(1, result.getAllComparisons().size());
         JPlagComparison comparison = result.getAllComparisons().getFirst();
 
-        assertTrue(comparison.firstSubmission().hasBaseCodeMatches());
-        assertTrue(comparison.secondSubmission().hasBaseCodeMatches());
+        assertTrue(comparison.firstSubmission().hasBaseCodeComparison());
+        assertTrue(comparison.secondSubmission().hasBaseCodeComparison());
         assertEquals(0, Math.min(comparison.firstSubmission().getBaseCodeComparison().similarity(),
                 comparison.secondSubmission().getBaseCodeComparison().similarity()));
         assertEquals(0.742857, comparison.similarity(), DELTA);

--- a/core/src/test/java/de/jplag/options/JPlagOptionsTest.java
+++ b/core/src/test/java/de/jplag/options/JPlagOptionsTest.java
@@ -13,7 +13,7 @@ class JPlagOptionsTest {
     void testWithLanguageOption() {
         JavaLanguage lang = new JavaLanguage();
         JPlagOptions options = new JPlagOptions(null, Set.of(), Set.of());
-        options = options.withLanguageOption(lang);
+        options = options.withLanguage(lang);
 
         assertEquals(lang, options.language());
     }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/FileTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/FileTestData.java
@@ -23,7 +23,7 @@ class FileTestData implements TestData {
 
     @Override
     public List<Token> parseTokens(Language language) throws ParsingException {
-        return language.parse(Set.of(file));
+        return language.parse(Set.of(file), false);
     }
 
     @Override

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
@@ -25,7 +25,7 @@ class InlineTestData implements TestData {
     public List<Token> parseTokens(Language language) throws ParsingException, IOException {
         File file = File.createTempFile("testSource", language.suffixes()[0]);
         FileUtils.write(file, this.testData);
-        List<Token> tokens = language.parse(Collections.singleton(file));
+        List<Token> tokens = language.parse(Collections.singleton(file), false);
         TemporaryFileHolder.temporaryFiles.add(file);
         return tokens;
     }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -60,7 +60,7 @@ public class TokenPositionTestData implements TestData {
     public List<Token> parseTokens(Language language) throws ParsingException, IOException {
         File file = File.createTempFile("testSource", language.suffixes()[0]);
         FileUtils.write(file, String.join(System.lineSeparator(), sourceLines));
-        List<Token> tokens = language.parse(Collections.singleton(file));
+        List<Token> tokens = language.parse(Collections.singleton(file), false);
         TemporaryFileHolder.temporaryFiles.add(file);
         return tokens;
     }

--- a/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
+++ b/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
@@ -49,7 +49,7 @@ class RLanguageTest {
     @Test
     void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
+++ b/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
@@ -54,7 +54,7 @@ class RustLanguageTest {
     @Test
     void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
+++ b/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
@@ -60,7 +60,7 @@ class ScalaLanguageTest {
     @Test
     void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinter.printTokens(tokens, testFileLocation);
             logger.info(output);
 

--- a/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
+++ b/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.jplag.ParsingException;
 import de.jplag.SharedTokenType;
 import de.jplag.Token;
 import de.jplag.TokenPrinter;
@@ -58,7 +57,7 @@ class ScalaLanguageTest {
     }
 
     @Test
-    void parseTestFiles() throws ParsingException {
+    void parseTestFiles() {
         for (String fileName : testFiles) {
             List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinter.printTokens(tokens, testFileLocation);

--- a/languages/swift/src/test/java/de/jplag/swift/SwiftFrontendTest.java
+++ b/languages/swift/src/test/java/de/jplag/swift/SwiftFrontendTest.java
@@ -65,7 +65,7 @@ class SwiftFrontendTest {
     @Test
     void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)));
+            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinter.printTokens(tokens, testFileLocation, Optional.empty());
             logger.info(output);
 

--- a/languages/text/src/test/java/jplag/text/NaturalLanguageTest.java
+++ b/languages/text/src/test/java/jplag/text/NaturalLanguageTest.java
@@ -43,7 +43,7 @@ class NaturalLanguageTest {
     @Test
     void testParsingJavaDoc() throws ParsingException {
         // Parse test input
-        List<Token> result = language.parse(Set.of(new File(BASE_PATH.toFile(), TEST_SUBJECT)));
+        List<Token> result = language.parse(Set.of(new File(BASE_PATH.toFile(), TEST_SUBJECT)), false);
         logger.info(TokenPrinter.printTokens(result, baseDirectory));
 
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();
@@ -56,7 +56,7 @@ class NaturalLanguageTest {
     void testLineBreakInputs(String input) throws IOException, ParsingException {
         File testFile = File.createTempFile("input", "txt");
         Files.writeString(testFile.toPath(), input);
-        List<Token> result = language.parse(Set.of(testFile));
+        List<Token> result = language.parse(Set.of(testFile), false);
         assertEquals(1, result.size());
     }
 
@@ -65,7 +65,7 @@ class NaturalLanguageTest {
     void testTokenAfterLineBreak(String input) throws IOException, ParsingException {
         File testFile = File.createTempFile("input", "txt");
         Files.writeString(testFile.toPath(), input);
-        List<Token> result = language.parse(Set.of(testFile));
+        List<Token> result = language.parse(Set.of(testFile), false);
         assertEquals(2, result.get(0).getLine());
     }
 


### PR DESCRIPTION
This PR addresses instances where deprecated methods were used within non-deprecated code, resulting in warnings.
To avoid errors after these deprecated methods are removed sometime in the future, I changed this code to use the respective replacement methods.
This occurred mainly in older test classes.