### PR TITLE
Fix merging matches across files

### DIFF
--- a/core/src/test/java/de/jplag/TestBase.java
+++ b/core/src/test/java/de/jplag/TestBase.java
@@ -1,5 +1,7 @@
 package de.jplag;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
@@ -7,6 +9,9 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Assumptions;
+import org.opentest4j.TestAbortedException;
 
 import de.jplag.clustering.ClusteringOptions;
 import de.jplag.exceptions.ExitException;
@@ -151,5 +156,15 @@ public abstract class TestBase {
             }
         }
         directory.delete();
+    }
+
+    /**
+     * Validate a given assumption for object equality based on {@link Assumptions#assumeTrue(boolean)}.
+     * @param expected the expected value.
+     * @param actual the actual value.
+     * @throws TestAbortedException if the assumption is not {@code true}.
+     */
+    protected static void assumeEquals(Object expected, Object actual) {
+        assumeTrue(expected.equals(actual), "Expected: " + expected + ", Actual: " + actual);
     }
 }

--- a/core/src/test/java/de/jplag/merging/MatchMergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MatchMergingTest.java
@@ -3,7 +3,6 @@ package de.jplag.merging;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -193,22 +192,21 @@ class MatchMergingTest extends TestBase {
     @Test
     @DisplayName("Test for the absence of cross file matches.")
     void testFileBoundaries() throws ExitException {
-
         MergingOptions mergingOptions = new MergingOptions(true, MINIMUM_NEIGHBOR_LENGTH, MAXIMUM_GAP_SIZE, MINIMUM_REQUIRED_MERGES);
-        JPlagOptions options = getDefaultOptions("crossFile").withMergingOptions(mergingOptions);
-        SubmissionSetBuilder builder = new SubmissionSetBuilder(options);
-        SubmissionSet submissionSet = builder.buildSubmissionSet();
-        LongestCommonSubsequenceSearch comparisonStrategy = new LongestCommonSubsequenceSearch(options);
-        JPlagResult result = comparisonStrategy.compareSubmissions(submissionSet);
+        JPlagOptions customOptions = getDefaultOptions("crossFile").withMergingOptions(mergingOptions);
+        SubmissionSetBuilder builder = new SubmissionSetBuilder(customOptions);
+        SubmissionSet submissions = builder.buildSubmissionSet();
+        LongestCommonSubsequenceSearch search = new LongestCommonSubsequenceSearch(customOptions);
+        JPlagResult result = search.compareSubmissions(submissions);
 
-        assumeTrue(2 == result.getNumberOfSubmissions());
-        assumeTrue(1 == result.getAllComparisons().size());
+        assumeEquals(2, result.getNumberOfSubmissions());
+        assumeEquals(1, result.getAllComparisons().size());
         JPlagComparison comparison = result.getAllComparisons().getFirst();
-        assumeTrue(2 == comparison.matches().size());
+        assumeEquals(2, comparison.matches().size());
 
         checkForCrossFileMatches(comparison, comparison.matches());
 
-        JPlagResult mergedResult = new MatchMerging(options).mergeMatchesOf(result);
+        JPlagResult mergedResult = new MatchMerging(customOptions).mergeMatchesOf(result);
         JPlagComparison mergedComparison = mergedResult.getAllComparisons().getFirst();
 
         assertEquals(2, mergedResult.getNumberOfSubmissions());
@@ -216,7 +214,6 @@ class MatchMergingTest extends TestBase {
         assertEquals(2, mergedComparison.matches().size());
 
         checkForCrossFileMatches(mergedComparison, mergedComparison.matches());
-
     }
 
     private void checkForCrossFileMatches(JPlagComparison comparison, List<Match> matches) {

--- a/core/src/test/resources/de/jplag/samples/crossFile/first/Hotel.java
+++ b/core/src/test/resources/de/jplag/samples/crossFile/first/Hotel.java
@@ -1,0 +1,50 @@
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class Hotel {
+    private final int id;
+    private final String city;
+    private final List<Room> rooms = new ArrayList<>();
+
+    public Hotel(int id, String city) {
+        this.id = id;
+        this.city = city;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public List<Room> getRooms() {
+        return rooms;
+    }
+
+    public void addRoom(Room room) {
+        rooms.add(room);
+    }
+
+    public void removeRoom(int roomId) {
+        Iterator<Room> iterator = rooms.iterator();
+        while (iterator.hasNext()) {
+            Room room = iterator.next();
+            if (room.getId() == roomId) {
+                iterator.remove();
+                break;
+            }
+        }
+    }
+
+    public Room getRoom(int roomId) {
+        for (Room room : rooms) {
+            if (room.getId() == roomId) {
+                return room;
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/crossFile/first/Room.java
+++ b/core/src/test/resources/de/jplag/samples/crossFile/first/Room.java
@@ -1,0 +1,41 @@
+import java.time.LocalDate;
+import java.util.List;
+
+public class Room {
+
+    private final int id;
+    private final String type;
+    private final double price;
+
+    public Room(int id, String type, double price) {
+        this.id = id;
+        this.type = type;
+        this.price = price;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public double getTotalPrice(LocalDate from, LocalDate to) {
+        long days = to.toEpochDay() - from.toEpochDay();
+        return price * days;
+    }
+
+    public boolean isAvailable(LocalDate from, LocalDate to, List<Booking> bookings) {
+        for (Booking booking : bookings) {
+            if (booking.getRoom().getId() == this.id && !(to.isBefore(booking.getFrom()) || from.isAfter(booking.getTo().minusDays(1)))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/crossFile/second/Hotel.java
+++ b/core/src/test/resources/de/jplag/samples/crossFile/second/Hotel.java
@@ -1,0 +1,45 @@
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class Hotel {
+    private final int id;
+    private final String city;
+    private final List<Room> rooms = new ArrayList<>();
+
+    public Hotel(int id, String city) {
+        this.id = id;
+        this.city = city;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public List<Room> getRooms() {
+        return rooms;
+    }
+
+    public void addRoom(Room room) {
+        rooms.add(room);
+    }
+
+    public void removeRoom(int roomId) {
+        Iterator<Room> iterator = rooms.iterator();
+        while (iterator.hasNext()) {
+            Room room = iterator.next();
+            if (room.getId() == roomId) {
+                iterator.remove();
+                break;
+            }
+        }
+    }
+
+    public Room getRoom(int roomId) {
+        return rooms.stream().filter(room -> room.getId() == roomId).findFirst().orElse(null);
+    }
+}

--- a/core/src/test/resources/de/jplag/samples/crossFile/second/Room.java
+++ b/core/src/test/resources/de/jplag/samples/crossFile/second/Room.java
@@ -1,0 +1,37 @@
+import java.time.LocalDate;
+import java.util.List;
+
+public class Room {
+
+    private final int id;
+    private final String type;
+    private final double price;
+
+    public Room(int id, String type, double price) {
+        this.id = id;
+        this.type = type;
+        this.price = price;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public double getTotalPrice(LocalDate from, LocalDate to) {
+        long days = to.toEpochDay() - from.toEpochDay();
+        return price * days;
+    }
+
+    public boolean isAvailable(LocalDate from, LocalDate to, List<Booking> bookings) {
+        return bookings.stream().filter(b -> b.getRoom().getId() == this.id)
+                .noneMatch(b -> !(to.isBefore(b.getFrom()) || from.isAfter(b.getTo().minusDays(1))));
+    }
+}


### PR DESCRIPTION
This PR fixes the logic in the subsequence match merging mechanisms that prevents merging across multiple files. Previously, the merging process did not correctly handle cases where the last token between two neighboring matches is an end-of-file (EOF) token. This bug is most likely in the codebase since match merging was introduced, but only arises rarely as it is an off-by-one error.