### PR TITLE
Improve naming in the core algorithm

### DIFF
--- a/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
@@ -29,9 +29,9 @@ public class GreedyStringTiling {
     private final JPlagOptions options;
     private final Map<Submission, Set<Token>> baseCodeMarkings = new IdentityHashMap<>();
 
-    private final Map<Submission, SubsequenceHashLookupTable> cachedHashLookupTables = Collections.synchronizedMap(new IdentityHashMap<>());
+    private final Map<Submission, RollingTokenHashTable> cachedHashLookupTables = Collections.synchronizedMap(new IdentityHashMap<>());
 
-    private final TokenValueMapper tokenValueMapper;
+    private final TokenSequenceMapper tokenValueMapper;
 
     private static final String ERROR_INDEX_OUT_OF_BOUNDS = """
                 GST index out of bounds. This is probably a random issue caused by multithreading issues.
@@ -42,7 +42,7 @@ public class GreedyStringTiling {
                 Submission (other): %s
             """.trim().stripIndent();
 
-    public GreedyStringTiling(JPlagOptions options, TokenValueMapper tokenValueMapper) {
+    public GreedyStringTiling(JPlagOptions options, TokenSequenceMapper tokenValueMapper) {
         this.options = options;
         // Ensures 1 <= neighborLength <= minimumTokenMatch
         int minimumNeighborLength = Math.clamp(options.mergingOptions().minimumNeighborLength(), 1, options.minimumTokenMatch());
@@ -101,7 +101,7 @@ public class GreedyStringTiling {
             smallerSubmission = secondSubmission;
             largerSubmission = firstSubmission;
         }
-        return compareInternal(smallerSubmission, largerSubmission);
+        return compareOrdered(smallerSubmission, largerSubmission);
     }
 
     /**
@@ -110,15 +110,15 @@ public class GreedyStringTiling {
      * @param rightSubmission is the submission with the larger sequence.
      * @return the comparison results.
      */
-    private JPlagComparison compareInternal(Submission leftSubmission, Submission rightSubmission) {
-        int[] leftValues = this.tokenValueMapper.getTokenValuesFor(leftSubmission);
-        int[] rightValues = this.tokenValueMapper.getTokenValuesFor(rightSubmission);
+    private JPlagComparison compareOrdered(Submission leftSubmission, Submission rightSubmission) {
+        int[] leftTokens = this.tokenValueMapper.getTokenSequenceFor(leftSubmission);
+        int[] rightTokens = this.tokenValueMapper.getTokenSequenceFor(rightSubmission);
 
-        boolean[] leftMarked = calculateInitiallyMarked(leftSubmission);
-        boolean[] rightMarked = calculateInitiallyMarked(rightSubmission);
+        boolean[] leftExcludedTokens = calculateExcludedTokens(leftSubmission);
+        boolean[] rightExcludedTokens = calculateExcludedTokens(rightSubmission);
 
-        SubsequenceHashLookupTable leftLookupTable = subsequenceHashLookupTableForSubmission(leftSubmission, leftMarked);
-        SubsequenceHashLookupTable rightLookupTable = subsequenceHashLookupTableForSubmission(rightSubmission, rightMarked);
+        RollingTokenHashTable leftLookupTable = getSubsequenceHashTableFor(leftSubmission, leftExcludedTokens);
+        RollingTokenHashTable rightLookupTable = getSubsequenceHashTableFor(rightSubmission, rightExcludedTokens);
 
         int maximumMatchLength;
         List<Match> globalMatches = new ArrayList<>();
@@ -126,23 +126,22 @@ public class GreedyStringTiling {
         do {
             maximumMatchLength = minimumMatchLength;
             List<Match> iterationMatches = new ArrayList<>();
-            for (int leftStartIndex = 0; leftStartIndex < leftValues.length - maximumMatchLength; leftStartIndex++) {
-                int leftSubsequenceHash = leftLookupTable.subsequenceHashForStartIndex(leftStartIndex);
-                if (checkMark(leftMarked, leftStartIndex, leftSubmission, rightSubmission)
-                        || leftSubsequenceHash == SubsequenceHashLookupTable.NO_HASH) {
+            for (int leftStartIndex = 0; leftStartIndex < leftTokens.length - maximumMatchLength; leftStartIndex++) {
+                int leftSubsequenceHash = leftLookupTable.getHashAt(leftStartIndex);
+                if (isTokenExcludedAt(leftExcludedTokens, leftStartIndex, leftSubmission, rightSubmission)
+                        || leftSubsequenceHash == RollingTokenHashTable.NO_HASH) {
                     continue;
                 }
-                List<Integer> possiblyMatchingRightStartIndexes = rightLookupTable
-                        .startIndexesOfPossiblyMatchingSubsequencesForSubsequenceHash(leftSubsequenceHash);
-                for (Integer rightStartIndex : possiblyMatchingRightStartIndexes) {
+                List<Integer> rightStartIndices = rightLookupTable.getStartIndicesForHash(leftSubsequenceHash);
+                for (Integer rightStartIndex : rightStartIndices) { // possible matches
                     // comparison uses >= because it is assumed that the last token is a pivot (FILE_END)
-                    if (checkMark(rightMarked, rightStartIndex, rightSubmission, leftSubmission)
-                            || maximumMatchLength >= rightValues.length - rightStartIndex) {
+                    if (isTokenExcludedAt(rightExcludedTokens, rightStartIndex, rightSubmission, leftSubmission)
+                            || maximumMatchLength >= rightTokens.length - rightStartIndex) {
                         continue;
                     }
 
-                    int subsequenceMatchLength = maximalMatchingSubsequenceLengthNotMarked(leftValues, leftStartIndex, leftMarked, rightValues,
-                            rightStartIndex, rightMarked, maximumMatchLength);
+                    int subsequenceMatchLength = findLongestUnmarkedMatch(leftTokens, leftStartIndex, leftExcludedTokens, rightTokens,
+                            rightStartIndex, rightExcludedTokens, maximumMatchLength);
                     if (subsequenceMatchLength >= maximumMatchLength) {
                         if (subsequenceMatchLength > maximumMatchLength) {
                             iterationMatches.clear();
@@ -162,8 +161,8 @@ public class GreedyStringTiling {
                 int leftStartIndex = match.startOfFirst();
                 int rightStartIndex = match.startOfSecond();
                 for (int offset = 0; offset < match.minimumLength(); offset++) {
-                    leftMarked[leftStartIndex + offset] = true;
-                    rightMarked[rightStartIndex + offset] = true;
+                    leftExcludedTokens[leftStartIndex + offset] = true;
+                    rightExcludedTokens[rightStartIndex + offset] = true;
                 }
             }
         } while (maximumMatchLength != minimumMatchLength);
@@ -184,8 +183,8 @@ public class GreedyStringTiling {
      * @return the maximal matching subsequence length, or 0 if there is no subsequence of at least the minimum sequence
      * length.
      */
-    private int maximalMatchingSubsequenceLengthNotMarked(int[] leftValues, int leftStartIndex, boolean[] leftMarked, int[] rightValues,
-            int rightStartIndex, boolean[] rightMarked, int minimumSequenceLength) {
+    private int findLongestUnmarkedMatch(int[] leftValues, int leftStartIndex, boolean[] leftMarked, int[] rightValues, int rightStartIndex,
+            boolean[] rightMarked, int minimumSequenceLength) {
         for (int offset = minimumSequenceLength - 1; offset >= 0; offset--) {
             int leftIndex = leftStartIndex + offset;
             int rightIndex = rightStartIndex + offset;
@@ -210,28 +209,33 @@ public class GreedyStringTiling {
         matches.add(match);
     }
 
-    private boolean[] calculateInitiallyMarked(Submission submission) {
+    /**
+     * Calculates an array of exclusion flags for a token sequence based on the basecode.
+     */
+    private boolean[] calculateExcludedTokens(Submission submission) {
         Set<Token> baseCodeTokens = baseCodeMarkings.get(submission);
         List<Token> tokens = submission.getTokenList();
-        boolean[] result = new boolean[tokens.size()];
-        for (int i = 0; i < result.length; i++) {
-            result[i] = tokens.get(i).getType().isExcludedFromMatching() || baseCodeTokens != null && baseCodeTokens.contains(tokens.get(i));
+        boolean[] exclusionFlags = new boolean[tokens.size()];
+        for (int tokenIndex = 0; tokenIndex < exclusionFlags.length; tokenIndex++) {
+            exclusionFlags[tokenIndex] = tokens.get(tokenIndex).getType().isExcludedFromMatching()
+                    || baseCodeTokens != null && baseCodeTokens.contains(tokens.get(tokenIndex));
         }
-        return result;
+        return exclusionFlags;
     }
 
-    private SubsequenceHashLookupTable subsequenceHashLookupTableForSubmission(Submission submission, boolean[] marked) {
+    private RollingTokenHashTable getSubsequenceHashTableFor(Submission submission, boolean[] marked) {
         return cachedHashLookupTables.computeIfAbsent(submission,
-                key -> new SubsequenceHashLookupTable(minimumMatchLength, this.tokenValueMapper.getTokenValuesFor(submission), marked));
+                key -> new RollingTokenHashTable(minimumMatchLength, this.tokenValueMapper.getTokenSequenceFor(submission), marked));
     }
 
-    private boolean checkMark(boolean[] marks, int index, Submission submission, Submission otherSubmission) {
-        if (index >= marks.length) {
-            throw new IllegalStateException(String.format(ERROR_INDEX_OUT_OF_BOUNDS, marks.length, index, submission.getTokenList().size(),
-                    submission.getTokenList().stream().map(it -> it.getType().getDescription()).collect(Collectors.joining(", ")),
-                    this.tokenValueMapper.getTokenValuesFor(submission).length, submission.getName(), otherSubmission.getName()));
+    private boolean isTokenExcludedAt(boolean[] exclusionFlags, int tokenIndex, Submission submission, Submission otherSubmission) {
+        if (tokenIndex >= exclusionFlags.length) {
+            throw new IllegalStateException(
+                    String.format(ERROR_INDEX_OUT_OF_BOUNDS, exclusionFlags.length, tokenIndex, submission.getTokenList().size(),
+                            submission.getTokenList().stream().map(it -> it.getType().getDescription()).collect(Collectors.joining(", ")),
+                            this.tokenValueMapper.getTokenSequenceFor(submission).length, submission.getName(), otherSubmission.getName()));
         }
 
-        return marks[index];
+        return exclusionFlags[tokenIndex];
     }
 }

--- a/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
@@ -91,8 +91,7 @@ public class GreedyStringTiling {
     public final JPlagComparison compare(Submission firstSubmission, Submission secondSubmission) {
         Submission smallerSubmission;
         Submission largerSubmission;
-        Comparator<Submission> submissionComparator = Comparator.comparing((Submission it) -> it.getTokenList().size())
-                .thenComparing(Submission::getName);
+        Comparator<Submission> submissionComparator = Comparator.comparing(Submission::getNumberOfTokens).thenComparing(Submission::getName);
 
         if (submissionComparator.compare(firstSubmission, secondSubmission) <= 0) {
             smallerSubmission = firstSubmission;
@@ -111,6 +110,7 @@ public class GreedyStringTiling {
      * @return the comparison results.
      */
     private JPlagComparison compareOrdered(Submission leftSubmission, Submission rightSubmission) {
+        assert leftSubmission.getNumberOfTokens() <= rightSubmission.getNumberOfTokens();
         int[] leftTokens = this.tokenValueMapper.getTokenSequenceFor(leftSubmission);
         int[] rightTokens = this.tokenValueMapper.getTokenSequenceFor(rightSubmission);
 
@@ -231,7 +231,7 @@ public class GreedyStringTiling {
     private boolean isTokenExcludedAt(boolean[] exclusionFlags, int tokenIndex, Submission submission, Submission otherSubmission) {
         if (tokenIndex >= exclusionFlags.length) {
             throw new IllegalStateException(
-                    String.format(ERROR_INDEX_OUT_OF_BOUNDS, exclusionFlags.length, tokenIndex, submission.getTokenList().size(),
+                    String.format(ERROR_INDEX_OUT_OF_BOUNDS, exclusionFlags.length, tokenIndex, submission.getNumberOfTokens(),
                             submission.getTokenList().stream().map(it -> it.getType().getDescription()).collect(Collectors.joining(", ")),
                             this.tokenValueMapper.getTokenSequenceFor(submission).length, submission.getName(), otherSubmission.getName()));
         }

--- a/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
+++ b/core/src/main/java/de/jplag/comparison/GreedyStringTiling.java
@@ -133,7 +133,7 @@ public class GreedyStringTiling {
                     continue;
                 }
                 List<Integer> rightStartIndices = rightLookupTable.getStartIndicesForHash(leftSubsequenceHash);
-                for (Integer rightStartIndex : rightStartIndices) { // possible matches
+                for (int rightStartIndex : rightStartIndices) { // possible matches
                     // comparison uses >= because it is assumed that the last token is a pivot (FILE_END)
                     if (isTokenExcludedAt(rightExcludedTokens, rightStartIndex, rightSubmission, leftSubmission)
                             || maximumMatchLength >= rightTokens.length - rightStartIndex) {

--- a/core/src/main/java/de/jplag/comparison/LongestCommonSubsequenceSearch.java
+++ b/core/src/main/java/de/jplag/comparison/LongestCommonSubsequenceSearch.java
@@ -101,7 +101,7 @@ public class LongestCommonSubsequenceSearch {
         long startTimeMillis = System.currentTimeMillis();
 
         // Set up data structures:
-        TokenValueMapper tokenValueMapper = new TokenValueMapper(submissionSet);
+        TokenSequenceMapper tokenValueMapper = new TokenSequenceMapper(submissionSet);
         GreedyStringTiling coreAlgorithm = new GreedyStringTiling(options, tokenValueMapper);
 
         // Prepare base code comparisons:

--- a/core/src/main/java/de/jplag/comparison/LongestCommonSubsequenceSearch.java
+++ b/core/src/main/java/de/jplag/comparison/LongestCommonSubsequenceSearch.java
@@ -101,8 +101,8 @@ public class LongestCommonSubsequenceSearch {
         long startTimeMillis = System.currentTimeMillis();
 
         // Set up data structures:
-        TokenSequenceMapper tokenValueMapper = new TokenSequenceMapper(submissionSet);
-        GreedyStringTiling coreAlgorithm = new GreedyStringTiling(options, tokenValueMapper);
+        TokenSequenceMapper tokenSequenceMapper = new TokenSequenceMapper(submissionSet);
+        GreedyStringTiling coreAlgorithm = new GreedyStringTiling(options, tokenSequenceMapper);
 
         // Prepare base code comparisons:
         if (submissionSet.hasBaseCode()) {

--- a/core/src/main/java/de/jplag/comparison/RollingTokenHashTable.java
+++ b/core/src/main/java/de/jplag/comparison/RollingTokenHashTable.java
@@ -6,10 +6,10 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A class to generate and store hashes over a fixed length subsequence of a given list of values. Hash generation is
- * optimized to work in O(n).
+ * A subsequence hash look-up table to generate and store rolling hashes over a fixed length subsequence of a given
+ * sequence of token values. Hash generation is optimized to work in O(n).
  */
-class SubsequenceHashLookupTable {
+class RollingTokenHashTable {
     /**
      * Value combination is chosen such that the maximum possible hash value does not exceed Int.max. Computation formula
      * for maximum hash value is \sum from (i=0 to MAX_HASH_LENGTH - 1) with (HASH_MODULO - 1) * 2^i
@@ -21,44 +21,45 @@ class SubsequenceHashLookupTable {
     public static final int NO_HASH = -1;
 
     private final int windowSize;
-    private final int[] values;
+    private final int[] tokenSequence;
     private int[] subsequenceHashes;
     private Map<Integer, List<Integer>> startIndexToSubsequenceHashesMap;
 
     /**
      * Generates a new subsequence hash lookup table. Performance is optimized to compute hashes in O(n).
-     * @param windowSize the size of the subsequences.
-     * @param values the values to hash over.
-     * @param marked Which values are marked. Subsequences containing a marked value obtain the {@link #NO_HASH} value.
+     * @param windowSize the size of the rolling subsequence (corresponds to the minimum token match value).
+     * @param tokenSequence the values to hash over, which is an integer-based token sequence.
+     * @param markedTokens denotes which values (meaning which tokens) are marked. Subsequences containing a marked value
+     * obtain the {@link #NO_HASH} value, thus preventing them from being matched.
      */
-    SubsequenceHashLookupTable(int windowSize, int[] values, boolean[] marked) {
+    RollingTokenHashTable(int windowSize, int[] tokenSequence, boolean[] markedTokens) {
         this.windowSize = Math.clamp(windowSize, 1, MAX_HASH_LENGTH);
-        this.values = values;
+        this.tokenSequence = tokenSequence;
 
-        if (values.length < windowSize) {
+        if (tokenSequence.length < this.windowSize) {
             return;
         }
 
-        subsequenceHashes = new int[values.length - windowSize];
+        subsequenceHashes = new int[tokenSequence.length - this.windowSize];
         startIndexToSubsequenceHashesMap = HashMap.newHashMap(subsequenceHashes.length);
-        computeSubsequenceHashes(marked);
+        computeSubsequenceHashes(markedTokens);
     }
 
     /**
-     * Returns the hash over the subsequence from startIndex to startIndex+windowSize.
+     * Returns the hash over the subsequence from startIndex to startIndex + windowSize.
      * @param startIndex the start index.
      * @return the hash of the requested subsequence.
      */
-    int subsequenceHashForStartIndex(int startIndex) {
+    int getHashAt(int startIndex) {
         return subsequenceHashes[startIndex];
     }
 
     /**
-     * Returns a list of all start indexes of possible subsequences for the given subsequence hash.
+     * Returns a list of all start indexes of possibly matching subsequences for the given subsequence hash.
      * @param subsequenceHash the hash value to obtain possibly matching subsequence start indexes for.
      * @return a list with possible matching start indexes.
      */
-    List<Integer> startIndexesOfPossiblyMatchingSubsequencesForSubsequenceHash(int subsequenceHash) {
+    List<Integer> getStartIndicesForHash(int subsequenceHash) {
         return startIndexToSubsequenceHashesMap.getOrDefault(subsequenceHash, List.of());
     }
 
@@ -72,18 +73,18 @@ class SubsequenceHashLookupTable {
         int hash = 0;
         int hashedLength = 0;
 
-        for (int windowEndIndex = 0; windowEndIndex < values.length; windowEndIndex++) {
+        for (int windowEndIndex = 0; windowEndIndex < tokenSequence.length; windowEndIndex++) {
             int windowStartIndex = windowEndIndex - windowSize;
             if (windowStartIndex >= 0) {
                 if (hashedLength >= windowSize) {
                     subsequenceHashes[windowStartIndex] = hash;
-                    addToStartIndexesToHashesMap(windowStartIndex, hash);
+                    startIndexToSubsequenceHashesMap.computeIfAbsent(hash, key -> new ArrayList<>()).add(windowStartIndex);
                 } else {
                     subsequenceHashes[windowStartIndex] = NO_HASH;
                 }
-                hash -= hashValueForValue(values[windowStartIndex]) << (windowSize - 1); // is [...] * 2^(windowSize - 1)
+                hash -= hashToken(tokenSequence[windowStartIndex]) << (windowSize - 1); // is [...] * 2^(windowSize - 1)
             }
-            hash = (hash << 1) + hashValueForValue(values[windowEndIndex]); // is 2 * hash + [...]
+            hash = (hash << 1) + hashToken(tokenSequence[windowEndIndex]); // is 2 * hash + [...]
             if (marked[windowEndIndex]) {
                 hashedLength = 0;
             } else {
@@ -92,11 +93,7 @@ class SubsequenceHashLookupTable {
         }
     }
 
-    private int hashValueForValue(int value) {
+    private int hashToken(int value) {
         return value % HASH_MODULO;
-    }
-
-    private void addToStartIndexesToHashesMap(int startIndex, int subsequenceHash) {
-        startIndexToSubsequenceHashesMap.computeIfAbsent(subsequenceHash, key -> new ArrayList<>()).add(startIndex);
     }
 }

--- a/core/src/main/java/de/jplag/comparison/TokenSequenceMapper.java
+++ b/core/src/main/java/de/jplag/comparison/TokenSequenceMapper.java
@@ -16,22 +16,22 @@ import de.jplag.logging.ProgressBarType;
 /**
  * Maps the tokens in a submission to integer IDs for usage in the {@link GreedyStringTiling} algorithm. Each token type
  * will be assigned a unique number. The token lists in that form can be queried by calling
- * {@link TokenValueMapper#getTokenValuesFor(Submission)}.
+ * {@link TokenSequenceMapper#getTokenSequenceFor(Submission)}.
  */
-public class TokenValueMapper {
-    private final Map<TokenType, Integer> tokenTypeValues;
-    private final Map<Submission, int[]> tokenValueMap;
+public class TokenSequenceMapper {
+    private final Map<TokenType, Integer> tokenTypeToId;
+    private final Map<Submission, int[]> submissionToTokenSequence;
 
     /**
      * Creates the submission to token ID mapping for a set of submissions. This will also show the progress to the user
      * using the {@link ProgressBarLogger}.
      * @param submissionSet is the set of submissions to process.
      */
-    public TokenValueMapper(SubmissionSet submissionSet) {
-        tokenTypeValues = new HashMap<>();
-        tokenValueMap = new IdentityHashMap<>();
+    public TokenSequenceMapper(SubmissionSet submissionSet) {
+        tokenTypeToId = new HashMap<>();
+        submissionToTokenSequence = new IdentityHashMap<>();
 
-        tokenTypeValues.put(SharedTokenType.FILE_END, 0);
+        tokenTypeToId.put(SharedTokenType.FILE_END, 0);
 
         addSubmissions(submissionSet);
         if (submissionSet.hasBaseCode()) {
@@ -40,27 +40,27 @@ public class TokenValueMapper {
     }
 
     private void addSubmissions(SubmissionSet submissionSet) {
-        ProgressBarLogger.iterate(ProgressBarType.TOKEN_VALUE_CREATION, submissionSet.getSubmissions(), this::addSingleSubmission);
+        ProgressBarLogger.iterate(ProgressBarType.TOKEN_SEQUENCE_CREATION, submissionSet.getSubmissions(), this::addSingleSubmission);
     }
 
     private void addSingleSubmission(Submission submission) {
         List<Token> tokens = submission.getTokenList();
-        int[] tokenValues = new int[tokens.size()];
+        int[] tokenSequence = new int[tokens.size()];
         for (int i = 0; i < tokens.size(); i++) {
             TokenType type = tokens.get(i).getType();
-            tokenTypeValues.putIfAbsent(type, tokenTypeValues.size());
-            tokenValues[i] = tokenTypeValues.get(type);
+            tokenTypeToId.putIfAbsent(type, tokenTypeToId.size());
+            tokenSequence[i] = tokenTypeToId.get(type);
         }
-        tokenValueMap.put(submission, tokenValues);
+        submissionToTokenSequence.put(submission, tokenSequence);
     }
 
     /**
      * Queries the token IDs for a single submission. Each number in the array corresponds to one token from the submission.
      * The {@link SharedTokenType#FILE_END} token is guaranteed to be mapped to 0.
      * @param submission The submission to query.
-     * @return the list of tokens.
+     * @return the integer-based token-sequence.
      */
-    public int[] getTokenValuesFor(Submission submission) {
-        return tokenValueMap.get(submission);
+    public int[] getTokenSequenceFor(Submission submission) {
+        return submissionToTokenSequence.get(submission);
     }
 }

--- a/core/src/main/java/de/jplag/logging/ProgressBarType.java
+++ b/core/src/main/java/de/jplag/logging/ProgressBarType.java
@@ -6,7 +6,7 @@ package de.jplag.logging;
 public enum ProgressBarType {
     LOADING("Loading Submissions", false),
     PARSING("Parsing Submissions", false),
-    TOKEN_VALUE_CREATION("Preparing Submissions", false),
+    TOKEN_SEQUENCE_CREATION("Preparing Submissions", false),
     COMPARING("Comparing Submission Pairs", false),
     MATCH_MERGING("Merging Matched Subsequences ", false),
     TOKEN_SEQUENCE_NORMALIZATION("Normalizing Token Sequences", false),

--- a/core/src/test/java/de/jplag/merging/MatchMergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MatchMergingTest.java
@@ -114,11 +114,11 @@ class MatchMergingTest extends TestBase {
     @DisplayName("Test if the number of matches tokens increases.")
     void testMoreToken() {
         for (int i = 0; i < comparisonsAfter.size(); i++) {
-            int tokensBeforeFirst = comparisonsBefore.get(i).firstSubmission().getTokenList().size();
-            int tokensBeforeSecond = comparisonsBefore.get(i).secondSubmission().getTokenList().size();
+            int tokensBeforeFirst = comparisonsBefore.get(i).firstSubmission().getNumberOfTokens();
+            int tokensBeforeSecond = comparisonsBefore.get(i).secondSubmission().getNumberOfTokens();
 
-            int tokensAfterFirst = comparisonsAfter.get(i).firstSubmission().getTokenList().size();
-            int tokensAfterSecond = comparisonsAfter.get(i).secondSubmission().getTokenList().size();
+            int tokensAfterFirst = comparisonsAfter.get(i).firstSubmission().getNumberOfTokens();
+            int tokensAfterSecond = comparisonsAfter.get(i).secondSubmission().getNumberOfTokens();
 
             assertTrue(tokensAfterFirst >= tokensBeforeFirst);
             assertTrue(tokensAfterSecond >= tokensBeforeSecond);


### PR DESCRIPTION
This PR enhances code quality and naming consistency in the core algorithm codebase by using names that are closer to the actual concepts. Should be merged after #2461.

<h3><span>TokenValueMapper </span><span>→ </span><span>TokenSequenceMapper</span></h3>

Old Method Name | New Method Name
-- | --
getTokenValuesFor(Submission) | getTokenSequenceFor(Submission)

<hr>

<h3><span>SubsequenceHashLookupTable </span><span>→ </span><span>RollingTokenHashTable</span></h3>

Old Method Name | New Method Name
-- | --
subsequenceHashForStartIndex(int) | getHashAt(int)
startIndexesOfPossiblyMatchingSubsequencesForSubsequenceHash(int) | getStartIndicesForHash(int)
hashValueForValue(int) | hashToken(int)
addToStartIndexesToHashesMap(int, int) | (method removed/inlined)
<hr>

<h3>GreedyStringTiling</h3>

Old Method Name | New Method Name
-- | --
compareInternal(Submission, Submission) | compareOrdered(Submission, Submission)
maximalMatchingSubsequenceLengthNotMarked(...) | findLongestUnmarkedMatch(...)
checkMark(boolean[], int, Submission, Submission) | isTokenExcludedAt(boolean[], int, Submission, Submission)
calculateInitiallyMarked(Submission) | calculateExcludedTokens(Submission)
subsequenceHashLookupTableForSubmission(Submission, boolean[]) | getSubsequenceHashTableFor(Submission, boolean[])


<hr>