### PR TITLE
Revert "Dependency(deps): Bump org.codehaus.mojo:exec-maven-plugin from 3.5.1 to 3.6.0"

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -198,7 +198,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.6.0</version>
+                        <version>3.5.1</version>
                         <executions>
                             <execution>
                                 <id>npm install</id>


### PR DESCRIPTION
Reverts jplag/JPlag#2630, as the actions did not run properly.