### PR TITLE
Remove mention of "file suffix" in report viewer

### DIFF
--- a/report-viewer/src/views/InformationView.vue
+++ b/report-viewer/src/views/InformationView.vue
@@ -21,7 +21,7 @@
           <TextInformation label="Subdirectory Name">{{
             options.subdirectoryName
           }}</TextInformation>
-          <TextInformation label="File Suffixes">{{
+          <TextInformation label="File Extensions">{{
             options.fileSuffixes.join(', ')
           }}</TextInformation>
           <TextInformation label="Exclusion File Name">{{

--- a/report-viewer/tests/e2e/Information.spec.ts
+++ b/report-viewer/tests/e2e/Information.spec.ts
@@ -20,7 +20,7 @@ test('Test information page', async ({ page }) => {
   expect(runOptions).toContain('Submission Directories:')
   expect(runOptions).toContain('Base Directory:')
   expect(runOptions).toContain('Language:')
-  expect(runOptions).toContain('File Suffixes:')
+  expect(runOptions).toContain('File Extensions:')
   expect(runOptions).toMatch(/Min Token Match:[0-9]+/)
 
   const runData = await page.getByText('Run Data:Date of Execution:').textContent()


### PR DESCRIPTION
relates to #2320 

Removes the mention of word file suffix on screen