### PR TITLE
Make click on bar diagramm scroll to bucket in table

### DIFF
--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -405,7 +405,10 @@ function isHighlightedRow(item: ComparisonListElement) {
   )
 }
 
-function scrollToItem(itemIndex: number) {
+function scrollToItem(itemIndex?: number) {
+  if (!itemIndex) {
+    dynamicScroller.value?.scrollToBottom()
+  }
   dynamicScroller.value?.scrollToItem(itemIndex)
 }
 defineExpose({

--- a/report-viewer/src/components/ComparisonsTable.vue
+++ b/report-viewer/src/components/ComparisonsTable.vue
@@ -405,6 +405,13 @@ function isHighlightedRow(item: ComparisonListElement) {
   )
 }
 
+function scrollToItem(itemIndex: number) {
+  dynamicScroller.value?.scrollToItem(itemIndex)
+}
+defineExpose({
+  scrollToItem
+})
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const dynamicScroller: Ref<any | null> = ref(null)
 

--- a/report-viewer/src/components/distributionDiagram/DistributionDiagram.vue
+++ b/report-viewer/src/components/distributionDiagram/DistributionDiagram.vue
@@ -4,7 +4,7 @@
 <template>
   <div class="flex flex-col">
     <div class="h-3/4 w-full print:h-fit print:w-fit">
-      <Bar :data="chartData" :options="options" />
+      <canvas ref="graphCanvas"></canvas>
     </div>
 
     <DistributionDiagramOptions class="grow print:grow-0" />
@@ -12,8 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType } from 'vue'
-import { Bar } from 'vue-chartjs'
+import { computed, onMounted, ref, watch, type PropType, type Ref } from 'vue'
 import { Chart, registerables } from 'chart.js'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import { graphColors } from '@/utils/ColorUtils'
@@ -35,6 +34,10 @@ const props = defineProps({
     default: 'linear'
   }
 })
+
+const emit = defineEmits<{
+  (e: 'click:upperPercentile', UpperPercentile: number): void
+}>()
 
 const graphOptions = computed(() => store().uiState.distributionChartConfig)
 const distribution = computed(() => props.distributions[graphOptions.value.metric])
@@ -153,6 +156,21 @@ const options = computed(() => {
         align: 'end' as const,
         onClick: () => {}
       }
+    },
+    // @ts-expect-error As there is not type to satisfy both the getElementsAtEventForMode function and Chart creations we leave the type out
+    onClick: (e) => {
+      if (!chart.value) {
+        return
+      }
+
+      const points = chart.value.getElementsAtEventForMode(e, 'nearest', { intersect: true }, true)
+      if (points.length <= 0 || points.length > 1) {
+        return
+      }
+      const index = points[0].index
+      const clickedBucket = distributionData.value.length - index
+      const clickedUpperPercentile = clickedBucket * (100 / graphOptions.value.bucketCount)
+      emit('click:upperPercentile', clickedUpperPercentile)
     }
   }
 })
@@ -171,4 +189,44 @@ function getDataLabelFontSize() {
   }
   return 12
 }
+
+const chart: Ref<Chart | null> = ref(null)
+const loaded: Ref<boolean> = ref(false)
+const graphCanvas: Ref<HTMLCanvasElement | null> = ref(null)
+
+function drawGraph() {
+  if (chart.value != null) {
+    chart.value.destroy()
+  }
+  if (graphCanvas.value == null) {
+    loaded.value = false
+    return
+  }
+  const ctx = graphCanvas.value.getContext('2d')
+  if (ctx == null) {
+    loaded.value = false
+    return
+  }
+  chart.value = new Chart(ctx, {
+    type: 'bar',
+    data: chartData.value,
+    options: options.value
+  })
+  loaded.value = true
+}
+
+onMounted(() => {
+  drawGraph()
+})
+watch(
+  computed(() => {
+    return {
+      d: chartData.value,
+      o: options.value
+    }
+  }),
+  () => {
+    drawGraph()
+  }
+)
 </script>

--- a/report-viewer/src/model/ui/ComparisonSorting.ts
+++ b/report-viewer/src/model/ui/ComparisonSorting.ts
@@ -71,6 +71,17 @@ export namespace Column {
     maximumSimilarity,
     cluster
   }
+
+  export function getSortingFromMetric(metric: MetricType) {
+    switch (metric) {
+      case MetricType.AVERAGE:
+        return averageSimilarity
+      case MetricType.MAXIMUM:
+        return maximumSimilarity
+      default:
+        return averageSimilarity
+    }
+  }
 }
 
 export interface ComparisonTableSorting {

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -213,7 +213,7 @@ function onBarClicked(upperPercentile: number) {
 
   // we scroll in the next tick so the table can adjust its sorting to the new metric
   nextTick(() => {
-    comparisonTable.value?.scrollToItem(index)
+    comparisonTable.value?.scrollToItem(value < 0 ? undefined : index)
   })
 }
 </script>

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -92,13 +92,18 @@
 
     <Container class="col-start-1 row-start-2 flex flex-col overflow-hidden print:overflow-visible">
       <h2>Distribution of Comparisons:</h2>
-      <DistributionDiagram :distributions="distributions" class="grow print:flex-none" />
+      <DistributionDiagram
+        :distributions="distributions"
+        class="grow print:flex-none"
+        @click:upper-percentile="onBarClicked"
+      />
     </Container>
 
     <Container
       class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2 print:hidden"
     >
       <ComparisonsTable
+        ref="comparisonTable"
         :clusters="clusters"
         :top-comparisons="topComparisons"
         class="min-h-0 max-w-full flex-1 print:min-h-full print:grow"
@@ -115,7 +120,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType, onErrorCaptured } from 'vue'
+import { computed, type PropType, onErrorCaptured, type Ref, ref, nextTick } from 'vue'
 import { redirectOnError, router } from '@/router'
 import DistributionDiagram from '@/components/distributionDiagram/DistributionDiagram.vue'
 import ComparisonsTable from '@/components/ComparisonsTable.vue'
@@ -130,6 +135,7 @@ import type { RunInformation } from '@/model/RunInformation'
 import type { DistributionMap } from '@/model/Distribution'
 import type { Cluster } from '@/model/Cluster'
 import InfoIcon from '@/components/InfoIcon.vue'
+import { Column, Direction } from '@/model/ui/ComparisonSorting'
 
 const props = defineProps({
   topComparisons: {
@@ -172,4 +178,42 @@ onErrorCaptured((error) => {
   redirectOnError(error, 'Error displaying overview:\n')
   return false
 })
+
+const comparisonTable: Ref<typeof ComparisonsTable | null> = ref(null)
+function onBarClicked(upperPercentile: number) {
+  const adjustedPercentile = upperPercentile / 100
+  if (!comparisonTable.value) {
+    return
+  }
+  const metric = store().uiState.distributionChartConfig.metric
+  store().uiState.comparisonTableSorting = {
+    column: Column.getSortingFromMetric(metric),
+    direction: Direction.descending
+  }
+
+  // determine largest similarity value that is still in the bucket
+  let value = -1
+  for (let i = 0; i < props.topComparisons.length; i++) {
+    const comparison = props.topComparisons[i]
+    if (
+      comparison.similarities[metric] <= adjustedPercentile &&
+      comparison.similarities[metric] > value
+    ) {
+      value = comparison.similarities[metric]
+    }
+  }
+  // the number of elements in this metric that are larger than that value equal the index in the list sorted by that metric
+  let index = 0
+  for (let i = 0; i < props.topComparisons.length; i++) {
+    const comparison = props.topComparisons[i]
+    if (comparison.similarities[metric] > value) {
+      index++
+    }
+  }
+
+  // we scroll in the next tick so the table can adjust its sorting to the new metric
+  nextTick(() => {
+    comparisonTable.value?.scrollToItem(index)
+  })
+}
 </script>


### PR DESCRIPTION
When clicking on a bar in the distribution diagram, the report viewer now finds the comparison with the highest similarity in the bucket of this bar. It then switches the metric in the comparison table to the same metric used in the distribution diagram and scrolls to the comparison. Thus, the top comparisons of this bucket will be visible.
If the comparison is not included in the exported comparisons, it scrolls to the table bottom, which has the warning that not all comparisons are included


For this, the wrapper from the `vue-chartjs` library had to be exchanged for a canvas and a manual creation of the `Chart` object. This is due to the click function requiring the chart object to run on and the wrapper not exposing it