### PR TITLE
Remove package lock file in root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "JPlag",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
A package.lock file was generated in the root directory previously. This file gets deleted