### PR TITLE
Error inside progress bar

### DIFF
--- a/core/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/core/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -82,11 +82,14 @@ public class SubmissionSetBuilder {
 
         ProgressBar progressBar = ProgressBarLogger.createProgressBar(ProgressBarType.LOADING, submissionFiles.size());
         Map<File, Submission> foundSubmissions = new HashMap<>();
-        for (SubmissionFileData submissionFile : submissionFiles) {
-            processSubmissionFile(submissionFile, multipleRoots, foundSubmissions);
-            progressBar.step();
+        try {
+            for (SubmissionFileData submissionFile : submissionFiles) {
+                processSubmissionFile(submissionFile, multipleRoots, foundSubmissions);
+                progressBar.step();
+            }
+        } finally {
+            progressBar.dispose();
         }
-        progressBar.dispose();
 
         Optional<Submission> baseCodeSubmission = loadBaseCode();
         baseCodeSubmission.ifPresent(baseSubmission -> foundSubmissions.remove(baseSubmission.getRoot()));


### PR DESCRIPTION
There is an error which causes exceptions not to be printed if an exception occurs inside a progress bar. This PR fixes that issue by making sure the progress bar is closes even if an exception occurs.