### PR TITLE
Fix deploy actions

### DIFF
--- a/.github/workflows/report-viewer-deploy-demo.yml
+++ b/.github/workflows/report-viewer-deploy-demo.yml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/report-viewer-deploy-dev-demo.yml
+++ b/.github/workflows/report-viewer-deploy-dev-demo.yml
@@ -71,6 +71,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
               
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/report-viewer-deploy-develop.yml
+++ b/.github/workflows/report-viewer-deploy-develop.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
This PR fixes the GitHub cross-repo deploy actions, which use actions/checkout@v6 and JamesIves/github-pages-deploy-action@v4.7.6. 

According to the now-updated [documentation ](https://github.com/JamesIves/github-pages-deploy-action/blob/9d6240e5eab335a7860d6cb2f9ca1995ffda454e/README.md#:~:text=When%20using%20actions/checkout%2C%20you%20must%20also%20set%20persist%2Dcredentials%3A%20false%20in%20the%20checkout%20step%20to%20prevent%20authentication%20conflicts.) of JamesIves/github-pages-deploy-action, the flag `persist-credentials: false` should be added to the Checkout step to fix credential injection; this PR does just that.