### PR TITLE
Fix syntax highlighting

### DIFF
--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -81,7 +81,7 @@
         @selection-changed="(index: number) => changeFileSorting(index)"
       />
     </Container>
-    <div ref="styleholder" class="row-span-0 col-span-0"></div>
+    <div ref="styleholder" class="col-span-0 row-span-0"></div>
     <FilesContainer
       ref="panel1"
       :files="filesOfFirst"
@@ -219,14 +219,7 @@ function print() {
 const styleholder: Ref<Node | null> = ref(null)
 
 onMounted(() => {
-  if (styleholder.value == null) {
-    console.warn()
-    return
-  }
-  const styleHolderDiv = styleholder.value as Node
-  const styleElement = document.createElement('style')
-  styleElement.innerHTML = store().uiState.useDarkMode ? hljsDarkMode : hljsLightMode
-  styleHolderDiv.appendChild(styleElement)
+  onThemeUpdate(store().uiState.useDarkMode)
 })
 
 const useDarkMode = computed(() => {
@@ -234,15 +227,22 @@ const useDarkMode = computed(() => {
 })
 
 watch(useDarkMode, (newValue) => {
+  onThemeUpdate(newValue)
+})
+
+function onThemeUpdate(useDarkMode: boolean) {
   if (styleholder.value == null) {
+    console.warn('Could not find styleholder. Syntax highlighting will not work.')
     return
   }
   const styleHolderDiv = styleholder.value as Node
-  styleHolderDiv.removeChild(styleHolderDiv.firstChild as Node)
+  while (styleHolderDiv.hasChildNodes()) {
+    styleHolderDiv.removeChild(styleHolderDiv.firstChild as Node)
+  }
   const styleElement = document.createElement('style')
-  styleElement.innerHTML = newValue ? hljsDarkMode : hljsLightMode
+  styleElement.innerHTML = useDarkMode ? hljsDarkMode : hljsLightMode
   styleHolderDiv.appendChild(styleElement)
-})
+}
 
 onErrorCaptured((error) => {
   redirectOnError(error, 'Error displaying comparison:\n', 'OverviewView', 'Back to overview')

--- a/report-viewer/src/views/ComparisonView.vue
+++ b/report-viewer/src/views/ComparisonView.vue
@@ -81,7 +81,7 @@
         @selection-changed="(index: number) => changeFileSorting(index)"
       />
     </Container>
-
+    <div ref="styleholder" class="row-span-0 col-span-0"></div>
     <FilesContainer
       ref="panel1"
       :files="filesOfFirst"
@@ -220,6 +220,7 @@ const styleholder: Ref<Node | null> = ref(null)
 
 onMounted(() => {
   if (styleholder.value == null) {
+    console.warn()
     return
   }
   const styleHolderDiv = styleholder.value as Node


### PR DESCRIPTION
In #2306 the styleholder for the hljs stylesheet got removed. 
Readded that

Also adds a warning when the holder was not found