### PR TITLE
Remove unzipped file based local mode

### DIFF
--- a/report-viewer/src/model/factories/BaseFactory.ts
+++ b/report-viewer/src/model/factories/BaseFactory.ts
@@ -14,30 +14,32 @@ export class BaseFactory {
    * @throws Error if the file could not be found
    */
   protected static async getFile(path: string): Promise<string> {
-    if (store().state.localModeUsed) {
-      return await (await this.getLocalFile(`/files/${path}`)).text()
-    } else if (store().state.zipModeUsed) {
-      return this.getFileFromStore(path)
-    } else if (await this.useLocalZipMode()) {
+    let storeFile = this.getFileFromStore(path)
+    if (storeFile != undefined) {
+      return storeFile
+    }
+
+    if (await this.useLocalZipMode()) {
       await new ZipFileHandler().handleFile(await this.getLocalFile(this.zipFileName))
-      store().setLoadingType('zip')
-      return this.getFileFromStore(path)
     } else if (import.meta.env.MODE == 'demo' || import.meta.env.MODE == 'dev-demo') {
       await new ZipFileHandler().handleFile(await this.getLocalFile('example.jplag'))
-      store().setLoadingType('zip')
-      return this.getFileFromStore(path)
     }
-    throw new Error('No loading type specified')
+
+    storeFile = this.getFileFromStore(path)
+    if (storeFile != undefined) {
+      return storeFile
+    }
+    throw new Error(`Could not find ${path} report files.`)
   }
 
-  private static getFileFromStore(path: string): string {
+  private static getFileFromStore(path: string): string | undefined {
     const index = Object.keys(store().state.files).find((name) => name.endsWith(path))
     if (index == undefined) {
-      throw new Error(`Could not find ${path} in zip file.`)
+      return undefined
     }
     const file = store().state.files[index]
     if (file == undefined) {
-      throw new Error(`Could not load ${path}.`)
+      return undefined
     }
     return file
   }

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -102,9 +102,6 @@ export class ComparisonFactory extends BaseFactory {
   }
 
   private static async getSubmissionFileContent(submissionId: string, fileName: string) {
-    if (store().state.localModeUsed && !store().state.zipModeUsed) {
-      return await this.getLocalFile('files/' + fileName).then((file) => file.text())
-    }
     const file = store().getSubmissionFile(submissionId, fileName)
     if (file == undefined) {
       throw new Error(

--- a/report-viewer/src/stores/state.ts
+++ b/report-viewer/src/stores/state.ts
@@ -20,14 +20,6 @@ export interface State {
    */
   files: Record<string, string>
   submissions: Record<string, Map<string, SubmissionFile>>
-  /**
-   * Indicates whether local mode is used.
-   */
-  localModeUsed: boolean
-  /**
-   * Indicates whether zip mode is used.
-   */
-  zipModeUsed: boolean
 
   fileIdToDisplayName: Map<string, string>
   submissionIdsToComparisonFileName: Map<string, Map<string, string>>

--- a/report-viewer/src/stores/store.ts
+++ b/report-viewer/src/stores/store.ts
@@ -16,9 +16,6 @@ const store = defineStore('store', {
       anonymousIds: {},
       files: {},
       submissions: {},
-      // Mode that was used to load the files
-      localModeUsed: false,
-      zipModeUsed: false,
       fileIdToDisplayName: new Map(),
       uploadedFileName: ''
     },
@@ -131,8 +128,6 @@ const store = defineStore('store', {
         anonymousIds: {},
         files: {},
         submissions: {},
-        localModeUsed: false,
-        zipModeUsed: false,
         fileIdToDisplayName: new Map(),
         uploadedFileName: ''
       }
@@ -194,14 +189,6 @@ const store = defineStore('store', {
         submissionFile.fileName,
         submissionFile
       )
-    },
-    /**
-     * Sets the loading type
-     * @param payload Type used to input JPlag results
-     */
-    setLoadingType(loadingType: 'zip' | 'local') {
-      this.state.localModeUsed = loadingType == 'local'
-      this.state.zipModeUsed = loadingType == 'zip'
     },
     /**
      * Switches whether darkMode is being used for the UI

--- a/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/src/views/FileUploadView.vue
@@ -36,9 +36,6 @@
           <div>Or click here to select a file</div>
         </div>
         <div>(No files will be uploaded)</div>
-        <Button v-if="localFiles" class="mx-auto mt-8 w-fit" @click="continueWithLocal">
-          Continue with local files
-        </Button>
         <a
           href="https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag"
           target="_blank"
@@ -62,7 +59,6 @@ import { onErrorCaptured, ref, type Ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { router } from '@/router'
 import { store } from '@/stores/store'
-import Button from '@/components/ButtonComponent.vue'
 import VersionInfoComponent from '@/components/VersionInfoComponent.vue'
 import LoadingCircle from '@/components/LoadingCircle.vue'
 import { ZipFileHandler } from '@/model/fileHandling/ZipFileHandler'
@@ -71,13 +67,6 @@ import { BaseFactory } from '@/model/factories/BaseFactory'
 store().clearStore()
 
 const exampleFiles = ref(import.meta.env.MODE == 'demo' || import.meta.env.MODE == 'dev-demo')
-const localFiles = ref(false)
-// Checks whether local files exist
-BaseFactory.getLocalFile('files/overview.json')
-  .then(() => {
-    localFiles.value = true
-  })
-  .catch(() => {})
 
 BaseFactory.useLocalZipMode().then((value) => {
   if (value) {
@@ -89,7 +78,7 @@ BaseFactory.useLocalZipMode().then((value) => {
 document.title = 'JPlag Report Viewer'
 
 const loadingFiles = ref(false)
-type fileMethod = 'query' | 'local' | 'upload' | 'unknown'
+type fileMethod = 'query' | 'upload' | 'unknown'
 const errors: Ref<{ error: Error; source: fileMethod }[]> = ref([])
 
 // Loads file passed in query param, if any.
@@ -127,7 +116,6 @@ async function handleFile(file: Blob) {
     case 'application/x-zip-compressed':
     case 'application/x-zip':
     case '':
-      store().setLoadingType('zip')
       await new ZipFileHandler().handleFile(file)
       return navigateToOverview()
     default:
@@ -188,15 +176,6 @@ async function loadQueryFile(url: URL) {
   }
 }
 
-/**
- * Handles click on Continue with local files.
- */
-function continueWithLocal() {
-  store().state.uploadedFileName = BaseFactory.zipFileName
-  store().setLoadingType('local')
-  navigateToOverview()
-}
-
 function registerError(error: Error, source: fileMethod) {
   loadingFiles.value = false
   store().state.uploadedFileName = ''
@@ -211,7 +190,6 @@ function getErrorText() {
     }
     const longNames = {
       query: 'querying files',
-      local: 'getting local files',
       upload: 'loading files'
     }
     return 'Error during ' + longNames[source]

--- a/report-viewer/tests/unit/model/factories/ComparisonFactory.test.ts
+++ b/report-viewer/tests/unit/model/factories/ComparisonFactory.test.ts
@@ -8,7 +8,6 @@ import { setActivePinia, createPinia } from 'pinia'
 describe('Test JSON to Comparison', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    store().setLoadingType('zip')
   })
 
   it('Post 5.0', async () => {

--- a/report-viewer/tests/unit/model/factories/OptionsFactory.test.ts
+++ b/report-viewer/tests/unit/model/factories/OptionsFactory.test.ts
@@ -9,7 +9,6 @@ import { store } from '@/stores/store'
 describe('Test JSON to Options', async () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    store().setLoadingType('zip')
   })
 
   it('Test Valid JSON', async () => {

--- a/report-viewer/tests/unit/model/factories/OverviewFactory.test.ts
+++ b/report-viewer/tests/unit/model/factories/OverviewFactory.test.ts
@@ -16,7 +16,6 @@ describe('Test JSON to Overview', () => {
 
   beforeEach(() => {
     setActivePinia(createPinia())
-    store().setLoadingType('zip')
   })
 
   it('Post 5.0', async () => {


### PR DESCRIPTION
The old local mode where you could leave an unzipped report in the files folder was still present.
With the new report based local mode, we do not see a use for it anymore.

This PR removes that mode