### PR TITLE
Fix scroll to top in Report Viewer

### DIFF
--- a/report-viewer/ui-components/widget/comparisonTable/ComparisonTable.vue
+++ b/report-viewer/ui-components/widget/comparisonTable/ComparisonTable.vue
@@ -503,10 +503,9 @@ function changeAnonymous(event: Event, submissionId: string) {
 }
 
 function scrollToItem(itemIndex?: number) {
-  if (!itemIndex) {
-    dynamicScroller.value?.scrollToBottom()
+  if (itemIndex !== undefined && itemIndex >= 0) {
+    dynamicScroller.value?.scrollToItem(itemIndex)
   }
-  dynamicScroller.value?.scrollToItem(itemIndex)
 }
 defineExpose({
   scrollToItem


### PR DESCRIPTION
This PR fixes #2734 by checking the index to scroll to against `undefined` explicitly instead of checking for falsiness. This way, `0` is accepted as a valid index to scroll to, enabling scrolling to the top of the ComparisonTable by clicking the top bucket in the DistributionDiagram.