### PR TITLE
Adjust dev-demo path

### DIFF
--- a/report-viewer/vite.config.ts
+++ b/report-viewer/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig((userConfig: UserConfig) => {
       base = '/Demo/'
       break
     case 'dev-demo':
-      base = '/DevDemo/'
+      base = '/'
       break
   }
   return {


### PR DESCRIPTION
We moved the dev demo from https://jplag.github.io/DevDemo/ to https://devdemo.jplag.de/.
This PR updates the vite config that used in the github action to reflect these changes.