### PR TITLE
Enable CheckStyle for test code

### DIFF
--- a/core/src/test/java/de/jplag/highlightextraction/frequencydetermination/StrategyIntegrationTest.java
+++ b/core/src/test/java/de/jplag/highlightextraction/frequencydetermination/StrategyIntegrationTest.java
@@ -5,16 +5,26 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.jplag.*;
+import de.jplag.JPlagResult;
+import de.jplag.SubmissionSet;
+import de.jplag.SubmissionSetBuilder;
+import de.jplag.TestBase;
+import de.jplag.TokenType;
 import de.jplag.comparison.LongestCommonSubsequenceSearch;
 import de.jplag.exceptions.ExitException;
-import de.jplag.highlightextraction.*;
+import de.jplag.highlightextraction.CompleteMatchesStrategy;
+import de.jplag.highlightextraction.ContainedMatchesStrategy;
+import de.jplag.highlightextraction.FrequencyDetermination;
+import de.jplag.highlightextraction.FrequencyStrategy;
+import de.jplag.highlightextraction.SubMatchesStrategy;
+import de.jplag.highlightextraction.WindowOfMatchesStrategy;
 import de.jplag.options.JPlagOptions;
 
 /**

--- a/core/src/test/java/de/jplag/highlightextraction/frequencydetermination/StrategyTest.java
+++ b/core/src/test/java/de/jplag/highlightextraction/frequencydetermination/StrategyTest.java
@@ -1,20 +1,39 @@
 package de.jplag.highlightextraction.frequencydetermination;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import de.jplag.*;
+import de.jplag.JPlagComparison;
+import de.jplag.JPlagResult;
 import de.jplag.Match;
+import de.jplag.Submission;
+import de.jplag.SubmissionSet;
+import de.jplag.SubmissionSetBuilder;
+import de.jplag.TestBase;
+import de.jplag.Token;
+import de.jplag.TokenType;
 import de.jplag.comparison.LongestCommonSubsequenceSearch;
 import de.jplag.exceptions.ExitException;
-import de.jplag.highlightextraction.*;
+import de.jplag.highlightextraction.CompleteMatchesStrategy;
+import de.jplag.highlightextraction.ContainedMatchesStrategy;
+import de.jplag.highlightextraction.FrequencyDetermination;
+import de.jplag.highlightextraction.FrequencyStrategy;
+import de.jplag.highlightextraction.SubMatchesStrategy;
+import de.jplag.highlightextraction.WindowOfMatchesStrategy;
 import de.jplag.options.JPlagOptions;
 
 /**

--- a/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
@@ -72,8 +72,9 @@ public abstract class LanguageModuleTest {
 
     /**
      * Creates a new language module test.
-     * @param language The language to test
-     * @param tokenEnum The enum containing the token types
+     * @param <T> the enum type implementing {@link TokenType}.
+     * @param language the language under test.
+     * @param tokenEnum the enum class representing token types.
      */
     public <T extends Enum<T> & TokenType> LanguageModuleTest(Language language, Class<T> tokenEnum) {
         this(language, tokenEnum.getEnumConstants());

--- a/language-testutils/src/test/java/de/jplag/testutils/TemporaryFileHolder.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/TemporaryFileHolder.java
@@ -8,7 +8,7 @@ import java.util.List;
  * Stores all temporary files that are created for a {@link LanguageModuleTest} and provides the option to delete them.
  */
 public class TemporaryFileHolder {
-    public static List<File> temporaryFiles = new ArrayList<>();
+    private static List<File> temporaryFiles = new ArrayList<>();
 
     /**
      * Deletes all temporary files that have been created up to this point.
@@ -16,5 +16,13 @@ public class TemporaryFileHolder {
     public static void deleteTemporaryFiles() {
         temporaryFiles.forEach(File::delete);
         temporaryFiles.clear();
+    }
+
+    /**
+     * Registers a temporary file for later tracking and cleanup.
+     * @param file the file to add.
+     */
+    public static void addTemporaryFile(File file) {
+        temporaryFiles.add(file);
     }
 }

--- a/language-testutils/src/test/java/de/jplag/testutils/TokenUtils.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/TokenUtils.java
@@ -6,6 +6,9 @@ import java.util.List;
 import de.jplag.Token;
 import de.jplag.TokenType;
 
+/**
+ * Utility class for working with tokens and their associated files. This class cannot be instantiated.
+ */
 public final class TokenUtils {
 
     private TokenUtils() {

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
@@ -26,7 +26,7 @@ class InlineTestData implements TestData {
         File file = File.createTempFile("testSource", language.fileExtensions().getFirst());
         FileUtils.write(file, this.testData);
         List<Token> tokens = language.parse(Collections.singleton(file), false);
-        TemporaryFileHolder.temporaryFiles.add(file);
+        TemporaryFileHolder.addTemporaryFile(file);
         return tokens;
     }
 

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
@@ -85,7 +85,7 @@ public class TestDataCollector {
      * using the returned {@link TestDataContext}.
      * @param directoryName The name of the directory containing the token position tests.
      * @return The context containing the added sources
-     * @throws IOException If the files cannot be read
+     * @throws RuntimeException If the files cannot be read
      */
     public TestDataContext addTokenPositionTests(String directoryName) {
         File directory = new File(this.testFileLocation, directoryName);
@@ -131,6 +131,9 @@ public class TestDataCollector {
         return Collections.unmodifiableList(tokenSequenceTest);
     }
 
+    /**
+     * @return The test data that should be checked for token positions.
+     */
     public List<TokenPositionTestData> getTokenPositionTestData() {
         return Collections.unmodifiableList(this.tokenPositionTestData);
     }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestSourceIgnoredLinesCollector.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestSourceIgnoredLinesCollector.java
@@ -4,10 +4,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
+/**
+ * Collects relevant source code lines by filtering out lines that should be ignored, such as empty lines, lines with
+ * specific prefixes, matching regex patterns, or enclosed between markers. Provides utilities for fine-grained control
+ * over which lines of a source are considered relevant for further processing or analysis.
+ */
+
 public class TestSourceIgnoredLinesCollector {
     private final String[] originalSource;
     private final List<Integer> relevantLines;
 
+    /**
+     * Constructs a collector for the given source lines, initially considering all lines as relevant.
+     * @param originalSource the original source lines
+     */
     public TestSourceIgnoredLinesCollector(String[] originalSource) {
         this.originalSource = originalSource;
         this.relevantLines = new ArrayList<>();
@@ -17,10 +27,17 @@ public class TestSourceIgnoredLinesCollector {
         }
     }
 
+    /**
+     * Ignores all empty or blank lines in the source.
+     */
     public void ignoreEmptyLines() {
         this.ignoreByCondition(String::isBlank);
     }
 
+    /**
+     * Ignores lines that start with the specified prefix.
+     * @param prefix the prefix to match
+     */
     public void ignoreLinesByPrefix(String prefix) {
         this.ignoreByCondition(line -> line.trim().startsWith(prefix));
     }
@@ -34,10 +51,19 @@ public class TestSourceIgnoredLinesCollector {
         this.ignoreByCondition(line -> line.trim().matches(regex));
     }
 
+    /**
+     * Ignores lines that contain the specified content substring.
+     * @param content the content to search for
+     */
     public void ignoreLinesByContains(String content) {
         this.ignoreByCondition(line -> line.contains(content));
     }
 
+    /**
+     * Ignores a block of lines starting with {@code startMarker} and ending with {@code endMarker}.
+     * @param startMarker the marker indicating the start of the block
+     * @param endMarker the marker indicating the end of the block
+     */
     public void ignoreMultipleLines(String startMarker, String endMarker) {
         boolean inMultilineIgnore = false;
 
@@ -59,10 +85,18 @@ public class TestSourceIgnoredLinesCollector {
         }
     }
 
+    /**
+     * Ignores a block of lines where the start and end markers are the same.
+     * @param startAndEnd the marker indicating both the start and end of the block
+     */
     public void ignoreMultipleLines(String startAndEnd) {
         this.ignoreMultipleLines(startAndEnd, startAndEnd);
     }
 
+    /**
+     * Ignores lines that satisfy the given condition.
+     * @param condition a predicate returning true for lines to ignore
+     */
     public void ignoreByCondition(Predicate<String> condition) {
         for (int i = 0; i < this.originalSource.length; i++) {
             if (condition.test(originalSource[i])) {
@@ -71,10 +105,18 @@ public class TestSourceIgnoredLinesCollector {
         }
     }
 
+    /**
+     * Ignores a specific line by its index in the original source.
+     * @param index the 0-based index of the line to ignore
+     */
     public void ignoreByIndex(int index) {
         this.relevantLines.remove((Object) (index + 1));
     }
 
+    /**
+     * Returns the list of relevant line numbers after ignoring operations.
+     * @return a list of 1-based line numbers that are not ignored
+     */
     public List<Integer> getRelevantLines() {
         return this.relevantLines;
     }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -94,7 +94,7 @@ public class TokenPositionTestData implements TestData {
         File file = File.createTempFile("testSource", language.fileExtensions().getFirst());
         FileUtils.write(file, String.join(System.lineSeparator(), sourceLines));
         List<Token> tokens = language.parse(Collections.singleton(file), false);
-        TemporaryFileHolder.temporaryFiles.add(file);
+        TemporaryFileHolder.addTemporaryFile(file);
         return tokens;
     }
 

--- a/languages/csharp/src/test/java/de/jplag/csharp/CSharpTest.java
+++ b/languages/csharp/src/test/java/de/jplag/csharp/CSharpTest.java
@@ -25,7 +25,16 @@ import de.jplag.testutils.LanguageModuleTest;
 import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
 
+/**
+ * Unit test for the C# language module, verifying tokenization and source coverage. Extends {@link LanguageModuleTest}
+ * to provide C#-specific test files, token sequences, and rules for ignoring irrelevant source lines such as comments,
+ * preprocessor directives, and using-alias statements.
+ */
 public class CSharpTest extends LanguageModuleTest {
+
+    /**
+     * Constructs a C# language test module with the appropriate language and token type.
+     */
     public CSharpTest() {
         super(new CSharpLanguage(), CSharpTokenType.class);
     }

--- a/languages/javascript/src/test/java/de/jplag/javascript/JavaScriptLanguageTest.java
+++ b/languages/javascript/src/test/java/de/jplag/javascript/JavaScriptLanguageTest.java
@@ -17,8 +17,17 @@ import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
 import de.jplag.typescript.TypeScriptTokenType;
 
+/**
+ * Unit test for the JavaScript language module, verifying tokenization and source coverage. Extends
+ * {@link LanguageModuleTest} to provide JavaScript-specific test files, filtered token sequences, and rules for
+ * ignoring irrelevant source lines such as comments and multi-line blocks.
+ */
+
 public class JavaScriptLanguageTest extends LanguageModuleTest {
 
+    /**
+     * Constructs a JavaScript language test module with the appropriate language and token type.
+     */
     public JavaScriptLanguageTest() {
         super(new JavaScriptLanguage(), TypeScriptTokenType.class);
     }

--- a/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
+++ b/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
@@ -5,9 +5,15 @@ import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
 
 /**
- * Provides tests for the kotlin language module.
+ * Unit test for the Kotlin language module, verifying tokenization and source coverage. Extends
+ * {@link LanguageModuleTest} to provide Kotlin-specific test files, token sequences, and rules for ignoring irrelevant
+ * source lines such as multi-line comments.
  */
 public class KotlinLanguageTest extends LanguageModuleTest {
+
+    /**
+     * Constructs a Kotlin language test module with the appropriate language and token type.
+     */
     public KotlinLanguageTest() {
         super(new KotlinLanguage(), KotlinTokenType.class);
     }

--- a/languages/llvmir/src/test/java/de/jplag/llvmir/LLVMIRLanguageTest.java
+++ b/languages/llvmir/src/test/java/de/jplag/llvmir/LLVMIRLanguageTest.java
@@ -17,6 +17,10 @@ import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
  * Provides tests for the llvmir language module.
  */
 class LLVMIRLanguageTest extends LanguageModuleTest {
+
+    /**
+     * Constructs a LLVM-IR language test module with the appropriate language and token type.
+     */
     public LLVMIRLanguageTest() {
         super(new LLVMIRLanguage(), LLVMIRTokenType.class);
     }

--- a/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
+++ b/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
@@ -39,6 +39,9 @@ class RustLanguageTest {
     private static final String COMPLETE_TEST_FILE = "complete.rs";
     private static final String RUST_SHEBANG = "#!.*$";
     private static final double EPSILON = 1E-6;
+    /**
+     * Minimum required source coverage for tests, represented as a fraction of lines covered by tokens.
+     */
     public static final double BASELINE_COVERAGE = 0.75;
 
     private final Logger logger = LoggerFactory.getLogger(RustLanguageTest.class);

--- a/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
+++ b/languages/scala/src/test/java/de/jplag/scala/ScalaLanguageTest.java
@@ -4,7 +4,16 @@ import de.jplag.testutils.LanguageModuleTest;
 import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
 
+/**
+ * Unit test for the Scala language module, verifying tokenization and source coverage. Extends
+ * {@link LanguageModuleTest} to provide Scala-specific test files and rules for ignoring irrelevant source lines,
+ * including comments, specific patterns, and multi-line blocks.
+ */
 public class ScalaLanguageTest extends LanguageModuleTest {
+
+    /**
+     * Constructs a Scala language test module with the appropriate language and token type.
+     */
     public ScalaLanguageTest() {
         super(new ScalaLanguage(), ScalaTokenType.class);
     }

--- a/languages/scxml/src/test/java/de/jplag/scxml/ConfigurableScxmlParserAdapter.java
+++ b/languages/scxml/src/test/java/de/jplag/scxml/ConfigurableScxmlParserAdapter.java
@@ -4,12 +4,28 @@ import de.jplag.scxml.parser.ScxmlParserAdapter;
 import de.jplag.scxml.sorting.SortingStrategy;
 import de.jplag.scxml.util.AbstractScxmlVisitor;
 
+/**
+ * SCXML parser adapter that allows dynamic configuration of the visitor and sorting strategy. Provides methods to set
+ * or update the {@link AbstractScxmlVisitor} and its {@link SortingStrategy}.
+ */
+
 public class ConfigurableScxmlParserAdapter extends ScxmlParserAdapter {
+
+    /**
+     * Configures the parser adapter with a visitor and a sorting strategy.
+     * @param visitor the SCXML visitor to use
+     * @param sorter the strategy for sorting elements during parsing
+     */
 
     public void configure(AbstractScxmlVisitor visitor, SortingStrategy sorter) {
         visitor.setSorter(sorter);
         this.visitor = visitor;
     }
+
+    /**
+     * Updates the sorting strategy of the current SCXML visitor.
+     * @param sortingStrategy the new sorting strategy to apply
+     */
 
     public void setSorter(SortingStrategy sortingStrategy) {
         this.visitor.setSorter(sortingStrategy);

--- a/languages/scxml/src/test/java/de/jplag/scxml/ScxmlTokenGeneratorTest.java
+++ b/languages/scxml/src/test/java/de/jplag/scxml/ScxmlTokenGeneratorTest.java
@@ -48,7 +48,7 @@ class ScxmlTokenGeneratorTest {
         COMPLEX_VIEW_FILE("complex_expected_scxmlview"),
         COVERAGE("coverage.scxml");
 
-        final String fileName;
+        private final String fileName;
 
         TestSubjects(String fileName) {
             this.fileName = fileName;

--- a/languages/scxml/src/test/java/de/jplag/scxml/util/StateBuilder.java
+++ b/languages/scxml/src/test/java/de/jplag/scxml/util/StateBuilder.java
@@ -9,6 +9,11 @@ import de.jplag.scxml.parser.model.Transition;
 import de.jplag.scxml.parser.model.executable_content.Action;
 import de.jplag.scxml.parser.model.executable_content.ExecutableContent;
 
+/**
+ * Builder class for constructing {@link State} instances in a fluent and configurable manner. Supports setting the
+ * state ID, marking as initial or parallel, adding transitions, substates, and specifying actions to execute on entry
+ * or exit.
+ */
 public class StateBuilder {
 
     private final String id;
@@ -18,40 +23,76 @@ public class StateBuilder {
     private boolean initial;
     private boolean parallel;
 
+    /**
+     * Initializes a new state builder with the given identifier.
+     * @param id the unique identifier for the state
+     */
     public StateBuilder(String id) {
         this.id = id;
     }
 
+    /**
+     * Marks the state as parallel, allowing concurrent substates.
+     * @return the current {@link StateBuilder} instance for chaining
+     */
     public StateBuilder setParallel() {
         parallel = true;
         return this;
     }
 
+    /**
+     * Marks the state as the initial state within its parent context.
+     * @return the current {@link StateBuilder} instance for chaining
+     */
     public StateBuilder setInitial() {
         initial = true;
         return this;
     }
 
+    /**
+     * Adds transitions to the state being built.
+     * @param transitions one or more {@link Transition} objects to add
+     * @return the current {@link StateBuilder} instance for chaining
+     */
     public StateBuilder addTransitions(Transition... transitions) {
         this.transitions = new ArrayList<>(List.of(transitions));
         return this;
     }
 
+    /**
+     * Adds substates to the state being built.
+     * @param substates one or more {@link State} objects to add as children
+     * @return the current {@link StateBuilder} instance for chaining
+     */
     public StateBuilder addSubstates(State... substates) {
         this.substates = Arrays.asList(substates);
         return this;
     }
 
+    /**
+     * Adds actions to be executed upon entering the state.
+     * @param contents one or more {@link ExecutableContent} to run on entry
+     * @return the current {@link StateBuilder} instance for chaining
+     */
     public StateBuilder addOnEntry(ExecutableContent... contents) {
         this.actions.add(new Action(Action.Type.ON_ENTRY, List.of(contents)));
         return this;
     }
 
+    /**
+     * Adds actions to be executed upon exiting the state.
+     * @param contents one or more {@link ExecutableContent} to run on exit
+     * @return the current {@link StateBuilder} instance for chaining
+     */
     public StateBuilder addOnExit(ExecutableContent... contents) {
         this.actions.add(new Action(Action.Type.ON_EXIT, List.of(contents)));
         return this;
     }
 
+    /**
+     * Constructs a {@link State} instance with the configured properties, transitions, substates, and actions.
+     * @return a new {@link State} object
+     */
     public State build() {
         return new State(id, transitions, substates, actions, initial, parallel);
     }

--- a/languages/swift/src/test/java/de/jplag/swift/SwiftLanguageTest.java
+++ b/languages/swift/src/test/java/de/jplag/swift/SwiftLanguageTest.java
@@ -4,7 +4,15 @@ import de.jplag.testutils.LanguageModuleTest;
 import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
 
+/**
+ * Unit test for the Swift language module, verifying tokenization and source coverage. Extends
+ * {@link LanguageModuleTest} to provide Swift-specific test files and rules for ignoring irrelevant source lines.
+ */
 public class SwiftLanguageTest extends LanguageModuleTest {
+
+    /**
+     * Constructs a Swift language test module with the appropriate language and token type.
+     */
     public SwiftLanguageTest() {
         super(new SwiftLanguage(), SwiftTokenType.class);
     }

--- a/languages/typescript/src/test/java/de/jplag/typescript/TypeScriptLanguageTest.java
+++ b/languages/typescript/src/test/java/de/jplag/typescript/TypeScriptLanguageTest.java
@@ -4,8 +4,16 @@ import de.jplag.testutils.LanguageModuleTest;
 import de.jplag.testutils.datacollector.TestDataCollector;
 import de.jplag.testutils.datacollector.TestSourceIgnoredLinesCollector;
 
+/**
+ * Unit test for the TypeScript language module, verifying tokenization and source coverage. Extends
+ * {@link LanguageModuleTest} to provide TypeScript-specific test files, token sequences, and rules for ignoring
+ * irrelevant source lines such as comments and multi-line blocks.
+ */
 public class TypeScriptLanguageTest extends LanguageModuleTest {
 
+    /**
+     * Constructs a TypeScript language test module with the appropriate language and token type.
+     */
     public TypeScriptLanguageTest() {
         super(new TypeScriptLanguage(), TypeScriptTokenType.class);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -343,7 +343,7 @@
                     <configLocation>config/checkstyle/checkstyle.xml</configLocation>
                     <sourceDirectories>
                         <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-                        <!-- <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory> -->
+                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
                     </sourceDirectories>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>


### PR DESCRIPTION
This PR enables the CheckStyle checks (mainly configured for documentation enforcement) for all test source code.

To pass the build, this PR also:

- adds missing and fixes existing JDoc comments
- fixes visibility and encapsulation
- resolves star imports