### PR TITLE
Enable resizing on overview

### DIFF
--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -3,9 +3,10 @@
 -->
 <template>
   <div
-    class="grid grid-cols-1 grid-rows-[auto_800px_90vh] gap-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:overflow-hidden print:grid-cols-1 print:grid-rows-[auto_auto]"
+    ref="container"
+    class="grid grid-cols-1 grid-rows-[auto_800px_90vh] gap-y-5 md:grid-cols-[1fr_20px_1fr] md:grid-rows-[auto_1fr] md:overflow-hidden print:grid-cols-1 print:grid-rows-[auto_auto]"
   >
-    <Container class="col-start-1 row-start-1 md:col-end-3 md:row-end-2">
+    <Container class="col-start-1 row-start-1 md:col-end-4 md:row-end-2">
       <div class="flex flex-col gap-x-5 md:flex-row md:items-center">
         <h2>JPlag Report</h2>
         <ToolTipComponent v-if="runInformation.failedSubmissions.length > 0" direction="bottom">
@@ -99,8 +100,12 @@
       />
     </Container>
 
+    <div ref="resizer" class="hidden w-5 cursor-col-resize md:col-start-2 md:row-start-2 md:flex">
+      <!-- Resizer -->
+    </div>
+
     <Container
-      class="col-start-1 row-start-3 flex overflow-hidden md:col-start-2 md:row-start-2 print:hidden"
+      class="col-start-1 row-start-3 flex overflow-hidden md:col-start-3 md:row-start-2 print:hidden"
     >
       <ComparisonsTable
         ref="comparisonTable"
@@ -120,7 +125,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, type PropType, onErrorCaptured, type Ref, ref, nextTick } from 'vue'
+import { computed, type PropType, onErrorCaptured, type Ref, ref, nextTick, onMounted } from 'vue'
 import { redirectOnError, router } from '@/router'
 import DistributionDiagram from '@/components/distributionDiagram/DistributionDiagram.vue'
 import ComparisonsTable from '@/components/ComparisonsTable.vue'
@@ -214,4 +219,44 @@ function onBarClicked(upperPercentile: number) {
     comparisonTable.value?.scrollToItem(value < 0 ? undefined : index)
   })
 }
+
+const isResizing = ref(false)
+const resizer = ref<HTMLDivElement | null>(null)
+const container = ref<HTMLDivElement | null>(null)
+onMounted(() => {
+  if (resizer.value) {
+    resizer.value.addEventListener('mousedown', (event) => {
+      isResizing.value = true
+      document.body.style.cursor = 'col-resize'
+      event.preventDefault()
+    })
+  }
+})
+document.addEventListener('mouseup', () => {
+  if (isResizing.value) {
+    isResizing.value = false
+    document.body.style.cursor = 'default'
+  }
+})
+const minWidthPercentage = 33 // Minimum width percentage for each column
+document.addEventListener('mousemove', (event) => {
+  if (isResizing.value && resizer.value && container.value) {
+    const containerRect = container.value.getBoundingClientRect()
+    const containerWidth = containerRect.width
+    const leftWidth = event.clientX - containerRect.left
+    const rightWidth = containerWidth - leftWidth - resizer.value.offsetWidth
+    let leftPercentage = (leftWidth / containerWidth) * 100
+    let rightPercentage = (rightWidth / containerWidth) * 100
+    if (leftPercentage < minWidthPercentage) {
+      leftPercentage = minWidthPercentage // Minimum width for left column
+      rightPercentage = 100 - leftPercentage
+    }
+    if (rightPercentage < minWidthPercentage) {
+      rightPercentage = minWidthPercentage // Minimum width for right column
+      leftPercentage = 100 - rightPercentage
+    }
+
+    container.value.style.gridTemplateColumns = `${leftPercentage}fr ${resizer.value.offsetWidth}px ${rightPercentage}fr`
+  }
+})
 </script>


### PR DESCRIPTION
This PR adds the ability to move the border between the distribution diagram and the comparison table.
![grafik](https://github.com/user-attachments/assets/6624e654-dd6b-41e6-9c98-03ebc780b6ba)
![grafik](https://github.com/user-attachments/assets/811237e3-1ed3-4099-806c-4fe041ced785)
