### PR TITLE
Fix relativization of paths

### DIFF
--- a/core/src/main/java/de/jplag/reporting/FilePathUtil.java
+++ b/core/src/main/java/de/jplag/reporting/FilePathUtil.java
@@ -34,7 +34,7 @@ public final class FilePathUtil {
      */
     public static Path forceRelativePath(Path path) {
         if (path.isAbsolute()) {
-            return Path.of("/").relativize(path);
+            return Path.of("./").toAbsolutePath().relativize(path);
         }
         return path;
     }


### PR DESCRIPTION
Relativization of paths now uses the current directory as an absolute base
Fixes #2441 

@tsaglam @TwoOfTwelve Could you quickly test this on your operating systems. Make sure to give the jar at least one submission path as an absolute path. Check that the report has all paths in the information view as relative