### PR TITLE
Added an assign token to java variable declarations if an initializer is present

### DIFF
--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -13,6 +13,7 @@ import de.jplag.semantics.VariableScope;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.AssertTree;
 import com.sun.source.tree.AssignmentTree;
+import com.sun.source.tree.BindingPatternTree;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.BreakTree;
 import com.sun.source.tree.CaseTree;
@@ -455,6 +456,16 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         long start = positions.getStartPosition(ast, node);
         addToken(JavaTokenType.J_ASSERT, start, 6, CodeSemantics.createControl());
         return super.visitAssert(node, null);
+    }
+
+    @Override
+    public Void visitBindingPattern(BindingPatternTree node, Void unused) {
+        super.visitBindingPattern(node, unused);
+        if (!node.getVariable().getName().toString().equals(ANONYMOUS_VARIABLE_NAME)) {
+            long end = positions.getEndPosition(ast, node);
+            addToken(JavaTokenType.J_ASSIGN, end, end, new CodeSemantics());
+        }
+        return null;
     }
 
     @Override

--- a/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
@@ -54,25 +54,26 @@ public class JavaLanguageTest extends LanguageModuleTest {
                 J_IF_END, J_METHOD_END, J_CLASS_END);
 
         collector.testFile("Verbose.java", "Compact.java").testSourceCoverage().testTokenSequence(J_PACKAGE, J_IMPORT, J_CLASS_BEGIN, J_METHOD_BEGIN,
-                J_VARDEF, J_VARDEF, J_IF_BEGIN, J_APPLY, J_RETURN, J_IF_END, J_VARDEF, J_LOOP_BEGIN, J_VARDEF, J_APPLY, J_ASSIGN, J_IF_BEGIN, J_APPLY,
-                J_APPLY, J_ASSIGN, J_IF_END, J_LOOP_END, J_IF_BEGIN, J_APPLY, J_ASSIGN, J_IF_END, J_IF_BEGIN, J_APPLY, J_APPLY, J_ASSIGN, J_IF_END,
-                J_RETURN, J_METHOD_END, J_CLASS_END);
+                J_VARDEF, J_VARDEF, J_IF_BEGIN, J_APPLY, J_RETURN, J_IF_END, J_VARDEF, J_ASSIGN, J_LOOP_BEGIN, J_VARDEF, J_ASSIGN, J_APPLY, J_ASSIGN,
+                J_IF_BEGIN, J_APPLY, J_APPLY, J_ASSIGN, J_IF_END, J_LOOP_END, J_IF_BEGIN, J_APPLY, J_ASSIGN, J_IF_END, J_IF_BEGIN, J_APPLY, J_APPLY,
+                J_ASSIGN, J_IF_END, J_RETURN, J_METHOD_END, J_CLASS_END);
 
         // Test difference between try block and try-with-resource block.
         collector.testFile("Try.java", "TryWithResource.java").testSourceCoverage().testTokenSequence(J_PACKAGE, J_IMPORT, J_IMPORT, J_IMPORT,
-                J_CLASS_BEGIN, J_METHOD_BEGIN, J_VARDEF, J_APPLY, J_NEWCLASS, J_METHOD_END, J_METHOD_BEGIN, J_VARDEF, J_VARDEF, J_TRY_BEGIN, J_VARDEF,
-                J_ASSIGN, J_NEWCLASS, J_NEWCLASS, J_LOOP_BEGIN, J_APPLY, J_APPLY, J_APPLY, J_LOOP_END, J_CATCH_BEGIN, J_VARDEF, J_APPLY, J_CATCH_END,
-                J_FINALLY_BEGIN, J_IF_BEGIN, J_APPLY, J_IF_END, J_FINALLY_END, J_TRY_END, J_METHOD_END, J_CLASS_END);
+                J_CLASS_BEGIN, J_METHOD_BEGIN, J_VARDEF, J_APPLY, J_NEWCLASS, J_METHOD_END, J_METHOD_BEGIN, J_VARDEF, J_VARDEF, J_ASSIGN, J_TRY_BEGIN,
+                J_VARDEF, J_ASSIGN, J_ASSIGN, J_NEWCLASS, J_NEWCLASS, J_LOOP_BEGIN, J_APPLY, J_APPLY, J_APPLY, J_LOOP_END, J_CATCH_BEGIN, J_VARDEF,
+                J_APPLY, J_CATCH_END, J_FINALLY_BEGIN, J_IF_BEGIN, J_APPLY, J_IF_END, J_FINALLY_END, J_TRY_END, J_METHOD_END, J_CLASS_END);
 
         collector.testFile("CLI.java").testSourceCoverage().testContainedTokens(J_TRY_END, J_IMPORT, J_VARDEF, J_LOOP_BEGIN, J_ARRAY_INIT_BEGIN,
                 J_IF_BEGIN, J_CATCH_END, J_COND, J_ARRAY_INIT_END, J_METHOD_BEGIN, J_TRY_BEGIN, J_CLASS_END, J_RETURN, J_ASSIGN, J_METHOD_END,
                 J_IF_END, J_CLASS_BEGIN, J_NEWARRAY, J_PACKAGE, J_APPLY, J_LOOP_END, J_THROW, J_NEWCLASS, J_CATCH_BEGIN);
 
         collector.testFile("PatternMatching.java", "PatternMatchingManual.java").testSourceCoverage().testTokenSequence(J_CLASS_BEGIN, J_RECORD_BEGIN,
-                J_VARDEF, J_RECORD_END, J_METHOD_BEGIN, J_VARDEF, J_NEWCLASS, J_IF_BEGIN, J_VARDEF, J_IF_END, J_METHOD_END, J_CLASS_END);
+                J_VARDEF, J_RECORD_END, J_METHOD_BEGIN, J_VARDEF, J_ASSIGN, J_NEWCLASS, J_IF_BEGIN, J_VARDEF, J_ASSIGN, J_IF_END, J_METHOD_END,
+                J_CLASS_END);
 
         collector.testFile("StringConcat.java", "StringTemplate.java").testSourceCoverage().testTokenSequence(J_CLASS_BEGIN, J_METHOD_BEGIN, J_VARDEF,
-                J_VARDEF, J_VARDEF, J_APPLY, J_METHOD_END, J_CLASS_END);
+                J_ASSIGN, J_VARDEF, J_ASSIGN, J_VARDEF, J_ASSIGN, J_APPLY, J_METHOD_END, J_CLASS_END);
 
         collector.testFile("AnonymousVariables.java").testTokenSequence(J_CLASS_BEGIN, J_METHOD_BEGIN, J_VARDEF, J_IF_BEGIN, J_IF_END, J_METHOD_END,
                 J_CLASS_END);

--- a/languages/java/src/test/resources/de/jplag/java/Try.java
+++ b/languages/java/src/test/resources/de/jplag/java/Try.java
@@ -12,7 +12,7 @@ public class Try {
     public void load(String path) {
         Scanner scanner = null;
         try {
-            Scanner other; // This is just here to keep the tokens similar.
+            Scanner other = null; // This is just here to keep the tokens similar.
             scanner = new Scanner(new File(path));
             while (scanner.hasNext()) {
                 System.out.println(scanner.nextLine());


### PR DESCRIPTION
Adds an assign token to variable declarations with initializers.

For example:

```java
int x = 1;
| VARDEF
      | ASSIGN
```

This should be better since it is now equivalent to:

```java
int x;
| VARDEF
x = 1;
  | ASSIGN
```

To make this compatible with the new pattern syntax, an assignment is also added there:

```java
public class PatternMatchingManual {
    private static final record Test(int x) {
    }

    public void test() {
        Object a = new Test(1);
        if (a instanceof Test testA) {
                         | VARDEF
                                  | ASSIGN
        }
    }
}
```

Required for #1962
