### PR TITLE
mvn dependency management

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -15,131 +15,108 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>jplag</artifactId>
-            <version>${revision}</version>
         </dependency>
 
         <!-- Languages -->
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-api</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>text</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>java</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>python-3</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>csharp</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>c</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>cpp</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>golang</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>kotlin</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>rlang</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>rust</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>scala</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>scheme</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>scxml</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>swift</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>emf-metamodel</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>emf-model</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>typescript</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>javascript</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>llvmir</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>multi-language</artifactId>
-            <version>${revision}</version>
         </dependency>
+
         <!-- CLI -->
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>info.picocli</groupId>
-            <artifactId>picocli</artifactId>
-            <version>4.7.7</version>
-        </dependency>
-
-        <dependency>
             <groupId>me.tongfei</groupId>
             <artifactId>progressbar</artifactId>
-            <version>0.10.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -198,7 +175,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.6.2</version>
                         <executions>
                             <execution>
                                 <id>npm install</id>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,6 @@
         <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
-            <version>1.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -24,25 +23,22 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
-            <version>3.6.1</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-api</artifactId>
-            <version>${revision}</version>
-        </dependency>
-        <!-- the core project only requires one language module for testing: -->
-        <dependency>
-            <groupId>de.jplag</groupId>
-            <artifactId>java</artifactId>
-            <version>${revision}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.soabase.record-builder</groupId>
             <artifactId>record-builder-processor</artifactId>
-            <version>${record.builder.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- the core project only requires one language module for testing: -->
+        <dependency>
+            <groupId>de.jplag</groupId>
+            <artifactId>java</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -53,29 +49,5 @@
                 <directory>src/main/resources</directory>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.plugin.version}</version>
-                <configuration>
-                    <sourcepath>src/main/java;target/generated-sources/annotations</sourcepath>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.plugin.version}</version>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>io.soabase.record-builder</groupId>
-                            <artifactId>record-builder-processor</artifactId>
-                            <version>${record.builder.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -12,139 +12,112 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>jplag</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>cli</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>endtoend-testing</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-api</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-testutils</artifactId>
-            <version>${revision}</version>
         </dependency>
 
         <!-- Languages -->
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>text</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>java</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>python-3</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>csharp</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>c</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>cpp</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>golang</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>kotlin</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>rlang</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>rust</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>scala</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>scheme</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>scxml</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>swift</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>emf-metamodel</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>emf-metamodel-dynamic</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>emf-model</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>typescript</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>llvmir</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>javascript</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>multi-language</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
     <build>

--- a/endtoend-testing/pom.xml
+++ b/endtoend-testing/pom.xml
@@ -24,6 +24,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jaxen</groupId>
+            <artifactId>jaxen</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/endtoend-testing/pom.xml
+++ b/endtoend-testing/pom.xml
@@ -12,17 +12,14 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>jplag</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>cli</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-testutils</artifactId>
-            <version>${revision}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -33,7 +30,6 @@
         <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
-            <version>1.4.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/endtoend-testing/src/test/java/de/jplag/endtoend/architecture/PomVersionTest.java
+++ b/endtoend-testing/src/test/java/de/jplag/endtoend/architecture/PomVersionTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Ensures that version tags in pom.xml files are defined properly
+ * Ensures that version tags in pom.xml files are defined properly.
  */
 class PomVersionTest {
     private static final String POM_XML_NAME = "pom.xml";
@@ -50,12 +50,9 @@ class PomVersionTest {
     private static final File projectRoot = new File("..");
     private static final File projectRootPom = new File(projectRoot, POM_XML_NAME);
 
-    /**
-     * Verifies the version of each module is defined using ${revision}
-     */
     @ParameterizedTest
     @MethodSource("getAllChildPomFiles")
-    @DisplayName("Ensure all pom use " + REVISION_REFERENCE + " to reference parent")
+    @DisplayName("Ensure all child poms use " + REVISION_REFERENCE + " to reference parent")
     void testModuleParentVersion(File pom) throws IOException, JDOMException {
         List<Element> versionTags = scanXpath(pom, XPATH_PARENT_VERSION);
         assertEquals(1, versionTags.size());

--- a/endtoend-testing/src/test/java/de/jplag/endtoend/architecture/PomVersionTest.java
+++ b/endtoend-testing/src/test/java/de/jplag/endtoend/architecture/PomVersionTest.java
@@ -1,0 +1,166 @@
+package de.jplag.endtoend.architecture;
+
+import static de.jplag.testutils.AssertionUtils.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.filter.ElementFilter;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.xpath.XPathBuilder;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Ensures that version tags in pom.xml files are defined properly
+ */
+class PomVersionTest {
+    private static final String POM_XML_NAME = "pom.xml";
+    private static final String REVISION_REFERENCE = "${revision}";
+
+    private static final String REGEX_VERSION_REFERENCE = "\\$\\{((version\\..+)|(revision))\\}";
+    private static final String REGEX_PLUGIN_VERSION_REFERENCE = "\\$\\{version\\.plugin\\..+\\}";
+
+    private static final String XPATH_JOIN = " | ";
+
+    private static final String XPATH_PARENT_VERSION = "/pom:project/pom:parent/pom:version";
+    private static final String XPATH_MODULE_VERSION = "/pom:project/pom:version";
+    private static final String XPATH_DEPENDENCY_VERSION = "/pom:project/pom:dependencies/pom:dependency/pom:version";
+    private static final String XPATH_DEPENDENCY_MANAGEMENT_VERSION = "/pom:project/pom:dependencyManagement/pom:dependencies/pom:dependency/pom:version";
+    private static final String XPATH_PLUGIN_VERSION = "/pom:project/pom:build/pom:plugins/pom:plugin/pom:version";
+    private static final String XPATH_PLUGIN_MANAGEMENT_VERSION = "/pom:project/pom:build/pom:pluginManagement/pom:plugins/pom:plugin/pom:version";
+
+    private static final String XPATH_ALL_DEPENDENCY_VERSION = XPATH_DEPENDENCY_VERSION + XPATH_JOIN + XPATH_DEPENDENCY_MANAGEMENT_VERSION;
+    private static final String XPATH_ALL_PLUGIN_VERSION = XPATH_PLUGIN_VERSION + XPATH_JOIN + XPATH_PLUGIN_MANAGEMENT_VERSION;
+    private static final String XPATH_EXTERNAL_VERSION = XPATH_ALL_DEPENDENCY_VERSION + XPATH_JOIN + XPATH_ALL_PLUGIN_VERSION;
+    private static final String XPATH_IMPORT_VERSION = XPATH_DEPENDENCY_VERSION + XPATH_JOIN + XPATH_PLUGIN_VERSION;
+
+    private static final File projectRoot = new File("..");
+    private static final File projectRootPom = new File(projectRoot, POM_XML_NAME);
+
+    /**
+     * Verifies the version of each module is defined using ${revision}
+     */
+    @ParameterizedTest
+    @MethodSource("getAllChildPomFiles")
+    @DisplayName("Ensure all pom use " + REVISION_REFERENCE + " to reference parent")
+    void testModuleParentVersion(File pom) throws IOException, JDOMException {
+        List<Element> versionTags = scanXpath(pom, XPATH_PARENT_VERSION);
+        assertEquals(1, versionTags.size());
+        assertEquals(REVISION_REFERENCE, versionTags.getFirst().getText(),
+                "Invalid parent version in " + pom.getPath() + ". Should be: " + REVISION_REFERENCE);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getAllChildPomFiles")
+    @DisplayName("Ensure all no child pom declares its own version")
+    void testNoVersionForChildPoms(File pom) throws IOException, JDOMException {
+        List<Element> versionTags = scanXpath(pom, XPATH_MODULE_VERSION);
+        assertEquals(0, versionTags.size(), "Pom file " + pom.getPath() + " should not declare its version");
+    }
+
+    @ParameterizedTest
+    @MethodSource("getAllChildPomFiles")
+    @DisplayName("Ensures no child pom declares any versions for dependencies and plugins")
+    void testNoDependencyVersionsInChildPom(File pom) throws IOException, JDOMException {
+        List<Element> versionTags = scanXpath(pom, XPATH_EXTERNAL_VERSION);
+        assertAll(versionTags, this::failForVersionTag);
+    }
+
+    @Test
+    @DisplayName("Ensures the root project sets its version as " + REVISION_REFERENCE)
+    void testRootProjectVersion() throws IOException, JDOMException {
+        List<Element> versionTag = scanXpath(projectRootPom, XPATH_MODULE_VERSION);
+        assertEquals(1, versionTag.size(), "No version declared in root pom file");
+        assertEquals(REVISION_REFERENCE, versionTag.getFirst().getText(), "Version in root pom should be defined as " + REVISION_REFERENCE);
+    }
+
+    @Test
+    @DisplayName("Ensures that the root pom does not reverence any versions in the dependencies or plugins section (dependencyManagement/pluginManagement should be used instead)")
+    void testRootProjectDependencyVersions() throws IOException, JDOMException {
+        List<Element> directlyReferencedVersions = scanXpath(projectRootPom, XPATH_IMPORT_VERSION);
+        assertAll(directlyReferencedVersions, this::failForVersionTag);
+    }
+
+    @Test
+    @DisplayName("Ensures That all version inside the root dependencyManagement are defined using 'version.*' variables")
+    void testRootProjectDependencyManagementVersions() throws IOException, JDOMException {
+        List<Element> managementVersions = scanXpath(projectRootPom, XPATH_DEPENDENCY_MANAGEMENT_VERSION);
+        assertAll(managementVersions, (versionTag) -> {
+            if (!versionTag.getText().matches(REGEX_VERSION_REFERENCE)) {
+                failForVersionTag(versionTag);
+            }
+        });
+    }
+
+    @Test
+    @DisplayName("Ensures That all version inside the root pluginManagement are defined using 'version.plugin.*' variables")
+    void testRootProjectPluginManagementVersions() throws IOException, JDOMException {
+        List<Element> managementVersions = scanXpath(projectRootPom, XPATH_PLUGIN_MANAGEMENT_VERSION);
+        assertAll(managementVersions, (versionTag) -> {
+            if (!versionTag.getText().matches(REGEX_PLUGIN_VERSION_REFERENCE)) {
+                failForVersionTag(versionTag);
+            }
+        });
+    }
+
+    private Document parsePom(File pom) throws IOException, JDOMException {
+        SAXBuilder builder = new SAXBuilder();
+        return builder.build(pom);
+    }
+
+    private List<Element> scanXpath(File pom, String xpathExpression) throws IOException, JDOMException {
+        return scanXpath(parsePom(pom), xpathExpression);
+    }
+
+    private List<Element> scanXpath(Document doc, String xpathExpression) {
+        XPathFactory factory = XPathFactory.instance();
+        XPathBuilder<Element> builder = new XPathBuilder<>(xpathExpression, new ElementFilter());
+        builder.setNamespace(Namespace.getNamespace("pom", "http://maven.apache.org/POM/4.0.0"));
+        XPathExpression<Element> expression = builder.compileWith(factory);
+        return expression.evaluate(doc);
+    }
+
+    private void failForVersionTag(Element versionTag) {
+        Namespace ns = versionTag.getNamespace();
+        Element definition = versionTag.getParentElement();
+        String definitionString = "{groupId: " + definition.getChildText("groupId", ns) + ", artifactId:" + definition.getChildText("artifactId", ns)
+                + ", version:" + versionTag.getText() + "}";
+        Assertions.fail("Invalid version tag found for: " + definitionString);
+    }
+
+    static List<File> getAllPomFiles() {
+        List<File> collector = new ArrayList<>();
+        getAllPomFiles(projectRoot, collector);
+        return collector;
+    }
+
+    static List<File> getAllChildPomFiles() {
+        List<File> poms = getAllPomFiles();
+        poms.remove(projectRootPom);
+        return poms;
+    }
+
+    static void getAllPomFiles(File scanDir, List<File> collector) {
+        for (File file : scanDir.listFiles()) {
+            if (file.isFile() && file.getName().equals(POM_XML_NAME)) {
+                collector.add(file);
+            }
+            if (file.isDirectory()) {
+                getAllPomFiles(file, collector);
+            }
+        }
+    }
+}

--- a/language-antlr-utils/pom.xml
+++ b/language-antlr-utils/pom.xml
@@ -18,12 +18,10 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-api</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-testutils</artifactId>
-            <version>${revision}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/language-api/pom.xml
+++ b/language-api/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>com.ibm.icu</groupId>
             <artifactId>icu4j-charset</artifactId>
-            <version>78.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/language-testutils/pom.xml
+++ b/language-testutils/pom.xml
@@ -14,7 +14,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-api</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 </project>

--- a/language-testutils/src/test/java/de/jplag/testutils/AssertionUtils.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/AssertionUtils.java
@@ -1,0 +1,16 @@
+package de.jplag.testutils;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Assertions;
+
+public class AssertionUtils {
+    public static <T> void assertAll(String heading, Collection<T> items, Consumer<T> check) {
+        Assertions.assertAll(heading, items.stream().map(item -> () -> check.accept(item)));
+    }
+
+    public static <T> void assertAll(Collection<T> items, Consumer<T> check) {
+        Assertions.assertAll(items.stream().map(item -> () -> check.accept(item)));
+    }
+}

--- a/language-testutils/src/test/java/de/jplag/testutils/AssertionUtils.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/AssertionUtils.java
@@ -6,11 +6,11 @@ import java.util.function.Consumer;
 import org.junit.jupiter.api.Assertions;
 
 /**
- * Utility functions for assertions
+ * Utility functions for assertions.
  */
 public class AssertionUtils {
     /**
-     * Runs a function on all elements and fails if any of the functions fail, returning all errors to the user
+     * Runs a function on all elements and fails if any of the functions fail, returning all errors to the user.
      * @param items The list of items
      * @param check The check to perform
      * @param <T> The type of element

--- a/language-testutils/src/test/java/de/jplag/testutils/AssertionUtils.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/AssertionUtils.java
@@ -5,11 +5,16 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Assertions;
 
+/**
+ * Utility functions for assertions
+ */
 public class AssertionUtils {
-    public static <T> void assertAll(String heading, Collection<T> items, Consumer<T> check) {
-        Assertions.assertAll(heading, items.stream().map(item -> () -> check.accept(item)));
-    }
-
+    /**
+     * Runs a function on all elements and fails if any of the functions fail, returning all errors to the user
+     * @param items The list of items
+     * @param check The check to perform
+     * @param <T> The type of element
+     */
     public static <T> void assertAll(Collection<T> items, Consumer<T> check) {
         Assertions.assertAll(items.stream().map(item -> () -> check.accept(item)));
     }

--- a/languages/c/pom.xml
+++ b/languages/c/pom.xml
@@ -23,7 +23,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <jdkVersion>21</jdkVersion>
-                            <javadocFriendlyComments>true</javadocFriendlyComments>
+                            <javadocFriendlyComments>true</javadocFriendlyComments> <!-- TODO valid? -->
                             <packageName>de.jplag.c</packageName>
                             <sourceDirectory>src/main/javacc</sourceDirectory>
                             <outputDirectory>${project.build.directory}/generated-sources/javacc</outputDirectory>

--- a/languages/c/pom.xml
+++ b/languages/c/pom.xml
@@ -23,7 +23,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <jdkVersion>21</jdkVersion>
-                            <javadocFriendlyComments>true</javadocFriendlyComments> <!-- TODO valid? -->
+                            <javadocFriendlyComments>true</javadocFriendlyComments>
                             <packageName>de.jplag.c</packageName>
                             <sourceDirectory>src/main/javacc</sourceDirectory>
                             <outputDirectory>${project.build.directory}/generated-sources/javacc</outputDirectory>

--- a/languages/cpp/pom.xml
+++ b/languages/cpp/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/languages/csharp/pom.xml
+++ b/languages/csharp/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/languages/emf-metamodel-dynamic/pom.xml
+++ b/languages/emf-metamodel-dynamic/pom.xml
@@ -13,22 +13,19 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>emf-metamodel</artifactId>
-            <version>${revision}</version>
         </dependency>
+
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.ecore</artifactId>
-            <version>${emf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.common</artifactId>
-            <version>${emf.ecore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-            <version>${emf.ecore.xmi.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/languages/emf-metamodel/pom.xml
+++ b/languages/emf-metamodel/pom.xml
@@ -13,27 +13,22 @@
         <dependency>
             <groupId>org.eclipse.emfatic</groupId>
             <artifactId>org.eclipse.emfatic.core</artifactId>
-            <version>${emfatic.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.core.resources</artifactId>
-            <version>${eclipse.core.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.ecore</artifactId>
-            <version>${emf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.common</artifactId>
-            <version>${emf.ecore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-            <version>${emf.ecore.xmi.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/languages/emf-model/pom.xml
+++ b/languages/emf-model/pom.xml
@@ -13,29 +13,24 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>emf-metamodel-dynamic</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-testutils</artifactId>
-            <version>${revision}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.ecore</artifactId>
-            <version>${emf.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.common</artifactId>
-            <version>${emf.ecore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-            <version>${emf.ecore.xmi.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/languages/emf-model/pom.xml
+++ b/languages/emf-model/pom.xml
@@ -15,12 +15,6 @@
             <artifactId>emf-metamodel-dynamic</artifactId>
         </dependency>
         <dependency>
-            <groupId>de.jplag</groupId>
-            <artifactId>language-testutils</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.emf</groupId>
             <artifactId>org.eclipse.emf.ecore</artifactId>
         </dependency>

--- a/languages/golang/pom.xml
+++ b/languages/golang/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/languages/javascript/pom.xml
+++ b/languages/javascript/pom.xml
@@ -18,19 +18,16 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>typescript</artifactId>
-            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-testutils</artifactId>
-            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -51,7 +48,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
                 <configuration>
                     <!-- required in order to avoid build failure on assembly: -->
                     <detectOfflineLinks>false</detectOfflineLinks>

--- a/languages/kotlin/pom.xml
+++ b/languages/kotlin/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/languages/llvmir/pom.xml
+++ b/languages/llvmir/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/languages/multi-language/pom.xml
+++ b/languages/multi-language/pom.xml
@@ -13,13 +13,11 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>java</artifactId>
-            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>cpp</artifactId>
-            <version>${revision}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/languages/pom.xml
+++ b/languages/pom.xml
@@ -36,12 +36,10 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-api</artifactId>
-            <version>${revision}</version>
         </dependency>
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-testutils</artifactId>
-            <version>${revision}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/languages/python-3/pom.xml
+++ b/languages/python-3/pom.xml
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/languages/rlang/pom.xml
+++ b/languages/rlang/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 
@@ -35,7 +34,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 </project>

--- a/languages/scala/pom.xml
+++ b/languages/scala/pom.xml
@@ -10,23 +10,16 @@
     <artifactId>scala</artifactId>
     <name>JPlag: Scala Language Module</name>
 
-    <properties>
-        <scala.version>2.13.17</scala.version>
-        <scala.compat.version>2.13</scala.compat.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.scalameta/scalameta -->
         <dependency>
             <groupId>org.scalameta</groupId>
-            <artifactId>scalameta_${scala.compat.version}</artifactId>
-            <version>4.14.1</version>
+            <artifactId>scalameta_${version.scalameta.suffix}</artifactId>
         </dependency>
     </dependencies>
 
@@ -34,5 +27,4 @@
         <sourceDirectory>src/main/scala</sourceDirectory>
         <testSourceDirectory>src/test/java</testSourceDirectory>
     </build>
-
 </project>

--- a/languages/scheme/pom.xml
+++ b/languages/scheme/pom.xml
@@ -23,7 +23,8 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <jdkVersion>1.5</jdkVersion>
-                            <javadocFriendlyComments>true</javadocFriendlyComments> <!-- TODO valid? -->
+                            <javadocFriendlyComments>true</javadocFriendlyComments>
+                            <!-- TODO valid? -->
                             <packageName>de.jplag.scheme</packageName>
                             <sourceDirectory>src/main/javacc</sourceDirectory>
                             <outputDirectory>${project.build.directory}/generated-sources/javacc</outputDirectory>

--- a/languages/scheme/pom.xml
+++ b/languages/scheme/pom.xml
@@ -23,7 +23,7 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <jdkVersion>1.5</jdkVersion>
-                            <javadocFriendlyComments>true</javadocFriendlyComments>
+                            <javadocFriendlyComments>true</javadocFriendlyComments> <!-- TODO valid? -->
                             <packageName>de.jplag.scheme</packageName>
                             <sourceDirectory>src/main/javacc</sourceDirectory>
                             <outputDirectory>${project.build.directory}/generated-sources/javacc</outputDirectory>

--- a/languages/scxml/pom.xml
+++ b/languages/scxml/pom.xml
@@ -13,7 +13,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.27.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/languages/swift/pom.xml
+++ b/languages/swift/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
         </dependency>
     </dependencies>
 

--- a/languages/typescript/pom.xml
+++ b/languages/typescript/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>de.jplag</groupId>
             <artifactId>language-antlr-utils</artifactId>
-            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -73,20 +73,53 @@
         <maven.compiler.target>25</maven.compiler.target>
         <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
-        <spotless.version>3.0.0</spotless.version>
-        <slf4j.version>2.0.17</slf4j.version>
-        <junit.version>6.0.1</junit.version>
-        <checkstyle.version>12.1.1</checkstyle.version>
-        <antlr2.version>2.7.7</antlr2.version>
-        <antlr4.version>4.13.2</antlr4.version>
-        <auto-service.version>1.1.1</auto-service.version>
-        <emf.version>2.40.0</emf.version>
-        <emf.ecore.version>2.43.0</emf.ecore.version>
-        <emf.ecore.xmi.version>2.39.0</emf.ecore.xmi.version>
-        <eclipse.core.version>3.23.0</eclipse.core.version>
-        <emfatic.version>1.1.0</emfatic.version>
-        <mockito.version>5.20.0</mockito.version>
-        <record.builder.version>50</record.builder.version>
+
+        <!-- Dependency versions -->
+        <version.antlr2>2.7.7</version.antlr2>
+        <version.antlr4>4.13.2</version.antlr4>
+        <version.argparser4j>0.9.0</version.argparser4j>
+        <version.corenlp>4.5.10</version.corenlp>
+        <version.slf4j>2.0.17</version.slf4j>
+        <version.auto-service>1.1.1</version.auto-service>
+        <version.jackson>2.20.1</version.jackson>
+        <version.spotless>3.0.0</version.spotless>
+        <version.junit>6.0.1</version.junit>
+        <version.mockito>5.20.0</version.mockito>
+        <version.record-builder>50</version.record-builder>
+        <version.picocli>4.7.7</version.picocli>
+        <version.progressbar>0.10.1</version.progressbar>
+        <version.jgrapht>1.5.2</version.jgrapht> <!-- graphs (data-structure) library -->
+        <version.apache.commons.math>3.6.1</version.apache.commons.math>
+        <version.archunit>1.4.1</version.archunit>
+        <version.icu-charset>78.1</version.icu-charset>
+        <version.emf>2.40.0</version.emf>
+        <version.emf.ecore>2.43.0</version.emf.ecore>
+        <version.emf.ecore-xmi>2.39.0</version.emf.ecore-xmi>
+        <version.eclipse.core>3.23.0</version.eclipse.core>
+        <version.eclipse.emfatic>1.1.0</version.eclipse.emfatic>
+        <version.scala>2.13.17</version.scala>
+        <version.scalameta>4.14.1</version.scalameta>
+        <version.scalameta.suffix>2.13</version.scalameta.suffix> <!-- Version suffix for the scalameta depdency -->
+        <version.assertj>3.27.6</version.assertj>
+
+        <!-- Plugin versions -->
+        <version.plugin.javacc>5.0.0</version.plugin.javacc>
+        <version.plugin.maven.jar>3.4.2</version.plugin.maven.jar>
+        <version.plugin.maven.assembly>3.7.1</version.plugin.maven.assembly>
+        <version.plugin.maven.gpg>3.2.8</version.plugin.maven.gpg>
+        <version.plugin.maven.deploy>3.1.4</version.plugin.maven.deploy>
+        <version.plugin.maven.surefire>3.5.4</version.plugin.maven.surefire>
+        <version.plugin.maven.javadoc>3.12.0</version.plugin.maven.javadoc>
+        <version.plugin.maven.source>3.3.1</version.plugin.maven.source>
+        <version.plugin.jacoco>0.8.14</version.plugin.jacoco>
+        <version.plugin.maven-flatten>1.7.3</version.plugin.maven-flatten>
+        <version.plugin.build-helper>3.6.1</version.plugin.build-helper>
+        <version.plugin.checkstyle-puppycrawl>12.1.1</version.plugin.checkstyle-puppycrawl>
+        <version.plugin.checkstyle>3.6.0</version.plugin.checkstyle>
+        <version.plugin.maven-central-publishing>0.9.0</version.plugin.maven-central-publishing>
+        <version.plugin.maven-exec>3.6.2</version.plugin.maven-exec>
+
+
         <!-- ensure that this variable is initialized, even if it is empty -->
         <argLine/>
 
@@ -100,87 +133,343 @@
             <dependency>
                 <groupId>antlr</groupId>
                 <artifactId>antlr</artifactId>
-                <version>${antlr2.version}</version>
+                <version>${version.antlr2}</version>
             </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
-                <version>${antlr4.version}</version>
+                <version>${version.antlr4}</version>
             </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4</artifactId>
-                <version>${antlr4.version}</version>
+                <version>${version.antlr4}</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.argparse4j</groupId>
                 <artifactId>argparse4j</artifactId>
-                <version>0.9.0</version>
+                <version>${version.argparser4j}</version>
             </dependency>
 
             <!-- CoreNLP -->
             <dependency>
                 <groupId>edu.stanford.nlp</groupId>
                 <artifactId>stanford-corenlp</artifactId>
-                <version>4.5.10</version>
+                <version>${version.corenlp}</version>
             </dependency>
 
             <!-- LOGGER -->
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
+                <version>${version.slf4j}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
+                <version>${version.slf4j}</version>
             </dependency>
+
+            <!-- Service loader -->
             <dependency>
                 <groupId>com.google.auto.service</groupId>
                 <artifactId>auto-service</artifactId>
-                <version>${auto-service.version}</version>
+                <version>${version.auto-service}</version>
                 <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>com.google.auto.service</groupId>
                 <artifactId>auto-service-annotations</artifactId>
-                <version>${auto-service.version}</version>
+                <version>${version.auto-service}</version>
             </dependency>
 
+            <!-- Jaxson Json parser/writer -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.20.1</version>
+                <version>${version.jackson}</version>
+            </dependency>
+
+            <!-- JUnit -->
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${version.junit}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>${version.junit}</version>
+            </dependency>
+
+            <!-- Mockito -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${version.mockito}</version>
+            </dependency>
+
+            <!-- Cli -->
+            <dependency>
+                <groupId>info.picocli</groupId>
+                <artifactId>picocli</artifactId>
+                <version>${version.picocli}</version>
+            </dependency>
+
+            <!-- Progress bar -->
+            <dependency>
+                <groupId>me.tongfei</groupId>
+                <artifactId>progressbar</artifactId>
+                <version>${version.progressbar}</version>
+            </dependency>
+
+            <!-- Apache commons -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-math3</artifactId>
+                <version>${version.apache.commons.math}</version>
+            </dependency>
+
+            <!-- JGrapht -->
+            <dependency>
+                <groupId>org.jgrapht</groupId>
+                <artifactId>jgrapht-core</artifactId>
+                <version>${version.jgrapht}</version>
+            </dependency>
+
+            <!-- Record builder -->
+            <dependency>
+                <groupId>io.soabase.record-builder</groupId>
+                <artifactId>record-builder-processor</artifactId>
+                <version>${version.record-builder}</version>
+            </dependency>
+
+            <!-- Archunit -->
+            <dependency>
+                <groupId>com.tngtech.archunit</groupId>
+                <artifactId>archunit-junit5</artifactId>
+                <version>${version.archunit}</version>
+            </dependency>
+
+            <!-- Icu -->
+            <dependency>
+                <groupId>com.ibm.icu</groupId>
+                <artifactId>icu4j-charset</artifactId>
+                <version>${version.icu-charset}</version>
+            </dependency>
+
+            <!-- Eclipse / EMF -->
+            <dependency>
+                <groupId>org.eclipse.emfatic</groupId>
+                <artifactId>org.eclipse.emfatic.core</artifactId>
+                <version>${version.eclipse.emfatic}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.platform</groupId>
+                <artifactId>org.eclipse.core.resources</artifactId>
+                <version>${version.eclipse.core}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.ecore</artifactId>
+                <version>${version.emf}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.common</artifactId>
+                <version>${version.emf.ecore}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+                <version>${version.emf.ecore-xmi}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>emf-metamodel-dynamic</artifactId>
+                <version>${revision}</version>
+            </dependency>
+
+            <!-- Scala -->
+            <dependency>
+                <groupId>org.scala-lang</groupId>
+                <artifactId>scala-library</artifactId>
+                <version>${version.scala}</version>
+            </dependency>
+            <dependency> <!-- https://mvnrepository.com/artifact/org.scalameta/scalameta -->
+                <groupId>org.scalameta</groupId>
+                <artifactId>scalameta_${version.scalameta.suffix}</artifactId>
+                <version>${version.scalameta}</version>
+            </dependency>
+
+            <!-- Assertj -->
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj}</version>
+            </dependency>
+
+            <!-- Internal dependencies -->
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>jplag</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>cli</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>endtoend-testing</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>language-antlr-utils</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>language-testutils</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>language-testutils</artifactId>
+                <version>${revision}</version>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>language-api</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>text</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>java</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>python-3</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>csharp</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>c</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>cpp</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>golang</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>kotlin</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>rlang</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>rust</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>scala</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>scheme</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>scxml</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>swift</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>emf-metamodel</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>emf-model</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>typescript</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>javascript</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>llvmir</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.jplag</groupId>
+                <artifactId>multi-language</artifactId>
+                <version>${revision}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
+        <!-- Junit -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
-            <version>1.2.1</version>
-            <scope>test</scope>
-        </dependency>
+
+        <!-- Mockito -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Slf4j -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -198,23 +487,154 @@
                 <plugin>
                     <groupId>com.helger.maven</groupId>
                     <artifactId>ph-javacc-maven-plugin</artifactId>
-                    <version>5.0.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>antlr-maven-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>${version.plugin.javacc}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-maven-plugin</artifactId>
-                    <version>${antlr4.version}</version>
+                    <version>${version.antlr4}</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${version.plugin.maven.gpg}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${version.plugin.maven-central-publishing}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>${version.plugin.maven-exec}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${version.plugin.build-helper}</version>
+                    <executions>
+                        <execution>
+                            <id>add-source</id>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <phase>generate-sources</phase>
+                            <configuration>
+                                <sources>
+                                    <source>${project.build.directory}/generated-sources/javacc/</source>
+                                    <source>${project.build.directory}/generated-sources/antlr4/</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${version.spotless}</version>
+                    <configuration>
+                        <java>
+                            <eclipse>
+                                <!--suppress UnresolvedMavenProperty -->
+                                <file>${maven.multiModuleProjectDirectory}/formatter.xml</file>
+                            </eclipse>
+
+                            <importOrder>
+                                <file>spotless.importorder</file>
+                            </importOrder>
+                            <removeUnusedImports/>
+                        </java>
+                        <pom>
+                            <sortPom>
+                                <encoding>UTF-8</encoding>
+                                <keepBlankLines>true</keepBlankLines>
+                                <indentBlankLines>false</indentBlankLines>
+                                <nrOfIndentSpace>4</nrOfIndentSpace>
+                            </sortPom>
+                        </pom>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${version.plugin.maven.source}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${version.plugin.checkstyle}</version>
+                    <configuration>
+                        <configLocation>config/checkstyle/checkstyle.xml</configLocation>
+                        <sourceDirectories>
+                            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                            <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                        </sourceDirectories>
+                        <consoleOutput>true</consoleOutput>
+                        <failsOnError>true</failsOnError>
+                        <linkXRef>false</linkXRef>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>${version.plugin.checkstyle-puppycrawl}</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <id>verify-checkstyle</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <phase>verify</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>${version.plugin.maven-flatten}</version>
+                    <configuration>
+                        <updatePomFile>true</updatePomFile>
+                        <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                        <pomElements>
+                            <dependencyManagement>expand</dependencyManagement>
+                            <dependencies>expand</dependencies>
+                        </pomElements>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>flatten</id>
+                            <goals>
+                                <goal>flatten</goal>
+                            </goals>
+                            <phase>process-resources</phase>
+                        </execution>
+                        <execution>
+                            <id>flatten.clean</id>
+                            <goals>
+                                <goal>clean</goal>
+                            </goals>
+                            <phase>clean</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>${version.plugin.maven.jar}</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -234,7 +654,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.7.1</version>
+                    <version>${version.plugin.maven.assembly}</version>
                     <configuration>
                         <descriptorRefs>
                             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -247,12 +667,12 @@
                         </archive>
                     </configuration>
                 </plugin>
-                <plugin>
+                <plugin> <!-- implicitly loaded by maven for jar projects -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.4</version>
+                    <version>${version.plugin.maven.surefire}</version>
                     <configuration>
-                        <argLine>@{argLine} -javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</argLine>
+                        <argLine>@{argLine} -javaagent:"${settings.localRepository}/org/mockito/mockito-core/${version.mockito}/mockito-core-${version.mockito}.jar"</argLine>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -264,7 +684,12 @@
                             <path>
                                 <groupId>com.google.auto.service</groupId>
                                 <artifactId>auto-service</artifactId>
-                                <version>${auto-service.version}</version>
+                                <version>${version.auto-service}</version>
+                            </path>
+                            <path>
+                                <groupId>io.soabase.record-builder</groupId>
+                                <artifactId>record-builder-processor</artifactId>
+                                <version>${version.record-builder}</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>
@@ -272,7 +697,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.14</version>
+                    <version>${version.plugin.jacoco}</version>
                     <executions>
                         <execution>
                             <id>prepare-agent</id>
@@ -295,13 +720,19 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.8</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.4</version>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${version.plugin.maven.javadoc}</version>
+                    <configuration>
+                        <sourcepath>src/main/java;target/generated-sources/annotations;target/generated-sources/antlr4;target/generated-sources/javacc</sourcepath>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -309,113 +740,35 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.7.3</version>
-                <configuration>
-                    <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
-                    <pomElements>
-                        <dependencyManagement>expand</dependencyManagement>
-                        <dependencies>expand</dependencies>
-                    </pomElements>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>flatten</id>
-                        <goals>
-                            <goal>flatten</goal>
-                        </goals>
-                        <phase>process-resources</phase>
-                    </execution>
-                    <execution>
-                        <id>flatten.clean</id>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                        <phase>clean</phase>
-                    </execution>
-                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.6.1</version>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources/javacc/</source>
-                                <source>${project.build.directory}/generated-sources/antlr/</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.6.0</version>
-                <configuration>
-                    <configLocation>config/checkstyle/checkstyle.xml</configLocation>
-                    <sourceDirectories>
-                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
-                    </sourceDirectories>
-                    <consoleOutput>true</consoleOutput>
-                    <failsOnError>true</failsOnError>
-                    <linkXRef>false</linkXRef>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>${checkstyle.version}</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <id>verify-checkstyle</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>verify</phase>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+            </plugin>
+
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
@@ -423,36 +776,6 @@
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>${spotless.version}</version>
-                <configuration>
-                    <java>
-                        <eclipse>
-                            <!--suppress UnresolvedMavenProperty -->
-                            <file>${maven.multiModuleProjectDirectory}/formatter.xml</file>
-                        </eclipse>
-
-                        <importOrder>
-                            <file>spotless.importorder</file>
-                        </importOrder>
-                        <removeUnusedImports/>
-                    </java>
-                    <pom>
-                        <sortPom>
-                            <encoding>UTF-8</encoding>
-                            <keepBlankLines>true</keepBlankLines>
-                            <indentBlankLines>false</indentBlankLines>
-                            <nrOfIndentSpace>4</nrOfIndentSpace>
-                        </sortPom>
-                    </pom>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -74,50 +74,50 @@
 
         <!-- Dependency versions -->
         <version.antlr4>4.13.2</version.antlr4>
-        <version.argparser4j>0.9.0</version.argparser4j>
-        <version.corenlp>4.5.10</version.corenlp>
-        <version.slf4j>2.0.17</version.slf4j>
-        <version.auto-service>1.1.1</version.auto-service>
-        <version.jackson>2.20.1</version.jackson>
-        <version.junit>6.0.1</version.junit>
-        <version.mockito>5.20.0</version.mockito>
-        <version.record-builder>51</version.record-builder>
-        <version.picocli>4.7.7</version.picocli>
-        <version.progressbar>0.10.1</version.progressbar>
-        <version.jgrapht>1.5.2</version.jgrapht>
         <version.apache.commons.math>3.6.1</version.apache.commons.math>
         <version.archunit>1.4.1</version.archunit>
-        <version.icu-charset>78.1</version.icu-charset>
-        <version.emf>2.40.0</version.emf>
-        <version.emf.ecore>2.43.0</version.emf.ecore>
-        <version.emf.ecore-xmi>2.39.0</version.emf.ecore-xmi>
+        <version.argparser4j>0.9.0</version.argparser4j>
+        <version.assertj>3.27.6</version.assertj>
+        <version.auto-service>1.1.1</version.auto-service>
+        <version.corenlp>4.5.10</version.corenlp>
         <version.eclipse.core>3.23.0</version.eclipse.core>
         <version.eclipse.emfatic>1.1.0</version.eclipse.emfatic>
-        <version.scala>2.13.17</version.scala>
-        <version.scalameta>4.14.1</version.scalameta>
-        <version.scalameta.suffix>2.13</version.scalameta.suffix>
-        <version.assertj>3.27.6</version.assertj>
-        <version.jdom>2.0.6.1</version.jdom>
+        <version.emf.ecore-xmi>2.39.0</version.emf.ecore-xmi>
+        <version.emf.ecore>2.43.0</version.emf.ecore>
+        <version.emf>2.40.0</version.emf>
+        <version.icu-charset>78.1</version.icu-charset>
+        <version.jackson>2.20.1</version.jackson>
         <version.jaxen>2.0.0</version.jaxen>
+        <version.jdom>2.0.6.1</version.jdom>
+        <version.jgrapht>1.5.2</version.jgrapht>
+        <version.junit>6.0.1</version.junit>
+        <version.mockito>5.20.0</version.mockito>
+        <version.picocli>4.7.7</version.picocli>
+        <version.progressbar>0.10.1</version.progressbar>
+        <version.record-builder>51</version.record-builder>
+        <version.scala>2.13.17</version.scala>
+        <version.scalameta.suffix>2.13</version.scalameta.suffix>
+        <version.scalameta>4.14.1</version.scalameta>
+        <version.slf4j>2.0.17</version.slf4j>
 
         <!-- Plugin versions -->
-        <version.plugin.antlr4>4.13.2</version.plugin.antlr4>
-        <version.plugin.javacc>5.0.0</version.plugin.javacc>
-        <version.plugin.maven.jar>3.4.2</version.plugin.maven.jar>
-        <version.plugin.maven.assembly>3.7.1</version.plugin.maven.assembly>
-        <version.plugin.maven.gpg>3.2.8</version.plugin.maven.gpg>
-        <version.plugin.maven.deploy>3.1.4</version.plugin.maven.deploy>
-        <version.plugin.maven.surefire>3.5.4</version.plugin.maven.surefire>
-        <version.plugin.maven.javadoc>3.12.0</version.plugin.maven.javadoc>
-        <version.plugin.maven.source>3.3.1</version.plugin.maven.source>
-        <version.plugin.maven.compiler>3.14.1</version.plugin.maven.compiler>
-        <version.plugin.jacoco>0.8.14</version.plugin.jacoco>
-        <version.plugin.maven-flatten>1.7.3</version.plugin.maven-flatten>
+        <version.plugin.antlr4>${version.antlr4}</version.plugin.antlr4>
         <version.plugin.build-helper>3.6.1</version.plugin.build-helper>
         <version.plugin.checkstyle-puppycrawl>12.1.2</version.plugin.checkstyle-puppycrawl>
         <version.plugin.checkstyle>3.6.0</version.plugin.checkstyle>
+        <version.plugin.jacoco>0.8.14</version.plugin.jacoco>
+        <version.plugin.javacc>5.0.0</version.plugin.javacc>
         <version.plugin.maven-central-publishing>0.9.0</version.plugin.maven-central-publishing>
         <version.plugin.maven-exec>3.6.2</version.plugin.maven-exec>
+        <version.plugin.maven-flatten>1.7.3</version.plugin.maven-flatten>
+        <version.plugin.maven.assembly>3.7.1</version.plugin.maven.assembly>
+        <version.plugin.maven.compiler>3.14.1</version.plugin.maven.compiler>
+        <version.plugin.maven.deploy>3.1.4</version.plugin.maven.deploy>
+        <version.plugin.maven.gpg>3.2.8</version.plugin.maven.gpg>
+        <version.plugin.maven.jar>3.4.2</version.plugin.maven.jar>
+        <version.plugin.maven.javadoc>3.12.0</version.plugin.maven.javadoc>
+        <version.plugin.maven.source>3.3.1</version.plugin.maven.source>
+        <version.plugin.maven.surefire>3.5.4</version.plugin.maven.surefire>
         <version.plugin.spotless>3.0.0</version.plugin.spotless>
 
         <!-- ensure that this variable is initialized, even if it is empty -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,24 +71,21 @@
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
-        <maven.compiler.plugin.version>3.14.1</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
 
         <!-- Dependency versions -->
-        <version.antlr2>2.7.7</version.antlr2>
         <version.antlr4>4.13.2</version.antlr4>
         <version.argparser4j>0.9.0</version.argparser4j>
         <version.corenlp>4.5.10</version.corenlp>
         <version.slf4j>2.0.17</version.slf4j>
         <version.auto-service>1.1.1</version.auto-service>
         <version.jackson>2.20.1</version.jackson>
-        <version.spotless>3.0.0</version.spotless>
         <version.junit>6.0.1</version.junit>
         <version.mockito>5.20.0</version.mockito>
         <version.record-builder>50</version.record-builder>
         <version.picocli>4.7.7</version.picocli>
         <version.progressbar>0.10.1</version.progressbar>
-        <version.jgrapht>1.5.2</version.jgrapht> <!-- graphs (data-structure) library -->
+        <version.jgrapht>1.5.2</version.jgrapht>
+        <!-- graphs (data-structure) library -->
         <version.apache.commons.math>3.6.1</version.apache.commons.math>
         <version.archunit>1.4.1</version.archunit>
         <version.icu-charset>78.1</version.icu-charset>
@@ -99,10 +96,14 @@
         <version.eclipse.emfatic>1.1.0</version.eclipse.emfatic>
         <version.scala>2.13.17</version.scala>
         <version.scalameta>4.14.1</version.scalameta>
-        <version.scalameta.suffix>2.13</version.scalameta.suffix> <!-- Version suffix for the scalameta depdency -->
+        <version.scalameta.suffix>2.13</version.scalameta.suffix>
+        <!-- Version suffix for the scalameta depdency -->
         <version.assertj>3.27.6</version.assertj>
+        <version.jdom>2.0.6.1</version.jdom>
+        <version.jaxen>2.0.0</version.jaxen>
 
         <!-- Plugin versions -->
+        <version.plugin.antlr4>4.13.2</version.plugin.antlr4>
         <version.plugin.javacc>5.0.0</version.plugin.javacc>
         <version.plugin.maven.jar>3.4.2</version.plugin.maven.jar>
         <version.plugin.maven.assembly>3.7.1</version.plugin.maven.assembly>
@@ -111,6 +112,7 @@
         <version.plugin.maven.surefire>3.5.4</version.plugin.maven.surefire>
         <version.plugin.maven.javadoc>3.12.0</version.plugin.maven.javadoc>
         <version.plugin.maven.source>3.3.1</version.plugin.maven.source>
+        <version.plugin.maven.compiler>3.14.1</version.plugin.maven.compiler>
         <version.plugin.jacoco>0.8.14</version.plugin.jacoco>
         <version.plugin.maven-flatten>1.7.3</version.plugin.maven-flatten>
         <version.plugin.build-helper>3.6.1</version.plugin.build-helper>
@@ -118,7 +120,7 @@
         <version.plugin.checkstyle>3.6.0</version.plugin.checkstyle>
         <version.plugin.maven-central-publishing>0.9.0</version.plugin.maven-central-publishing>
         <version.plugin.maven-exec>3.6.2</version.plugin.maven-exec>
-
+        <version.plugin.spotless>3.0.0</version.plugin.spotless>
 
         <!-- ensure that this variable is initialized, even if it is empty -->
         <argLine/>
@@ -130,11 +132,6 @@
     <dependencyManagement>
         <dependencies>
             <!-- ANTLR -->
-            <dependency>
-                <groupId>antlr</groupId>
-                <artifactId>antlr</artifactId>
-                <version>${version.antlr2}</version>
-            </dependency>
             <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
@@ -296,7 +293,8 @@
                 <artifactId>scala-library</artifactId>
                 <version>${version.scala}</version>
             </dependency>
-            <dependency> <!-- https://mvnrepository.com/artifact/org.scalameta/scalameta -->
+            <dependency>
+                <!-- https://mvnrepository.com/artifact/org.scalameta/scalameta -->
                 <groupId>org.scalameta</groupId>
                 <artifactId>scalameta_${version.scalameta.suffix}</artifactId>
                 <version>${version.scalameta}</version>
@@ -307,6 +305,18 @@
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${version.assertj}</version>
+            </dependency>
+
+            <!-- Xml parsing -->
+            <dependency>
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom2</artifactId>
+                <version>${version.jdom}</version>
+            </dependency>
+            <dependency>
+                <groupId>jaxen</groupId>
+                <artifactId>jaxen</artifactId>
+                <version>${version.jaxen}</version>
             </dependency>
 
             <!-- Internal dependencies -->
@@ -492,7 +502,7 @@
                 <plugin>
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-maven-plugin</artifactId>
-                    <version>${version.antlr4}</version>
+                    <version>${version.plugin.antlr4}</version>
                 </plugin>
 
                 <plugin>
@@ -535,7 +545,7 @@
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>${version.spotless}</version>
+                    <version>${version.plugin.spotless}</version>
                     <configuration>
                         <java>
                             <eclipse>
@@ -667,7 +677,8 @@
                         </archive>
                     </configuration>
                 </plugin>
-                <plugin> <!-- implicitly loaded by maven for jar projects -->
+                <plugin>
+                    <!-- implicitly loaded by maven for jar projects -->
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.plugin.maven.surefire}</version>
@@ -678,7 +689,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven.compiler.plugin.version}</version>
+                    <version>${version.plugin.maven.compiler}</version>
                     <configuration>
                         <annotationProcessorPaths>
                             <path>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
         <version.picocli>4.7.7</version.picocli>
         <version.progressbar>0.10.1</version.progressbar>
         <version.jgrapht>1.5.2</version.jgrapht>
-        <!-- graphs (data-structure) library -->
         <version.apache.commons.math>3.6.1</version.apache.commons.math>
         <version.archunit>1.4.1</version.archunit>
         <version.icu-charset>78.1</version.icu-charset>
@@ -97,7 +96,6 @@
         <version.scala>2.13.17</version.scala>
         <version.scalameta>4.14.1</version.scalameta>
         <version.scalameta.suffix>2.13</version.scalameta.suffix>
-        <!-- Version suffix for the scalameta depdency -->
         <version.assertj>3.27.6</version.assertj>
         <version.jdom>2.0.6.1</version.jdom>
         <version.jaxen>2.0.0</version.jaxen>


### PR DESCRIPTION
This PR moves all dependency and plugin versions in maven into the management sections in the root pom.xml. Redundant and obsolete dependencies have been removed and the plugin configurations have mostly been moved to the pluginManagement section and simplified.

All versions are now defined using 'version.\*' variables in maven
All plugin versions are now defined using 'version.plugin.\*' in maven

Fixes #2606