### PR TITLE
Fix bugs with failed submissions display

### DIFF
--- a/report-viewer/src/components/TextInformation.vue
+++ b/report-viewer/src/components/TextInformation.vue
@@ -5,8 +5,10 @@
   <div class="print:flex-none">
     <ToolTipComponent :direction="tooltipSide">
       <template #default>
-        {{ label }}:
-        <i><slot name="default"></slot></i>
+        <div class="flex items-start gap-x-1">
+          <span>{{ label }}:</span>
+          <i><slot name="default"></slot></i>
+        </div>
       </template>
       <template v-if="$slots.tooltip" #tooltip>
         <slot name="tooltip"></slot>

--- a/report-viewer/src/views/OverviewView.vue
+++ b/report-viewer/src/views/OverviewView.vue
@@ -18,7 +18,11 @@
           </template>
           <template #tooltip>
             <p class="max-w-[50rem] text-sm whitespace-pre-wrap">
-              {{ runInformation.failedSubmissions.slice(0, 20).join(', ')
+              {{
+                runInformation.failedSubmissions
+                  .slice(0, 20)
+                  .map((f) => f.submissionId)
+                  .join(', ')
               }}<span v-if="runInformation.failedSubmissions.length > 20"
                 >... (click "<i>More</i>" to see the complete list of failed submissions)</span
               >

--- a/report-viewer/tests/e2e/Comparison.spec.ts
+++ b/report-viewer/tests/e2e/Comparison.spec.ts
@@ -45,9 +45,9 @@ test('Test comparison table and comparsion view', async ({ page }) => {
   const content2 = 'class Node'
 
   const bodyComparison = await page.locator('body').textContent()
-  expect(bodyComparison).toMatch(/Average Similarity: [0-9]{2}.[0-9]{2}%/)
-  expect(bodyComparison).toMatch(new RegExp(`Similarity ${submissionName1}: [0-9]{2}.[0-9]{2}%`))
-  expect(bodyComparison).toMatch(new RegExp(`Similarity ${submissionName2}: [0-9]{2}.[0-9]{2}%`))
+  expect(bodyComparison).toMatch(/Average Similarity:[0-9]{2}.[0-9]{2}%/)
+  expect(bodyComparison).toMatch(new RegExp(`Similarity ${submissionName1}:[0-9]{2}.[0-9]{2}%`))
+  expect(bodyComparison).toMatch(new RegExp(`Similarity ${submissionName2}:[0-9]{2}.[0-9]{2}%`))
 
   expect(bodyComparison).toMatch(new RegExp(`${fileName1} - ${fileName2}: [0-9]+`))
   expect(bodyComparison).toContain(`${submissionName1}/${fileName1}`)

--- a/report-viewer/tests/e2e/Information.spec.ts
+++ b/report-viewer/tests/e2e/Information.spec.ts
@@ -6,10 +6,10 @@ test('Test information page', async ({ page }) => {
 
   // check displayed information on overview page
   const bodyOverview = await page.locator('body').textContent()
-  expect(bodyOverview).toContain('Directory: ')
-  expect(bodyOverview).toMatch(/Total Submissions: [0-9]+/)
-  expect(bodyOverview).toMatch(/Total Comparisons: [0-9]+/)
-  expect(bodyOverview).toMatch(/Min Token Match: [0-9]+/)
+  expect(bodyOverview).toContain('Directory:')
+  expect(bodyOverview).toMatch(/Total Submissions:[0-9]+/)
+  expect(bodyOverview).toMatch(/Total Comparisons:[0-9]+/)
+  expect(bodyOverview).toMatch(/Min Token Match:[0-9]+/)
 
   // go to information page
   await page.getByText('More', { exact: true }).click()
@@ -17,17 +17,17 @@ test('Test information page', async ({ page }) => {
 
   // check displayed run options on information page
   const runOptions = await page.getByText('Run Options:Language:').textContent()
-  expect(runOptions).toContain('Submission Directories: ')
-  expect(runOptions).toContain('Base Directory: ')
-  expect(runOptions).toContain('Language: ')
-  expect(runOptions).toContain('File Suffixes: ')
-  expect(runOptions).toMatch(/Min Token Match: [0-9]+/)
+  expect(runOptions).toContain('Submission Directories:')
+  expect(runOptions).toContain('Base Directory:')
+  expect(runOptions).toContain('Language:')
+  expect(runOptions).toContain('File Suffixes:')
+  expect(runOptions).toMatch(/Min Token Match:[0-9]+/)
 
   const runData = await page.getByText('Run Data:Date of Execution:').textContent()
-  expect(runData).toMatch(/Date of Execution: [0-9]{2}\/[0-9]{2}\/[0-9]{2}/)
-  expect(runData).toMatch(/Execution Duration: [0-9]+ ms/)
-  expect(runData).toMatch(/Total Submissions: [0-9]+/)
-  expect(runData).toMatch(/Total Comparisons: [0-9]+/)
-  expect(runData).toMatch(/Shown Comparisons: [0-9]+/)
-  expect(runData).toMatch(/Missing Comparisons: [0-9]+/)
+  expect(runData).toMatch(/Date of Execution:[0-9]{2}\/[0-9]{2}\/[0-9]{2}/)
+  expect(runData).toMatch(/Execution Duration:[0-9]+ ms/)
+  expect(runData).toMatch(/Total Submissions:[0-9]+/)
+  expect(runData).toMatch(/Total Comparisons:[0-9]+/)
+  expect(runData).toMatch(/Shown Comparisons:[0-9]+/)
+  expect(runData).toMatch(/Missing Comparisons:[0-9]+/)
 })


### PR DESCRIPTION
Fixes two bugs when displaying failed submissions
- On the overview the tooltip displays the submission names instead ob `[object Object]`
- On the information view the label is always at the top