### PR TITLE
Fix typos and extend some documentation

### DIFF
--- a/core/src/main/java/de/jplag/JPlag.java
+++ b/core/src/main/java/de/jplag/JPlag.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.jplag.clustering.ClusteringFactory;
-import de.jplag.comparison.LongestCommonSubsquenceSearch;
+import de.jplag.comparison.LongestCommonSubsequenceSearch;
 import de.jplag.exceptions.BasecodeException;
 import de.jplag.exceptions.ExitException;
 import de.jplag.exceptions.RootDirectoryException;
@@ -78,7 +78,7 @@ public class JPlag {
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
         SubmissionSet submissionSet = builder.buildSubmissionSet();
 
-        LongestCommonSubsquenceSearch comparisonStrategy = new LongestCommonSubsquenceSearch(options);
+        LongestCommonSubsequenceSearch comparisonStrategy = new LongestCommonSubsequenceSearch(options);
 
         if (options.normalize() && options.language().supportsNormalization() && options.language().requiresCoreNormalization()) {
             submissionSet.normalizeSubmissions();

--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -154,7 +154,7 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * @deprecated Use {@link hasBaseCodeComparison} instead.
+     * @deprecated Use {@link #hasBaseCodeComparison()} instead.
      */
     @Deprecated(since = "6.1.0", forRemoval = true)
     public boolean hasBaseCodeMatches() {
@@ -169,7 +169,7 @@ public class Submission implements Comparable<Submission> {
     }
 
     /**
-     * @return whether the submission is new, That is, must be checked for plagiarism.
+     * @return whether the submission is new, that is, must be checked for plagiarism.
      */
     public boolean isNew() {
         return isNew;

--- a/core/src/main/java/de/jplag/SubmissionFileData.java
+++ b/core/src/main/java/de/jplag/SubmissionFileData.java
@@ -3,11 +3,10 @@ package de.jplag;
 import java.io.File;
 
 /**
- * Contains the information about a single file in a submission. For single file submissions the submission file is the
- * same as the root.
- * @param submissionFile The file, that is part of a submission
+ * Captures information about an individual submission.
+ * @param submissionFile The file that is part of a submission
  * @param root The root of the submission
- * @param isNew Indicates weather this follows the new or the old syntax
+ * @param isNew Indicates whether this follows the new or the old syntax
  */
 public record SubmissionFileData(File submissionFile, File root, boolean isNew) {
 }

--- a/core/src/main/java/de/jplag/SubmissionFileData.java
+++ b/core/src/main/java/de/jplag/SubmissionFileData.java
@@ -3,10 +3,11 @@ package de.jplag;
 import java.io.File;
 
 /**
- * Captures information about an individual submission.
- * @param submissionFile The file that is part of a submission
- * @param root The root of the submission
- * @param isNew Indicates whether this follows the new or the old syntax
+ * Captures file information for a specific submission.
+ * @param submissionFile the entry file of the submission, which can be either a directory or a program file.
+ * @param rootDirectory the root directory in which the submission file resides.
+ * @param isNew indicates whether this submission is marked as new or old. Old submissions are only compared to new
+ * ones, not to each other.
  */
-public record SubmissionFileData(File submissionFile, File root, boolean isNew) {
+public record SubmissionFileData(File submissionFile, File rootDirectory, boolean isNew) {
 }

--- a/core/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/core/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -132,6 +132,8 @@ public class SubmissionSetBuilder {
 
     /**
      * Verify that the new and old directory sets are disjunct and modify the old submissions set if necessary.
+     * @param submissionDirectories directories of submissions which should be checked for plagiarism
+     * @param oldSubmissionDirectories directories of submissions which are considered possible sources of plagiarism
      */
     private void checkForNonOverlappingRootDirectories(Set<File> submissionDirectories, Set<File> oldSubmissionDirectories) {
 
@@ -173,6 +175,14 @@ public class SubmissionSetBuilder {
         return Optional.of(baseCodeSubmission);
     }
 
+    /**
+     * Creates a {@link SubmissionFileData} object for each submission in the given root directory.
+     * @param rootDirectory the root directory which may contain single-file submissions and submission directories.
+     * @param isNew if true, the resulting submission files will be compared to all other submissions, including "old"
+     * submissions.
+     * @return the submission file data for each single-file submission
+     * @throws RootDirectoryException if #rootDirectory is not a valid path or an I/O error occurs.
+     */
     private List<SubmissionFileData> listSubmissionFiles(File rootDirectory, boolean isNew) throws RootDirectoryException {
         if (!rootDirectory.isDirectory()) {
             throw new AssertionError("Given root is not a directory.");
@@ -192,12 +202,12 @@ public class SubmissionSetBuilder {
     }
 
     /**
-     * Process the given directory entry as a submission, the path MUST not be excluded.
+     * Process the given directory entry as a submission. The complete path of the submission MUST be preserved!
      * @param submissionName The name of the submission
      * @param submissionFile the file for the submission.
-     * @param isNew states whether submissions found in the root directory must be checked for plagiarism.
+     * @param isNew If true, the resulting submission should be checked for plagiarism.
      * @return The entry converted to a submission.
-     * @throws ExitException when an error has been found with the entry.
+     * @throws ExitException when an error has been found while processing the entry.
      */
     private Submission processSubmission(String submissionName, File submissionFile, boolean isNew) throws ExitException {
         File file = submissionFile;

--- a/core/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/core/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -235,7 +235,7 @@ public class SubmissionSetBuilder {
         } else if (file.submissionFile().isFile() && !hasValidSuffix(file.submissionFile())) {
             logger.error("Ignore submission with invalid suffix: {}", file.submissionFile().getName());
         } else {
-            String rootDirectoryPrefix = multipleRoots ? file.root().getName() + File.separator : "";
+            String rootDirectoryPrefix = multipleRoots ? file.rootDirectory().getName() + File.separator : "";
             String submissionName = rootDirectoryPrefix + file.submissionFile().getName();
             Submission submission = processSubmission(submissionName, file.submissionFile(), file.isNew());
             foundSubmissions.put(submission.getRoot(), submission);

--- a/core/src/main/java/de/jplag/comparison/LongestCommonSubsequenceSearch.java
+++ b/core/src/main/java/de/jplag/comparison/LongestCommonSubsequenceSearch.java
@@ -20,9 +20,9 @@ import de.jplag.options.JPlagOptions;
  * Implements a parallelized token-based longest common subsequence search for all pairs of programs in a given set of
  * programs.
  */
-public class LongestCommonSubsquenceSearch {
+public class LongestCommonSubsequenceSearch {
 
-    private final Logger logger = LoggerFactory.getLogger(LongestCommonSubsquenceSearch.class);
+    private final Logger logger = LoggerFactory.getLogger(LongestCommonSubsequenceSearch.class);
 
     private final JPlagOptions options;
 
@@ -30,7 +30,7 @@ public class LongestCommonSubsquenceSearch {
      * Creates an instance of the subsequence search algorithm.
      * @param options specifies relevant parameters for the comparison.
      */
-    public LongestCommonSubsquenceSearch(JPlagOptions options) {
+    public LongestCommonSubsequenceSearch(JPlagOptions options) {
         this.options = options;
     }
 

--- a/core/src/test/java/de/jplag/merging/MergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MergingTest.java
@@ -20,7 +20,7 @@ import de.jplag.SubmissionSet;
 import de.jplag.SubmissionSetBuilder;
 import de.jplag.TestBase;
 import de.jplag.Token;
-import de.jplag.comparison.LongestCommonSubsquenceSearch;
+import de.jplag.comparison.LongestCommonSubsequenceSearch;
 import de.jplag.exceptions.ExitException;
 import de.jplag.options.JPlagOptions;
 
@@ -35,7 +35,7 @@ class MergingTest extends TestBase {
     private List<Match> matches;
     private List<JPlagComparison> comparisonsBefore;
     private List<JPlagComparison> comparisonsAfter;
-    private final LongestCommonSubsquenceSearch comparisonStrategy;
+    private final LongestCommonSubsequenceSearch comparisonStrategy;
     private final SubmissionSet submissionSet;
     private static final int MINIMUM_NEIGHBOR_LENGTH = 1;
     private static final int MAXIMUM_GAP_SIZE = 10;
@@ -48,7 +48,7 @@ class MergingTest extends TestBase {
         SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
         submissionSet = builder.buildSubmissionSet();
 
-        comparisonStrategy = new LongestCommonSubsquenceSearch(options);
+        comparisonStrategy = new LongestCommonSubsequenceSearch(options);
     }
 
     @BeforeEach

--- a/docs/1.-How-to-Use-JPlag.md
+++ b/docs/1.-How-to-Use-JPlag.md
@@ -156,7 +156,7 @@ The target location of the report can be specified with the `-r` flag.
 
 If the `-r` is not specified, the location defaults `result.jplag`. Specifying the `-r` flag with a path `/path/to/desiredFolder` results in the report being created as `/path/to/desiredFolder.jplag`.
 
-The report will always be zipped unless there is an error during the zipping process. If the zipping process fails, the report will be available in an unzipped version under the specified location. Note that the result file use the file ending `.jplag`.
+The report will always be zipped unless there is an error during the zipping process. If the zipping process fails, the report will be available in an unzipped version under the specified location. Note that the result files use the file extension `.jplag`.
 
 ## Viewing Reports
 

--- a/language-api/src/main/java/de/jplag/Language.java
+++ b/language-api/src/main/java/de/jplag/Language.java
@@ -32,7 +32,7 @@ public interface Language {
     int minimumTokenMatch();
 
     /**
-     * Parses a set of files. Override this method, if you don't require normalization.
+     * Parses a set of files. Override this method if you do not require normalization.
      * @param files are the files to parse.
      * @return the list of parsed JPlag tokens.
      * @throws ParsingException if an error during parsing the files occurred.
@@ -44,7 +44,7 @@ public interface Language {
     }
 
     /**
-     * Parses a set of files. Override this method, if you require normalization within the language module.
+     * Parses a set of files. Override this method if you require normalization within the language module.
      * @param files are the files to parse.
      * @param normalize True, if the tokens should be normalized
      * @return the list of parsed JPlag tokens.
@@ -53,7 +53,7 @@ public interface Language {
     List<Token> parse(Set<File> files, boolean normalize) throws ParsingException;
 
     /**
-     * Indicates whether the tokens returned by parse have semantic information added to them, i.e. whether the token
+     * Indicates whether the tokens returned by parse have semantic information added to them, i.e., whether the token
      * attribute semantics is null or not.
      */
     default boolean tokensHaveSemantics() {
@@ -68,8 +68,8 @@ public interface Language {
     }
 
     /**
-     * Indicates whether the input files (code) should be used as representation in the report, or different files that form
-     * a view on the input files.
+     * Indicates whether the input code files should be used as representation in the report, or different files that form a
+     * view on the input files.
      */
     default boolean useViewFiles() {
         return false;
@@ -99,16 +99,16 @@ public interface Language {
     }
 
     /**
-     * Re-orders the provided submission according the requirements of the language.
+     * Reorders the provided submission according the requirements of the language.
      * @param submissions is the list of submissions.
-     * @return the re-ordered list.
+     * @return the reordered list.
      */
     default List<File> customizeSubmissionOrder(List<File> submissions) {
         return submissions;
     }
 
     /**
-     * @return True, if this language supports token sequence normalization. This does not include other normalization
+     * @return True if this language supports token sequence normalization. This does not include other normalization
      * mechanisms that might be part of the language modules.
      */
     default boolean supportsNormalization() {
@@ -116,8 +116,8 @@ public interface Language {
     }
 
     /**
-     * Override this method, if you need normalization within the language module, but not in the core module.
-     * @return True, If the core normalization should be used.
+     * Override this method if you need normalization within the language module, but not in the core module.
+     * @return True if the core normalization should be used.
      */
     default boolean requiresCoreNormalization() {
         return true;


### PR DESCRIPTION
This PR fixes some typos, primarily in the JavaDoc documentation, as well as in a class name, and adds some detail here and there.
Naturally, this covers only a small part of the project, and other parts need to be revised in the future. Still, every step helps!