### PR TITLE
Remove deprecated call to length in BaseCodeReportWriter

### DIFF
--- a/core/src/main/java/de/jplag/reporting/jsonfactory/BaseCodeReportWriter.java
+++ b/core/src/main/java/de/jplag/reporting/jsonfactory/BaseCodeReportWriter.java
@@ -77,7 +77,9 @@ public class BaseCodeReportWriter {
         CodePosition endPosition = new CodePosition(end.getLine(), end.getColumn() + end.getLength() - 1,
                 takeLeft ? match.endOfFirst() : match.endOfSecond());
 
+        int length = takeLeft ? match.lengthOfFirst() : match.lengthOfSecond();
+
         return new BaseCodeMatch(FilePathUtil.getRelativeSubmissionPath(start.getFile(), submission, submissionToIdFunction).toString(),
-                startPosition, endPosition, match.length());
+                startPosition, endPosition, length);
     }
 }


### PR DESCRIPTION
Removes the deprecated call to length of Match and instead choses the length of the correct side