### PR TITLE
Switch pre-commit to bash

### DIFF
--- a/gitHooks/hooks/pre-commit
+++ b/gitHooks/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Running pre commit checks"
 


### PR DESCRIPTION
Fixes #2400

As the Issue states, some Linux systems have a non bash-compatible shell as /bin/bash.

I decided to keep the script bash-compatible, because I think it's more wide-spread than posix compliant shells. On Windows, especially, the execution relies on the in-built shell of git, which is bash.