### PR TITLE
Check that content of record and interface match

### DIFF
--- a/.github/workflows/match-record-to-interface.yml
+++ b/.github/workflows/match-record-to-interface.yml
@@ -1,4 +1,4 @@
-name: Check that Java records match TypeScript interfaces
+name: Match Report Schema
 
 on:
   workflow_dispatch:

--- a/.github/workflows/match-record-to-interface.yml
+++ b/.github/workflows/match-record-to-interface.yml
@@ -1,0 +1,37 @@
+name: Check that Java records match TypeScript interfaces
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/match-record-to-interface.yml"
+      - ".github/workflows/scripts/matchRecordToInterface.py"
+      - "report-viewer/**"
+      - "**.java"
+
+jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+
+  check_matches:
+    runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v4
+      
+    - name: Run script
+      working-directory: .github/workflows/scripts
+      run: |
+        python matchRecordToInterface.py

--- a/.github/workflows/scripts/matchRecordToInterface.py
+++ b/.github/workflows/scripts/matchRecordToInterface.py
@@ -1,0 +1,262 @@
+def readFileContents(file_path):
+    with open(file_path, 'r') as file:
+        return file.read()
+
+
+def getContentBetweenBrackets(text, open_bracket='{', close_bracket='}'):
+    start = text.find(open_bracket)
+    end = start + 1
+    bracket_count = 1
+    while end < len(text) and bracket_count > 0:
+        if text[end] == open_bracket:
+            bracket_count += 1
+        elif text[end] == close_bracket:
+            bracket_count -= 1
+        end += 1
+    return text[start + 1:end - 1].strip() if bracket_count == 0 else ''
+
+def getTextAfterKeyword(text, keyword):
+    start = text.find(keyword)
+    if start == -1:
+        return ''
+    start += len(keyword)
+    return text[start:].strip()
+
+# Gets all variables from within the record body
+# seperates variables that are in the same line into multiple strings
+# used to filter blank lines and comments
+def extractRecordVariables(text):
+    variables = []
+    current_variable = ''
+    open_brackets = 0
+    for char in text:
+        if char == '(' or char == '{' or char == '[' or char == '<':
+            open_brackets += 1
+            current_variable += char
+        elif char == ')' or char == '}' or char == ']' or char == '>':
+            open_brackets -= 1
+            current_variable += char
+        elif char == ',' and open_brackets == 0:
+            variables.append(current_variable.strip())
+            current_variable = ''
+        else:
+            current_variable += char
+    variables.append(current_variable.strip())  # Add the last variable
+    return variables
+
+# Transforms the text of a Java variable definition to the internal representation
+def transformJavaVariable(variable): 
+    parts = variable.split(' ')
+    if len(parts) < 2:
+        return None
+    type_name = parts[-2].strip()
+    variable_name = parts[-1].replace(';', '').strip()
+    return (type_name, variable_name)
+
+# Extracts variables from a Java file with an record
+def getJavaRecordVariables(text, record_name):
+    record = getTextAfterKeyword(text, 'record ' + record_name)
+    content_between_brackets = getContentBetweenBrackets(record, '(', ')')
+    variables = extractRecordVariables(content_between_brackets)
+    return [transformJavaVariable(var) for var in variables if transformJavaVariable(var) is not None]
+
+# Gets all lines from within the interface body that are variable declarations
+# used to filter blank lines and comments
+def extractInterfaceVariables(text):
+    lines = text.splitlines()
+    return [line.strip() for line in lines if not line.strip().startswith('/') and ':' in line]
+
+# Transforms the text of a TypeScript variable definition to the internal representation
+def transformTypescriptVariable(variable):
+    parts = variable.split(':')
+    if len(parts) < 2:
+        return None
+    variable_name = parts[0].strip()
+    type_name = parts[1].strip().replace(';', '').replace(',', '')
+    return (type_name, variable_name)
+
+# Extracts variables from a TypeScript file with an interface
+def getTypescriptInterfaceVariables(text, interface_name):
+    interface_text = getTextAfterKeyword(text, 'interface ' + interface_name)
+    content_between_brackets = getContentBetweenBrackets(interface_text, '{', '}')
+    variables = extractInterfaceVariables(content_between_brackets)
+    return [transformTypescriptVariable(var) for var in variables if transformTypescriptVariable(var) is not None]
+
+# Basic map from Java types to TypeScript types
+typeMatches = {
+    'int': 'number',
+    'Integer': 'number',
+    'double': 'number',
+    'String': 'string',
+    'boolean': 'boolean',
+    'Set<File>': 'string[]',
+    'List<String>': 'string[]',
+}
+
+# Strips a file path for pretty printing
+def getPrettyFilePath(file_path):
+    return file_path.split('/')[-1] if '/' in file_path else file_path
+
+# transforms a file path to be based on the project root
+def getAbsoluteFilePath(file_path):
+    parts = file_path.split('/')
+    return '/'.join(filter(lambda x: x != '.' and x != '..' and x != '', parts))
+
+# Warning for mismatching type
+class Warning:
+    def __init__(self, java_variable, java_file_path, java_line_number, typescript_variable, typescript_file_path, typescript_line_number):
+        self.java_variable = java_variable
+        self.java_file_path = java_file_path
+        self.java_line_number = java_line_number
+        self.typescript_variable = typescript_variable
+        self.typescript_file_path = typescript_file_path
+        self.typescript_line_number = typescript_line_number
+    
+    def is_error(self):
+        return False
+    def is_warning(self):
+        return True
+    def actions_print(self):
+        return [
+            f"::warning file={getAbsoluteFilePath(self.java_file_path)},line={self.java_line_number},title=Variable types do not match::Type of Java variable '{self.java_variable[1]}' ({self.java_variable[0]}) does not match TypeScript variable '{self.typescript_variable[1]}' ({self.typescript_variable[0]}) in {getAbsoluteFilePath(self.typescript_file_path)} at line {self.typescript_line_number}.",
+            f"::warning file={getAbsoluteFilePath(self.typescript_file_path)},line={self.typescript_line_number},tile=Variable types do not match::Type of TypeScript variable '{self.typescript_variable[1]}' ({self.typescript_variable[0]}) does not match Java variable '{self.java_variable[1]}' ({self.java_variable[0]}) in {getAbsoluteFilePath(self.java_file_path)} at line {self.java_line_number}."
+        ]
+
+# Base Error
+class Error:
+    def __init__(self, variable, file_path, line_number, other_file_path, other_line_number):
+        self.variable = variable
+        self.file_path = file_path
+        self.line_number = line_number
+        self.other_file_path = other_file_path
+        self.other_line_number = other_line_number
+    def is_error(self):
+        return True
+    def is_warning(self):
+        return False
+# Error for: Variable from a TypeScript interface not found in Java record
+class TsError(Error):
+    def actions_print(self):
+        return [
+            f"::error file={getAbsoluteFilePath(self.file_path)},line={self.line_number},title=Variable not found in Java equivalent::TypeScript variable '{self.variable[1]}' ({self.variable[0]}) does not match any Java variable in {getAbsoluteFilePath(self.other_file_path)}.",
+            f"::error file={getAbsoluteFilePath(self.other_file_path)},line={self.other_line_number},title=Missing variable from TypeScript equivalent::Java record should have a variable equivalent to '{self.variable[1]}' ({self.variable[0]}) from {getAbsoluteFilePath(self.file_path)} at line {self.line_number}."
+        ]
+# Error for: Variable from Java record not found in TypeScript interface
+class JavaError(Error):
+    def actions_print(self):
+        return [
+            f"::error file={getAbsoluteFilePath(self.file_path)},line={self.line_number},title=Variable not found in TypeScript equivalent::Java variable '{self.variable[1]}' ({self.variable[0]}) does not match any TypeScript variable in {getAbsoluteFilePath(self.other_file_path)}.",
+            f"::error file={getAbsoluteFilePath(self.other_file_path)},line={self.other_line_number},title=Missing variable from Java equivalent::TypeScript interface should have a variable equivalent to '{self.variable[1]}' ({self.variable[0]}) from {getAbsoluteFilePath(self.file_path)} at line {self.line_number}."
+        ]
+
+# Finds the line number of subtext
+def findLineNumber(lines, subtext):
+    for i, line in enumerate(lines):
+        if subtext in line:
+            return i + 1  # Return 1-based line number
+    return -1  # Not found
+
+# Reads files and compares the variables
+def checkVariableMatch(java_file, typescript_file):
+    java_text = readFileContents(java_file['file_path'])
+    java_variables = getJavaRecordVariables(java_text, java_file['record_name'])
+    java_lines = java_text.splitlines()
+
+    typescript_text = readFileContents(typescript_file['file_path'])
+    typescript_variables = getTypescriptInterfaceVariables(typescript_text, typescript_file['interface_name'])
+    typescript_lines = typescript_text.splitlines()
+
+    annotations = []
+
+    # Check if all Java variables are in interface
+    for java_var in java_variables:
+        java_type, java_name = java_var
+        matched = False
+        for ts_var in typescript_variables:
+            ts_type, ts_name = ts_var
+            if java_name == ts_name:
+                matched = True
+                break
+        if not matched:
+            annotations.append(JavaError(
+                variable=java_var,
+                file_path=java_file['file_path'],
+                line_number=findLineNumber(java_lines, f"{java_type} {java_name}"),
+                other_file_path=typescript_file['file_path'],
+                other_line_number=findLineNumber(typescript_lines, f"interface {typescript_file['interface_name']}")
+            ))
+
+    # Check if all TypeScipt variables are in record
+    for ts_var in typescript_variables:
+        ts_type, ts_name = ts_var
+        matched = False
+        for java_var in java_variables:
+            java_type, java_name = java_var
+            if ts_name == java_name:
+                matched = True
+                break
+        if not matched:
+            annotations.append(TsError(
+                variable=ts_var,
+                file_path=typescript_file['file_path'],
+                line_number=findLineNumber(typescript_lines, f"{ts_name}: {ts_type}"),
+                other_file_path=java_file['file_path'],
+                other_line_number=findLineNumber(java_lines, f"record {java_file['record_name']}")
+            ))
+
+    # check for all Java variables that the type matches the TypeScript type if it is comparable
+    for java_var in java_variables:
+        java_type, java_name = java_var
+        for ts_var in typescript_variables:
+            ts_type, ts_name = ts_var
+            if java_name == ts_name:
+                if typeMatches.get(java_type) != ts_type:
+                    annotations.append(Warning(
+                        java_variable=java_var,
+                        java_file_path=java_file['file_path'],
+                        java_line_number=findLineNumber(java_lines, f"{java_type} {java_name}"),
+                        typescript_variable=ts_var,
+                        typescript_file_path=typescript_file['file_path'],
+                        typescript_line_number=findLineNumber(typescript_lines, f"{ts_name}: {ts_type}")
+                    ))
+                break
+    return annotations
+
+# Runs the comparison for the files and printes all errors and warnings
+def runForPair(java_file, typescript_file):
+    print(f"Checking variables in {getPrettyFilePath(java_file['file_path'])} and {getPrettyFilePath(typescript_file['file_path'])}")
+    annotations = checkVariableMatch(java_file, typescript_file)
+    if not annotations:
+        print("No mismatches found.")
+        return False
+
+    _errors = [a.actions_print() for a in annotations if a.is_error()]
+    errors = [item for sub_list in _errors for item in sub_list]
+    if errors:
+        print(f"Found {len(errors)} errors:")
+        for error in errors:
+            print(error)
+        print("") # Add a newline for better readability
+
+    _warnings = [a.actions_print() for a in annotations if a.is_warning()]
+    warnings = [item for sub_list in _warnings for item in sub_list]
+    if warnings:
+        print(f"Found {len(warnings)} warnings:")
+        for warning in warnings:
+            print(warning)
+    
+    return len(errors) > 0
+
+# Interativly run comparison for all files
+def runForAllPairs(pairs):
+    found_errors = False
+    for java_file, typescript_file in pairs:
+        found_errors |= runForPair(java_file, typescript_file)
+    if not found_errors:
+        exit(0)
+    else:
+        exit(1)
+
+cli_options = ({ 'file_path': '../../../core/src/main/java/de/jplag/options/JPlagOptions.java', 'record_name': 'JPlagOptions' }, { 'file_path': '../../../report-viewer/src/model/CliOptions.ts', 'interface_name': 'AbstractOptions' })
+
+runForAllPairs([cli_options])

--- a/.github/workflows/scripts/matchRecordToInterface.py
+++ b/.github/workflows/scripts/matchRecordToInterface.py
@@ -224,7 +224,7 @@ class Warning:
     def actions_print(self):
         return [
             f"::warning file={getAbsoluteFilePath(self.java_file_path)},line={self.java_line_number},title=Variable types do not match::Type of Java variable '{self.java_variable[1]}' ({self.java_variable[0]}) does not match TypeScript variable '{self.typescript_variable[1]}' ({self.typescript_variable[0]}) in {getAbsoluteFilePath(self.typescript_file_path)} at line {self.typescript_line_number}.",
-            f"::warning file={getAbsoluteFilePath(self.typescript_file_path)},line={self.typescript_line_number},tile=Variable types do not match::Type of TypeScript variable '{self.typescript_variable[1]}' ({self.typescript_variable[0]}) does not match Java variable '{self.java_variable[1]}' ({self.java_variable[0]}) in {getAbsoluteFilePath(self.java_file_path)} at line {self.java_line_number}."
+            f"::warning file={getAbsoluteFilePath(self.typescript_file_path)},line={self.typescript_line_number},title=Variable types do not match::Type of TypeScript variable '{self.typescript_variable[1]}' ({self.typescript_variable[0]}) does not match Java variable '{self.java_variable[1]}' ({self.java_variable[0]}) in {getAbsoluteFilePath(self.java_file_path)} at line {self.java_line_number}."
         ]
 
 # Base Error

--- a/.github/workflows/scripts/matchRecordToInterface.py
+++ b/.github/workflows/scripts/matchRecordToInterface.py
@@ -1,27 +1,32 @@
 import re
 
-cli_options = ({ 'file_path': '../../../core/src/main/java/de/jplag/options/JPlagOptions.java', 'record_name': 'JPlagOptions' }, { 'file_path': '../../../report-viewer/src/model/CliOptions.ts', 'interface_name': 'AbstractOptions' })
-merging_options = ({ 'file_path': '../../../core/src/main/java/de/jplag/merging/MergingOptions.java', 'record_name': 'MergingOptions' }, { 'file_path': '../../../report-viewer/src/model/CliOptions.ts', 'interface_name': 'CliMergingOptions' })
-clustering_options = ({ 'file_path': '../../../core/src/main/java/de/jplag/clustering/ClusteringOptions.java', 'record_name': 'ClusteringOptions' }, { 'file_path': '../../../report-viewer/src/model/CliOptions.ts', 'interface_name': 'CliClusterOptions' })
+CORE_PACKAGE = '../../../core/src/main/java/de/jplag'
+REPORTING_PACKAGE = f"{CORE_PACKAGE}/reporting/reportobject/model"
+REPORT_VIEWER_MODELS = f"../../../report-viewer/src/model"
+REPORT_VIEWER_FACTORIES = f"{REPORT_VIEWER_MODELS}/factories"
 
-comparison = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/ComparisonReport.java', 'record_name': 'ComparisonReport' }, { 'file_path': '../../../report-viewer/src/model/factories/ComparisonFactory.ts', 'interface_name': 'ReportFormatComparison' })
-match = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/Match.java', 'record_name': 'Match' }, { 'file_path': '../../../report-viewer/src/model/Match.ts', 'interface_name': 'ReportFormatMatch' })
-code_position = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/CodePosition.java', 'record_name': 'CodePosition' }, { 'file_path': '../../../report-viewer/src/model/Match.ts', 'interface_name': 'CodePosition' })
+cli_options = ({ 'file_path': f"{CORE_PACKAGE}/options/JPlagOptions.java", 'record_name': 'JPlagOptions' }, { 'file_path': f"{REPORT_VIEWER_MODELS}/CliOptions.ts", 'interface_name': 'AbstractOptions' })
+merging_options = ({ 'file_path': f"{CORE_PACKAGE}/merging/MergingOptions.java", 'record_name': 'MergingOptions' }, { 'file_path': f"{REPORT_VIEWER_MODELS}/CliOptions.ts", 'interface_name': 'CliMergingOptions' })
+clustering_options = ({ 'file_path': f"{CORE_PACKAGE}/clustering/ClusteringOptions.java", 'record_name': 'ClusteringOptions' }, { 'file_path': f"{REPORT_VIEWER_MODELS}/CliOptions.ts", 'interface_name': 'CliClusterOptions' })
 
-basecode_match = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/BaseCodeMatch.java', 'record_name': 'BaseCodeMatch' }, { 'file_path': '../../../report-viewer/src/model/factories/BaseCodeReportFactory.ts', 'interface_name': 'ReportFormatBaseCodeMatch' })
+comparison = ({ 'file_path': f"{REPORTING_PACKAGE}/ComparisonReport.java", 'record_name': 'ComparisonReport' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/ComparisonFactory.ts", 'interface_name': 'ReportFormatComparison' })
+match = ({ 'file_path': f"{REPORTING_PACKAGE}/Match.java", 'record_name': 'Match' }, { 'file_path': f"{REPORT_VIEWER_MODELS}/Match.ts", 'interface_name': 'ReportFormatMatch' })
+code_position = ({ 'file_path': f"{REPORTING_PACKAGE}/CodePosition.java", 'record_name': 'CodePosition' }, { 'file_path': f"{REPORT_VIEWER_MODELS}/Match.ts", 'interface_name': 'CodePosition' })
 
-submission_file_index = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionFileIndex.java', 'record_name': 'SubmissionFileIndex' }, { 'file_path': '../../../report-viewer/src/model/factories/ComparisonFactory.ts', 'interface_name': 'ReportFormatSubmmisionFileIndex' })
-submission_file = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionFile.java', 'record_name': 'SubmissionFile' }, { 'file_path': '../../../report-viewer/src/model/factories/ComparisonFactory.ts', 'interface_name': 'ReportFormatSubmissionFile' })
+basecode_match = ({ 'file_path': f"{REPORTING_PACKAGE}/BaseCodeMatch.java", 'record_name': 'BaseCodeMatch' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/BaseCodeReportFactory.ts", 'interface_name': 'ReportFormatBaseCodeMatch' })
 
-run_information = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/RunInformation.java', 'record_name': 'RunInformation' }, { 'file_path': '../../../report-viewer/src/model/factories/RunInformationFactory.ts', 'interface_name': 'ReportFormatRunInformation' })
-failed_submission = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/FailedSubmission.java', 'record_name': 'FailedSubmission' }, { 'file_path': '../../../report-viewer/src/model/RunInformation.ts', 'interface_name': 'FailedSubmission' })
-version = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/Version.java', 'record_name': 'Version' }, { 'file_path': '../../../report-viewer/src/model/factories/RunInformationFactory.ts', 'interface_name': 'ReportFormatVersion' })
+submission_file_index = ({ 'file_path': f"{REPORTING_PACKAGE}/SubmissionFileIndex.java", 'record_name': 'SubmissionFileIndex' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/ComparisonFactory.ts", 'interface_name': 'ReportFormatSubmissionFileIndex' })
+submission_file = ({ 'file_path': f"{REPORTING_PACKAGE}/SubmissionFile.java", 'record_name': 'SubmissionFile' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/ComparisonFactory.ts", 'interface_name': 'ReportSubmissionFile' })
 
-submission_mappings = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionMappings.java', 'record_name': 'SubmissionMappings' }, { 'file_path': '../../../report-viewer/src/model/factories/SubmissionMappingsFactory.ts', 'interface_name': 'ReportFormatSubmissionMappings' })
+run_information = ({ 'file_path': f"{REPORTING_PACKAGE}/RunInformation.java", 'record_name': 'RunInformation' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/RunInformationFactory.ts", 'interface_name': 'ReportFormatRunInformation' })
+failed_submission = ({ 'file_path': f"{REPORTING_PACKAGE}/FailedSubmission.java", 'record_name': 'FailedSubmission' }, { 'file_path': f"{REPORT_VIEWER_MODELS}/RunInformation.ts", 'interface_name': 'FailedSubmission' })
+version = ({ 'file_path': f"{REPORTING_PACKAGE}/Version.java", 'record_name': 'Version' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/RunInformationFactory.ts", 'interface_name': 'ReportFormatVersion' })
 
-top_comparison = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/TopComparison.java', 'record_name': 'TopComparison' }, { 'file_path': '../../../report-viewer/src/model/factories/TopComparisonFactory.ts', 'interface_name': 'ReportFormatTopComparison' })
+submission_mappings = ({ 'file_path': f"{REPORTING_PACKAGE}/SubmissionMappings.java", 'record_name': 'SubmissionMappings' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/SubmissionMappingsFactory.ts", 'interface_name': 'ReportFormatSubmissionMappings' })
 
-cluster = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/Cluster.java', 'record_name': 'Cluster' }, { 'file_path': '../../../report-viewer/src/model/Cluster.ts', 'interface_name': 'ReportFormatCluster' })
+top_comparison = ({ 'file_path': f"{REPORTING_PACKAGE}/TopComparison.java", 'record_name': 'TopComparison' }, { 'file_path': f"{REPORT_VIEWER_FACTORIES}/TopComparisonFactory.ts", 'interface_name': 'ReportFormatTopComparison' })
+
+cluster = ({ 'file_path': f"{REPORTING_PACKAGE}/Cluster.java", 'record_name': 'Cluster' }, { 'file_path': f"{REPORT_VIEWER_MODELS}/Cluster.ts", 'interface_name': 'ReportFormatCluster' })
 
 # we do not check the distribution as it has own record and is just a map directly written to a json file
 

--- a/.github/workflows/scripts/matchRecordToInterface.py
+++ b/.github/workflows/scripts/matchRecordToInterface.py
@@ -23,7 +23,7 @@ def getTextAfterKeyword(text, keyword):
     return text[start:].strip()
 
 # Gets all variables from within the record body
-# seperates variables that are in the same line into multiple strings
+# separates variables that are in the same line into multiple strings
 # used to filter blank lines and comments
 def extractRecordVariables(text):
     variables = []
@@ -53,9 +53,12 @@ def transformJavaVariable(variable):
     variable_name = parts[-1].replace(';', '').strip()
     return (type_name, variable_name)
 
-# Extracts variables from a Java file with an record
+# Extracts variables from a Java file with a record
 def getJavaRecordVariables(text, record_name):
-    record = getTextAfterKeyword(text, 'record ' + record_name)
+    complete_name = 'record ' + record_name
+    if not complete_name in text:
+        raise Exception(f"Could not find {complete_name}")
+    record = getTextAfterKeyword(text, complete_name)
     content_between_brackets = getContentBetweenBrackets(record, '(', ')')
     variables = extractRecordVariables(content_between_brackets)
     return [transformJavaVariable(var) for var in variables if transformJavaVariable(var) is not None]
@@ -77,7 +80,10 @@ def transformTypescriptVariable(variable):
 
 # Extracts variables from a TypeScript file with an interface
 def getTypescriptInterfaceVariables(text, interface_name):
-    interface_text = getTextAfterKeyword(text, 'interface ' + interface_name)
+    complete_name = 'interface ' + interface_name
+    if not complete_name in text: 
+        raise Exception(f"Could not find {complete_name}")
+    interface_text = getTextAfterKeyword(text, complete_name)
     content_between_brackets = getContentBetweenBrackets(interface_text, '{', '}')
     variables = extractInterfaceVariables(content_between_brackets)
     return [transformTypescriptVariable(var) for var in variables if transformTypescriptVariable(var) is not None]
@@ -186,7 +192,7 @@ def checkVariableMatch(java_file, typescript_file):
                 other_line_number=findLineNumber(typescript_lines, f"interface {typescript_file['interface_name']}")
             ))
 
-    # Check if all TypeScipt variables are in record
+    # Check if all TypeScript variables are in record
     for ts_var in typescript_variables:
         ts_type, ts_name = ts_var
         matched = False
@@ -224,7 +230,7 @@ def checkVariableMatch(java_file, typescript_file):
                 break
     return annotations
 
-# Runs the comparison for the files and printes all errors and warnings
+# Runs the comparison for the files and prints all errors and warnings
 def runForPair(java_file, typescript_file):
     print(f"Checking variables in {getPrettyFilePath(java_file['file_path'])} and {getPrettyFilePath(typescript_file['file_path'])}")
     annotations = checkVariableMatch(java_file, typescript_file)
@@ -249,7 +255,7 @@ def runForPair(java_file, typescript_file):
     
     return len(errors) > 0
 
-# Interativly run comparison for all files
+# Iteratively run comparison for all files
 def runForAllPairs(pairs):
     found_errors = False
     for java_file, typescript_file in pairs:
@@ -260,5 +266,30 @@ def runForAllPairs(pairs):
         exit(1)
 
 cli_options = ({ 'file_path': '../../../core/src/main/java/de/jplag/options/JPlagOptions.java', 'record_name': 'JPlagOptions' }, { 'file_path': '../../../report-viewer/src/model/CliOptions.ts', 'interface_name': 'AbstractOptions' })
+merging_options = ({ 'file_path': '../../../core/src/main/java/de/jplag/merging/MergingOptions.java', 'record_name': 'MergingOptions' }, { 'file_path': '../../../report-viewer/src/model/CliOptions.ts', 'interface_name': 'CliMergingOptions' })
+clustering_options = ({ 'file_path': '../../../core/src/main/java/de/jplag/clustering/ClusteringOptions.java', 'record_name': 'ClusteringOptions' }, { 'file_path': '../../../report-viewer/src/model/CliOptions.ts', 'interface_name': 'CliClusterOptions' })
 
-runForAllPairs([cli_options])
+comparison = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/ComparisonReport.java', 'record_name': 'ComparisonReport' }, { 'file_path': '../../../report-viewer/src/model/factories/ComparisonFactory.ts', 'interface_name': 'ReportFormatComparison' })
+match = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/Match.java', 'record_name': 'Match' }, { 'file_path': '../../../report-viewer/src/model/Match.ts', 'interface_name': 'Match' })
+code_position = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/CodePosition.java', 'record_name': 'CodePosition' }, { 'file_path': '../../../report-viewer/src/model/Match.ts', 'interface_name': 'CodePosition' })
+
+basecode_match = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/BaseCodeMatch.java', 'record_name': 'BaseCodeMatch' }, { 'file_path': '../../../report-viewer/src/model/factories/BaseCodeReportFactory.ts', 'interface_name': 'ReportFormatBaseCodeMatch' })
+
+submission_file_index = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionFileIndex.java', 'record_name': 'SubmissionFileIndex' }, { 'file_path': '../../../report-viewer/src/model/factories/ComparisonFactory.ts', 'interface_name': 'ReportFormatSubmmisionFileIndex' })
+
+run_information = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/RunInformation.java', 'record_name': 'RunInformation' }, { 'file_path': '../../../report-viewer/src/model/factories/RunInformationFactory.ts', 'interface_name': 'ReportFormatRunInformation' })
+failed_submission = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/FailedSubmission.java', 'record_name': 'FailedSubmission' }, { 'file_path': '../../../report-viewer/src/model/RunInformation.ts', 'interface_name': 'FailedSubmission' })
+version = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/Version.java', 'record_name': 'Version' }, { 'file_path': '../../../report-viewer/src/model/factories/RunInformationFactory.ts', 'interface_name': 'ReportFormatVersion' })
+
+submission_mappings = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/SubmissionMappings.java', 'record_name': 'SubmissionMappings' }, { 'file_path': '../../../report-viewer/src/model/factories/SubmissionMappingsFactory.ts', 'interface_name': 'ReportFormatSubmissionMappings' })
+
+top_comparisons = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/TopComparison.java', 'record_name': 'TopComparison' }, { 'file_path': '../../../report-viewer/src/model/factories/TopComparisonFactory.ts', 'interface_name': 'ReportFormatTopComparison' })
+
+cluster = ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/Cluster.java', 'record_name': 'Cluster' }, { 'file_path': '../../../report-viewer/src/model/Cluster.ts', 'interface_name': 'ReportFormatCluster' })
+
+# ({ 'file_path': '../../../core/src/main/java/de/jplag/reporting/reportobject/model/', 'record_name': '' }, { 'file_path': '../../../report-viewer/src/model/factories/', 'interface_name': '' })
+
+# we do not check the distribution as it has own record and is just a map directly written to a json file
+
+
+runForAllPairs([cli_options,merging_options, clustering_options, comparison, match, code_position, basecode_match, submission_file_index, run_information, failed_submission, version, submission_mappings, top_comparisons, cluster])

--- a/.github/workflows/scripts/matchRecordToInterface.py
+++ b/.github/workflows/scripts/matchRecordToInterface.py
@@ -109,9 +109,9 @@ def transformJavaVariable(variable):
 def extractTypeFromLong(type_name_and_prior):
     open_brackets = 0
     for i in range(len(type_name_and_prior) - 1, -1, -1):
-        if type_name_and_prior[i] == ')' or type_name_and_prior[i] == ')' or type_name_and_prior[i] == '>':
+        if type_name_and_prior[i] == ')' or type_name_and_prior[i] == ']' or type_name_and_prior[i] == '>' or type_name_and_prior[i] == '}':
             open_brackets += 1
-        elif type_name_and_prior[i] == '(' or type_name_and_prior[i] == '[' or type_name_and_prior[i] == '<':
+        elif type_name_and_prior[i] == '(' or type_name_and_prior[i] == '[' or type_name_and_prior[i] == '<' or type_name_and_prior[i] == '{':
             open_brackets -= 1
         elif type_name_and_prior[i] == ' ' and open_brackets == 0:
             return type_name_and_prior[i + 1:]

--- a/.github/workflows/scripts/matchRecordToInterface.py
+++ b/.github/workflows/scripts/matchRecordToInterface.py
@@ -210,6 +210,8 @@ def checkVariableMatch(java_file, typescript_file):
         for ts_var in typescript_variables:
             ts_type, ts_name = ts_var
             if java_name == ts_name:
+                if java_type not in typeMatches:
+                    continue
                 if typeMatches.get(java_type) != ts_type:
                     annotations.append(Warning(
                         java_variable=java_var,

--- a/.github/workflows/scripts/matchRecordToInterface.py
+++ b/.github/workflows/scripts/matchRecordToInterface.py
@@ -190,7 +190,7 @@ def checkTypeMatch(java_type, ts_type):
             # check types of key and value
             key_check = checkTypeMatch(java_map_check.group(1).strip(), ts_record_check.group(1).strip())
             value_check = checkTypeMatch(java_map_check.group(2).strip(), ts_record_check.group(2).strip())
-            return key_check or value_check
+            return key_check and value_check
         else:
             # is not a record in ts
             return False

--- a/report-viewer/src/model/CliOptions.ts
+++ b/report-viewer/src/model/CliOptions.ts
@@ -9,7 +9,7 @@ interface AbstractOptions<L> {
   minimumTokenMatch: number
   submissionDirectories: string[]
   oldSubmissionDirectories: string[]
-  baseCodeSubmissionDirectory: File
+  baseCodeSubmissionDirectory: string
   subdirectoryName: string
   fileSuffixes: string[]
   exclusionFileName: string

--- a/report-viewer/src/model/Match.ts
+++ b/report-viewer/src/model/Match.ts
@@ -11,7 +11,11 @@ import type { MatchColorIndex } from '@/utils/ColorUtils'
  * @property tokens - Number of tokens in the match.
  * @property colorIndex - Index of the color to use for the match.
  */
-export interface Match {
+export interface Match extends ReportFormatMatch {
+  colorIndex: MatchColorIndex
+}
+
+export interface ReportFormatMatch {
   firstFileName: string
   secondFileName: string
   startInFirst: CodePosition
@@ -20,7 +24,6 @@ export interface Match {
   endInSecond: CodePosition
   lengthOfFirst: number
   lengthOfSecond: number
-  colorIndex: MatchColorIndex
 }
 
 export interface CodePosition {

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -180,9 +180,9 @@ interface ReportFormatComparison {
 }
 
 interface ReportFormatSubmissionFileIndex {
-  fileIndexes: Record<string, Record<string, ReportFormatSubmissionFile>>
+  fileIndexes: Record<string, Record<string, ReportSubmissionFile>>
 }
 
-interface ReportFormatSubmissionFile {
+interface ReportSubmissionFile {
   tokenCount: number
 }

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -1,5 +1,5 @@
 import { Comparison } from '../Comparison'
-import { getMatchLength, type Match } from '../Match'
+import { getMatchLength, type Match, type ReportFormatMatch } from '../Match'
 import { store } from '@/stores/store'
 import { getMatchColorCount } from '@/utils/ColorUtils'
 import slash from 'slash'
@@ -29,7 +29,8 @@ export class ComparisonFactory extends BaseFactory {
       return {
         ...match,
         firstFileName: slash(match.firstFileName),
-        secondFileName: slash(match.secondFileName)
+        secondFileName: slash(match.secondFileName),
+        colorIndex: -1 // Will be set later
       }
     })
     matches.forEach((match) => {
@@ -173,19 +174,15 @@ interface ReportFormatComparison {
   firstSubmissionId: string
   secondSubmissionId: string
   similarities: Record<string, number>
-  matches: Match[]
+  matches: ReportFormatMatch[]
   firstSimilarity: number
   secondSimilarity: number
 }
 
 interface ReportFormatSubmmisionFileIndex {
-  fileIndexes: Record<
-    string,
-    Record<
-      string,
-      {
-        tokenCount: number
-      }
-    >
-  >
+  fileIndexes: Record<string, Record<string, ReportFormatSubmissionFile>>
+}
+
+interface ReportFormatSubmissionFile {
+  tokenCount: number
 }

--- a/report-viewer/src/model/factories/ComparisonFactory.ts
+++ b/report-viewer/src/model/factories/ComparisonFactory.ts
@@ -70,7 +70,7 @@ export class ComparisonFactory extends BaseFactory {
   private static async getSubmissionFileList(
     submissionId: string
   ): Promise<Record<string, { tokenCount: number }>> {
-    const submissionFileIndex: ReportFormatSubmmisionFileIndex = JSON.parse(
+    const submissionFileIndex: ReportFormatSubmissionFileIndex = JSON.parse(
       await this.getFile(`submissionFileIndex.json`)
     )
     return submissionFileIndex.fileIndexes[submissionId]
@@ -179,7 +179,7 @@ interface ReportFormatComparison {
   secondSimilarity: number
 }
 
-interface ReportFormatSubmmisionFileIndex {
+interface ReportFormatSubmissionFileIndex {
   fileIndexes: Record<string, Record<string, ReportFormatSubmissionFile>>
 }
 

--- a/report-viewer/src/model/factories/SubmissionMappingsFactory.ts
+++ b/report-viewer/src/model/factories/SubmissionMappingsFactory.ts
@@ -11,13 +11,13 @@ export class SubmissionMappingsFactory extends BaseFactory {
     this.saveComparisonFilesLookup(json.submissionIdsToComparisonFileName)
   }
 
-  private static saveIdToDisplayNameMap(json: SubmissionIdToDisplayName) {
+  private static saveIdToDisplayNameMap(json: Record<string, string>) {
     const map = new Map<string, string>(Object.entries(json))
 
     store().saveSubmissionNames(map)
   }
 
-  private static saveComparisonFilesLookup(json: SubmissionIdsToComparisonFileName) {
+  private static saveComparisonFilesLookup(json: Record<string, Record<string, string>>) {
     const entries: Array<Array<string | object>> = Object.entries(json)
     const comparisonMap = new Map<string, Map<string, string>>()
     for (const [key, value] of entries) {
@@ -29,9 +29,6 @@ export class SubmissionMappingsFactory extends BaseFactory {
 }
 
 interface ReportFormatSubmissionMappings {
-  submissionIds: SubmissionIdToDisplayName
-  submissionIdsToComparisonFileName: SubmissionIdsToComparisonFileName
+  submissionIds: Record<string, string>
+  submissionIdsToComparisonFileName: Record<string, Record<string, string>>
 }
-
-type SubmissionIdToDisplayName = Record<string, string>
-type SubmissionIdsToComparisonFileName = Record<string, Record<string, string>>


### PR DESCRIPTION
This PR adds a check that varifies that the content of records that are exported into the report matches with the content of the interfaces in the report viewer.
Errors get printed in both files.
The script also checks types.
If a type mismatch is found, a warning is displayed in both files.

[Example](https://github.com/Kr0nox/JPlag/pull/2/files#diff-d5bf94cece18f6505916c2114842818b22fa8d4836aacd0f7ac97fb36e29ef3d)
<details>
<summary>Screenshots</summary>
<table>
<tr>
<td>Type</td>
<td>Java</td>
<td>Typescript</td>
</tr>

<tr>
<td>Missing variable in record</td>
<td><img src="https://github.com/user-attachments/assets/c2e82935-83a6-478b-ae03-051e42e16953"></td>
<td><img src="https://github.com/user-attachments/assets/2cc112e2-93f0-4c97-a2b5-52e4655a1029"></td>
</tr>

<tr>
<td>Missing variable in interface</td>
<td><img src="https://github.com/user-attachments/assets/2f42d2ea-43eb-416c-81fd-748ee239b288"></td>
<td><img src="https://github.com/user-attachments/assets/9977be75-c2dd-4375-9fe9-8d3973f0b94b"></td>
</tr>

<tr>
<td>Type Mismatch</td>
<td><img src="https://github.com/user-attachments/assets/fd8e3b1a-a7b1-40ec-ab71-1be709ca4e09"></td>
<td><img src="https://github.com/user-attachments/assets/24095a28-f4d9-40c1-9238-df6bd809857a"></td>
</tr>
</table>
</details>