### PR TITLE
Fix vulnerabilites in Sonar CI workflows

### DIFF
--- a/.github/workflows/check-sonarcloud-main-develop.yml
+++ b/.github/workflows/check-sonarcloud-main-develop.yml
@@ -18,7 +18,7 @@ jobs:
   sonar:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/check-sonarcloud-pr.yml
+++ b/.github/workflows/check-sonarcloud-pr.yml
@@ -16,7 +16,7 @@ jobs:
   get-info:
     name: "Get information about the source run"
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
     outputs:
       sourceHeadRepo: ${{ steps.source-run-info.outputs.sourceHeadRepo }}
       sourceHeadBranch: ${{ steps.source-run-info.outputs.sourceHeadBranch }}
@@ -38,14 +38,16 @@ jobs:
   sonar:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
-    if: ${{ needs.get-info.outputs.sourceEvent == 'pull_request' && github.actor != 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ needs.get-info.outputs.sourceEvent == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
     needs: get-info
 
     steps:
       - uses: actions/checkout@v6
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ env.HEAD_BRANCH }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/check-sonarcloud-pr.yml
+++ b/.github/workflows/check-sonarcloud-pr.yml
@@ -43,11 +43,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
-          ref: ${{ env.HEAD_BRANCH }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK
         uses: actions/setup-java@v5

--- a/.github/workflows/report-viewer-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-check-sonarcloud.yml
@@ -26,7 +26,7 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
This PR addresses some vulnerabilities in the GitHub Actions workflows related to Sonar scans.
Note that these issues are also raised by Sonar and thus cause the Sonar check to fail for the `develop` branch.

From sonar:

_Using `github.actor` or equivalent properties to check if the actor is a trusted principal on events like `pull_request_target` could be a security issue, because they do not always refer to the actual creator of the commit or the pull request._

_The value represents the entity who triggered the workflow event, which may differ from the actual author of the commit or pull request. If a threat actor could force a trusted actor (such as a bot) into making a change that triggers the workflow, they can bypass the check._

See also: https://rules.sonarsource.com/githubactions/RSPEC-8232/