### PR TITLE
Add coverage data for report viewer

### DIFF
--- a/.github/workflows/report-viewer-test-unit.yml
+++ b/.github/workflows/report-viewer-test-unit.yml
@@ -8,6 +8,10 @@ on:
       - ".github/workflows/report-viewer-test-unit.yml"
       - "report-viewer/**"
 
+permissions:
+  issues: write
+  pull-requests: write 
+
 jobs:
   pre_job:
     runs-on: ubuntu-latest
@@ -25,30 +29,107 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
+      - name: Checkout
         uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
 
-      - name: Install
+      - name: Install and run tests and merge-reports
+        id: generate
         working-directory: report-viewer
         run: |
           npm install
-      - name: Test model
-        working-directory: report-viewer/model
+          npm run test:coverage --workspaces
+          npm run merge-coverage
+      
+      - name: Post comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const owner = "jplag"
+            const repo = "JPlag"
+            const issueNumber = ${{ github.event.pull_request.number }}
+
+            // Delete old comments
+            const comments = await github.paginate(
+                github.issues.listComments,
+                {
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  per_page: 100,
+                }
+              )
+            for (const comment of comments) {
+              if (comment.user.login !== 'github-actions[bot]') {
+                continue;
+              }
+              if (!comment.body.includes('Coverage')) {
+                continue;
+              }
+              await github.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: comment.id,
+              })
+            }
+
+            // read coverage results
+            const fs = require('fs');
+            const path = require('path');
+            const basePath = path.join(process.cwd(), 'report-viewer/coverage/');
+            const summaryPath = path.join(basePath, 'summary.txt');
+            const detailPath = path.join(basePath, 'detail.txt');
+            const globber = await glob.create('report-viewer/*/coverage/summary.txt');
+            const packageSummaryPaths = (await globber.glob()).sort();
+
+            // build comment body
+            const summaryContent = fs.readFileSync(summaryPath, 'utf8').trim();
+            const detailContent = fs.readFileSync(detailPath, 'utf8').trim();
+            const packageSummaries = packageSummaryPaths.map(p => {
+              const content = fs.readFileSync(p, 'utf8').trim();
+              const name = path.relative(path.join(process.cwd(), 'report-viewer/'), p).split('/')[0];
+              return `### ${name}\n\`\`\`\n${content}\n\`\`\``;
+            }).join('\n');
+            const body = `\`\`\`
+            ${summaryContent}
+            \`\`\`
+            <details>
+            <summary>Per Package Coverage</summary>
+
+            ${packageSummaries}
+            </details>
+            <details>
+            <summary>Per File Coverage</summary>
+
+            \`\`\`
+            ${detailContent}
+            \`\`\`
+            </details>`
+
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+
+      - name: Upload coverage results
+        uses: actions/upload-artifact@v6
+        with:
+          name: "coverage-report"
+          path: report-viewer/coverage/html
+          retention-days: 30
+
+      - name: Fail on low coverage
+        env:
+          COVERAGE: ${{ steps.generate.outputs.COVERAGE }}
         run: |
-          npm run test
-      - name: Test parser
-        working-directory: report-viewer/parser
-        run: |
-          npm run test
-      - name: Test ui-components
-        working-directory: report-viewer/ui-components
-        run: |
-          npm run test
-      - name: Test report-viewer
-        working-directory: report-viewer/report-viewer
-        run: |
-          npm run test:unit
+          echo "Coverage: ${{ steps.generate.outputs.COVERAGE }}"
+          if [ $(bc <<< "$COVERAGE < 20.0") -eq 1 ]; then
+            exit 1
+          fi

--- a/report-viewer/base.vitest.config.ts
+++ b/report-viewer/base.vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['json', ['text-summary', { file: 'summary.txt' }]],
+      reportsDirectory: './coverage',
+      exclude: ['**/tests/**']
+    }
+  }
+})

--- a/report-viewer/eslint.config.mjs
+++ b/report-viewer/eslint.config.mjs
@@ -11,7 +11,14 @@ export default [
   ...tseslint.configs.recommended,
   eslintConfigPrettier,
   {
-    ignores: ['**/*.config.ts', '**/node_modules/**', '**/dist/**', '**/playwright-report/**']
+    ignores: [
+      '**/*.config.ts',
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/playwright-report/**',
+      './scripts/**',
+      '**/coverage/**'
+    ]
   },
   {
     files: ['**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx', '**/*.vue'],

--- a/report-viewer/model/package.json
+++ b/report-viewer/model/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
   }
 }

--- a/report-viewer/model/vitest.config.ts
+++ b/report-viewer/model/vitest.config.ts
@@ -1,0 +1,3 @@
+import baseVitestConfig from '../base.vitest.config'
+
+export default baseVitestConfig

--- a/report-viewer/package-lock.json
+++ b/report-viewer/package-lock.json
@@ -9,17 +9,22 @@
       "workspaces": [
         "report-viewer/",
         "ui-components/",
-        "model/"
+        "model/",
+        "parser/"
       ],
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.4",
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.2.3",
+        "@vitest/coverage-v8": "^4.0.18",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.6.0",
         "eslint": "^10.0.2",
         "eslint-plugin-vue": "^10.8.0",
         "globals": "^17.3.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
         "lint-staged": "^16.2.7",
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
@@ -136,6 +141,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -2269,6 +2284,37 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
@@ -2852,6 +2898,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-walker-scope": {
@@ -4707,6 +4765,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5254,6 +5319,68 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -5311,6 +5438,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -5889,6 +6023,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {

--- a/report-viewer/package.json
+++ b/report-viewer/package.json
@@ -12,17 +12,22 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint --max-warnings 0",
-    "prepare": "git config --local core.hooksPath gitHooks/hooks"
+    "prepare": "git config --local core.hooksPath gitHooks/hooks",
+    "merge-coverage": "node scripts/merge-coverage-reports.js"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.4",
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.2.3",
+    "@vitest/coverage-v8": "^4.0.18",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.6.0",
     "eslint": "^10.0.2",
     "eslint-plugin-vue": "^10.8.0",
     "globals": "^17.3.0",
+    "istanbul-lib-coverage": "^3.2.2",
+    "istanbul-lib-report": "^3.0.1",
+    "istanbul-reports": "^3.2.0",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",

--- a/report-viewer/parser/package.json
+++ b/report-viewer/parser/package.json
@@ -9,6 +9,7 @@
     "slash": "^5.1.0"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
   }
 }

--- a/report-viewer/parser/vitest.config.ts
+++ b/report-viewer/parser/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vite'
+import baseVitestConfig from '../base.vitest.config'
+
+export default baseVitestConfig

--- a/report-viewer/report-viewer/package.json
+++ b/report-viewer/report-viewer/package.json
@@ -13,7 +13,8 @@
     "type-check": "vue-tsc --noEmit --composite false",
     "test:e2e": "playwright test",
     "test:unit": "vitest",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@fortawesome/free-brands-svg-icons": "^7.2.0",

--- a/report-viewer/report-viewer/vitest.config.ts
+++ b/report-viewer/report-viewer/vitest.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from 'vite'
+import { defineConfig, mergeConfig } from 'vite'
 import { configDefaults } from 'vitest/config'
+import baseVitestConfig from '../base.vitest.config'
 
-export default defineConfig({
-  test: {
-    exclude: [...configDefaults.exclude, 'tests/e2e/*']
-  }
-})
+export default mergeConfig(
+  baseVitestConfig,
+  defineConfig({
+    test: {
+      exclude: [...configDefaults.exclude, 'tests/e2e/*', 'src/views', 'src/viewWrapper']
+    }
+  })
+)

--- a/report-viewer/scripts/merge-coverage-reports.js
+++ b/report-viewer/scripts/merge-coverage-reports.js
@@ -1,0 +1,38 @@
+import iCoverage from 'istanbul-lib-coverage'
+import iReport from 'istanbul-lib-report'
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync } from 'fs'
+import reports from 'istanbul-reports'
+
+const coverageMap = iCoverage.createCoverageMap({})
+
+const files = ['parser', 'model', 'ui-components', 'report-viewer'].map(
+  (pkg) => `${pkg}/coverage/coverage-final.json`
+)
+
+files.forEach((file) => {
+  const coverage = JSON.parse(readFileSync(file, 'utf-8'))
+  coverageMap.merge(coverage)
+})
+
+// remove old coverage report if exists and create new one
+if (existsSync('coverage')) {
+  rmSync('coverage', { recursive: true, force: true })
+}
+mkdirSync('coverage')
+
+const context = iReport.createContext({
+  dir: 'coverage',
+  coverageMap
+})
+
+reports.create('text-summary', { file: 'summary.txt' }).execute(context)
+reports.create('text', { file: 'detail.txt', maxCols: 200, skipEmpty: true }).execute(context)
+reports.create('html', { subdir: 'html' }).execute(context)
+
+// export summary for github actions to allow it to fail
+const githubOutput = process.env.GITHUB_OUTPUT
+if (githubOutput) {
+  appendFileSync(githubOutput, `COVERAGE=${coverageMap.getCoverageSummary().lines.pct}\n`)
+}
+
+console.log('Merged Coverage Reports')

--- a/report-viewer/ui-components/package.json
+++ b/report-viewer/ui-components/package.json
@@ -20,7 +20,8 @@
     "vue": "^3.5.20"
   },
   "scripts": {
-    "test": "vitest"
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "jsdom": "^28.1.0",

--- a/report-viewer/ui-components/vitest.config.ts
+++ b/report-viewer/ui-components/vitest.config.ts
@@ -1,12 +1,21 @@
 import { fileURLToPath } from 'node:url'
-import { configDefaults, defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig, mergeConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
+import baseVitestConfig from '../base.vitest.config'
 
-export default defineConfig({
-  plugins: [vue()],
-  test: {
-    environment: 'jsdom',
-    exclude: [...configDefaults.exclude],
-    root: fileURLToPath(new URL('./', import.meta.url))
-  }
-})
+export default mergeConfig(
+  baseVitestConfig,
+  defineConfig({
+    plugins: [vue()],
+    test: {
+      environment: 'jsdom',
+      exclude: [...configDefaults.exclude],
+      root: fileURLToPath(new URL('./', import.meta.url)),
+      coverage: {
+        provider: 'v8',
+        reporter: ['json'],
+        reportsDirectory: './coverage'
+      }
+    }
+  })
+)


### PR DESCRIPTION
This PR adds a test coverage report for the report-viewer.

The tests get executed for each package and then a script bundles them into a single report.

The action then posts a comment containing:
- The overview for the entire report viewer with the 4 available coverage metrics
- A collapsable section with the metrics for each package
- A collapse section with the metrics for each testable file

An HTML version of the report where a per line analysis can be seen is attached to the action run

If the line coverage falls below 20% the action fails


We should discuss whether the line coverage is what we want for this or whether we should use a different metric or even a composed one like sonarcloud does.
We should discuss if we want a simple message like the one below or put in the work to create a more styled one with colors for different values