### PR TITLE
Adjust allowed metrics for boxplot

### DIFF
--- a/report-viewer/src/components/distributionDiagram/BoxPlotDiagramOptions.vue
+++ b/report-viewer/src/components/distributionDiagram/BoxPlotDiagramOptions.vue
@@ -6,6 +6,7 @@
         class="mt-2"
         title="Metric:"
         :default-selected="store().uiState.distributionChartConfig.metric"
+        :metrics="metricOptions"
         @selection-changed="
           (metric: MetricJsonIdentifier) =>
             (store().uiState.distributionChartConfig.metric = metric)
@@ -19,5 +20,10 @@
 import { store } from '@/stores/store'
 import MetricSelector from '@/components/optionsSelectors/MetricSelector.vue'
 import ScrollableComponent from '../ScrollableComponent.vue'
-import type { MetricJsonIdentifier } from '@/model/MetricJsonIdentifier'
+import { MetricJsonIdentifier } from '@/model/MetricJsonIdentifier'
+
+const metricOptions = [
+  MetricJsonIdentifier.AVERAGE_SIMILARITY,
+  MetricJsonIdentifier.MAXIMUM_SIMILARITY
+]
 </script>


### PR DESCRIPTION
The boxplot can only display the average and maximum similarity and not the other new metrics. This PR adjust the selector to reflect that