### PR TITLE
Switch to new sonarcloud workflow implementation

### DIFF
--- a/.github/workflows/report-viewer-sonarcloud.yml
+++ b/.github/workflows/report-viewer-sonarcloud.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.3.0
         with:
           projectBaseDir: report-viewer
         env:


### PR DESCRIPTION
This PR updates the SonarCloud workflow to use a new action implementation by switching from the deprecated SonarCloud GitHub action to the newer SonarQube scan action with a specific version.

See also: #2467 