### PR TITLE
Fix issues raised by newly introduced Spotless rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <emfatic.version>1.1.0</emfatic.version>
         <mockito.version>5.18.0</mockito.version>
         <!-- ensure that this variable is initialized, even if it is empty -->
-        <argLine></argLine>
+        <argLine/>
 
         <!-- The Revision of JPlag -->
         <revision>6.2.0-SNAPSHOT</revision>
@@ -386,7 +386,7 @@
                         <importOrder>
                             <file>spotless.importorder</file>
                         </importOrder>
-                        <removeUnusedImports></removeUnusedImports>
+                        <removeUnusedImports/>
                     </java>
                     <pom>
                         <sortPom>


### PR DESCRIPTION
The recent version bump of Spotless (#2484) introduces new rules that fail on the develop branch.
This only affects pom files, but is fixed by this PR. While these changes are also included in #2486, this PR allows us to restore the build for the develop branch immediately.