### PR TITLE
Use short hash 

### DIFF
--- a/report-viewer/report-viewer/src/components/VersionRepositoryReference.vue
+++ b/report-viewer/report-viewer/src/components/VersionRepositoryReference.vue
@@ -13,7 +13,7 @@
         class="text-link-dark dark:text-link underline"
         target="_blank"
         :href="`https://github.com/jplag/JPlag/commit/${commitHash}`"
-        >{{ commitHash }}</a
+        >{{ commitHash.substring(0, 7) }}</a
       >
     </span>
     <span>


### PR DESCRIPTION
On the main screens of the dev versions we use the long commit hash. This shortens it to 6 characters