### PR TITLE
Enhance token warning information

### DIFF
--- a/language-api/src/main/java/de/jplag/Token.java
+++ b/language-api/src/main/java/de/jplag/Token.java
@@ -68,16 +68,16 @@ public class Token {
      */
     public Token(TokenType type, File file, int startLine, int startColumn, int endLine, int endColumn, int length) {
         if (startLine == 0 || endLine == 0) {
-            logger.warn("Creating a token with line index 0 while index is 1-based. "
-                    + generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
+            logger.warn("Creating a token with line index 0 while index is 1-based. {}",
+                    generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
         }
         if (startColumn == 0 || endColumn == 0) {
-            logger.warn("Creating a token with column index 0 while index is 1-based. "
-                    + generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
+            logger.warn("Creating a token with column index 0 while index is 1-based. {}",
+                    generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
         }
         if (startLine > endLine || startLine == endLine && startColumn > endColumn) {
-            logger.warn("Creating a token that ends earlier than it start. "
-                    + generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
+            logger.warn("Creating a token that ends earlier than it start. {}",
+                    generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
         }
         this.type = type;
         this.file = file;

--- a/language-api/src/main/java/de/jplag/Token.java
+++ b/language-api/src/main/java/de/jplag/Token.java
@@ -68,13 +68,16 @@ public class Token {
      */
     public Token(TokenType type, File file, int startLine, int startColumn, int endLine, int endColumn, int length) {
         if (startLine == 0 || endLine == 0) {
-            logger.warn("Creating a token with line index 0 while index is 1-based");
+            logger.warn("Creating a token with line index 0 while index is 1-based. "
+                    + generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
         }
         if (startColumn == 0 || endColumn == 0) {
-            logger.warn("Creating a token with column index 0 while index is 1-based");
+            logger.warn("Creating a token with column index 0 while index is 1-based. "
+                    + generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
         }
         if (startLine > endLine || startLine == endLine && startColumn > endColumn) {
-            logger.warn("Creating a token that ends earlier than it start. Start: {}:{}; End: {}:{}", startLine, startColumn, endLine, endColumn);
+            logger.warn("Creating a token that ends earlier than it start. "
+                    + generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
         }
         this.type = type;
         this.file = file;
@@ -217,5 +220,9 @@ public class Token {
      */
     public CodeSemantics getSemantics() {
         return semantics;
+    }
+
+    private static String generateErrorPosition(TokenType type, File file, int startLine, int startColumn, int endLine, int endColumn) {
+        return String.format("Type: %s; File: %s; Start: %d:%d; End: %d:%d", type, file, startLine, startColumn, endLine, endColumn);
     }
 }

--- a/language-api/src/main/java/de/jplag/Token.java
+++ b/language-api/src/main/java/de/jplag/Token.java
@@ -67,18 +67,21 @@ public class Token {
      * @param length is the length of the token in the source code.
      */
     public Token(TokenType type, File file, int startLine, int startColumn, int endLine, int endColumn, int length) {
-        if (startLine == 0 || endLine == 0) {
-            logger.warn("Creating a token with line index 0 while index is 1-based. {}",
-                    generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
+        if (logger.isWarnEnabled()) {
+            if (startLine == 0 || endLine == 0) {
+                logger.warn("Creating a token with line index 0 while index is 1-based. {}",
+                        generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
+            }
+            if (startColumn == 0 || endColumn == 0) {
+                logger.warn("Creating a token with column index 0 while index is 1-based. {}",
+                        generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
+            }
+            if (startLine > endLine || startLine == endLine && startColumn > endColumn) {
+                logger.warn("Creating a token that ends earlier than it start. {}",
+                        generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
+            }
         }
-        if (startColumn == 0 || endColumn == 0) {
-            logger.warn("Creating a token with column index 0 while index is 1-based. {}",
-                    generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
-        }
-        if (startLine > endLine || startLine == endLine && startColumn > endColumn) {
-            logger.warn("Creating a token that ends earlier than it start. {}",
-                    generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
-        }
+
         this.type = type;
         this.file = file;
         this.startLine = startLine;

--- a/language-api/src/main/java/de/jplag/Token.java
+++ b/language-api/src/main/java/de/jplag/Token.java
@@ -77,7 +77,7 @@ public class Token {
                         generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
             }
             if (startLine > endLine || startLine == endLine && startColumn > endColumn) {
-                logger.warn("Creating a token that ends earlier than it start. {}",
+                logger.warn("Creating a token that ends before it starts. {}",
                         generateErrorPosition(type, file, startLine, startColumn, endLine, endColumn));
             }
         }


### PR DESCRIPTION
This PR enhances the warnings for invalid token data to improve tracing them to their exact source.
Closes #2732 

Example:
```
2026-01-04-01:59:01_330 [WARN] Token - Creating a token that ends earlier than it start. Type: J_VARDEF; File: AbsolutePath\Black Dolphin\Sociologia.java; Start: 134:38; End: 134:31
```