### PR TITLE
Add pull_request_target event to report viewer SonarCloud workflow

### DIFF
--- a/.github/workflows/report-viewer-sonarcloud.yml
+++ b/.github/workflows/report-viewer-sonarcloud.yml
@@ -13,6 +13,11 @@ on:
     paths:
       - "report-viewer/**"
       - ".github/workflows/sonarcloud-report-viewer.yml"
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "report-viewer/**"
+      - ".github/workflows/sonarcloud-report-viewer.yml"
 
       # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Enables PRs from forks to run the Sonar action, which was previously possible due to the unavailability of the Sonar token.