### PR TITLE
Remove link to hosted report viewer

### DIFF
--- a/cli/src/main/java/de/jplag/cli/OutputFileGenerator.java
+++ b/cli/src/main/java/de/jplag/cli/OutputFileGenerator.java
@@ -49,6 +49,6 @@ public final class OutputFileGenerator {
         ReportObjectFactory reportObjectFactory = new ReportObjectFactory(outputFile);
         reportObjectFactory.createAndSaveReport(result);
         logger.info("Successfully written the result: {}", outputFile.getPath());
-        logger.info("View the result using --mode or at: https://jplag.github.io/JPlag/");
+        logger.info("View the result using --mode");
     }
 }

--- a/docs/1.-How-to-Use-JPlag.md
+++ b/docs/1.-How-to-Use-JPlag.md
@@ -170,8 +170,6 @@ This can be prevented by passing `--mode run` (`java -jar jplag.jar --mode run <
 
 Additional information can be found [here](7.-Report-Viewer.md)
 
-An online version of the viewer is still hosted at https://jplag.github.io/JPlag/ in order to view pre-v6.0.0 reports. Your submissions will neither be uploaded to a server nor stored permanently. They are stored as long as you view them. Once you refresh the page, all information will be erased.
-
 ## Basic Concepts
 
 This section explains some fundamental concepts about JPlag that make it easier to understand and use.


### PR DESCRIPTION
Removes references to hosted report viewer
- In the cli output
- In the wiki, since old reports can now be opened with the new jars and the old version mode

fixes #2411 