### PR TITLE
Java token position tests Break-Cond

### DIFF
--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Break_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Break_1.java
@@ -1,0 +1,8 @@
+>public class Break {
+>    void test() {
+>        do {
+>            break;
+$            | J_BREAK 5
+>        } while(true);
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Break_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Break_2.java
@@ -1,0 +1,10 @@
+>public class Break {
+>    void test() {
+>        int x = 1;
+>        switch(x) {
+>            case 1:
+>                break;
+$                | J_BREAK 5
+>        }
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Case.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Case.java
@@ -1,0 +1,10 @@
+>public class Case {
+>    void test() {
+>        int x = 1;
+>        switch(x) {
+>            case 1:
+$            | J_CASE 4
+>                break;
+>        }
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Catch.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Catch.java
@@ -1,0 +1,9 @@
+>public class Catch {
+>    void x() {
+>        try {
+>        } catch (Exception e) {
+$          | J_CATCH_BEGIN 5
+>        }
+$        | J_CATCH_END 1
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/CatchMultipleCases.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/CatchMultipleCases.java
@@ -1,0 +1,12 @@
+>public class Catch {
+>    void x() {
+>        try {
+>        } catch (Exception e) {
+$          | J_CATCH_BEGIN 5
+>        } catch (Throwable t) {
+$        | J_CATCH_END 1
+$          | J_CATCH_BEGIN 5
+>        }
+$        | J_CATCH_END 1
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Class.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Class.java
@@ -1,0 +1,4 @@
+>class Class {
+$| J_CLASS_BEGIN 5
+>}
+$| J_CLASS_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/ClassWithModifier.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/ClassWithModifier.java
@@ -1,0 +1,4 @@
+>public class Class {
+$       | J_CLASS_BEGIN 5
+>}
+$| J_CLASS_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_1.java
@@ -1,6 +1,6 @@
 >class Cond {
 >    void test() {
 >        int x = true ? 1 : 0;
-$                     | J_COND 1
+$                | J_COND 1
 >    }
 >}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_1.java
@@ -1,0 +1,6 @@
+>class Cond {
+>    void test() {
+>        int x = true ? 1 : 0;
+$                     | J_COND 1
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_2.java
@@ -1,0 +1,10 @@
+>class Cond {
+>    void test() {
+>        int x = condition() ? 1 + 2 : Math.abs(-1);
+$                            | J_COND 1
+>    }
+>
+>    boolean condition() {
+>        return true;
+>    }
+>}

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Cond_2.java
@@ -1,7 +1,7 @@
 >class Cond {
 >    void test() {
 >        int x = condition() ? 1 + 2 : Math.abs(-1);
-$                            | J_COND 1
+$                | J_COND 1
 >    }
 >
 >    boolean condition() {

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/InnerClass.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/InnerClass.java
@@ -1,0 +1,6 @@
+>class Class {
+>    public static class InnerClass {
+$                  | J_CLASS_BEGIN 5
+>    }
+$    | J_CLASS_END 1
+>}


### PR DESCRIPTION
Java token positions tests for tokens:

J_BREAK
J_CASE
J_CATCH_BEGIN
J_CATCH_END
J_CLASS_BEGIN
J_CLASS_END
J_COND

The test for cond currently fails because the way it's currently extracted can lead to tokens overlapping. @jplag/maintainer can you tell me what you think about that?