### PR TITLE
Fix Tokens ending before they start

### DIFF
--- a/languages/java/src/main/java/de/jplag/java/FixedSourcePositions.java
+++ b/languages/java/src/main/java/de/jplag/java/FixedSourcePositions.java
@@ -25,6 +25,7 @@ public class FixedSourcePositions implements SourcePositions {
 
     @Override
     public long getEndPosition(CompilationUnitTree compilationUnitTree, Tree tree) {
-        return Math.max(this.getStartPosition(compilationUnitTree, tree), this.base.getEndPosition(compilationUnitTree, tree));
+        // Add one to assert start <= end (one is subtracted later)
+        return Math.max(this.getStartPosition(compilationUnitTree, tree) + 1, this.base.getEndPosition(compilationUnitTree, tree));
     }
 }

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -492,11 +492,13 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
             long start = positions.getStartPosition(ast, node);
             long end = positions.getEndPosition(ast, node);
             if (Objects.isNull(node.getInitializer())) {
-                // VARDEF token should end before the start of the assigned value.
+                // VARDEF token should end before semicolon
                 end -= 1;
-            } else if (!node.toString().contains(ENUM_MARKER)) { // enum initializers are implicit - no need to subtract.
+            } else if (!node.toString().contains(ENUM_MARKER)) {
+                // VARDEF token should end before assigned value
                 end -= node.getInitializer().toString().length();
-            }
+            } // else: for enum constants, end is already correct.
+
             String name = node.getName().toString();
             boolean inLocalScope = variableRegistry.inLocalScope();
             // this presents a problem when classes are declared in local scopes, which can happen in ad-hoc implementations

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -414,7 +414,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         }
         if (start > end) {
             // implicit constructor call for ENUMS - identifier is not present in code, so end needs to be fixed.
-            end = positions.getEndPosition(ast, node);
+            end = positions.getEndPosition(ast, node) - 1;
         }
         addToken(JavaTokenType.J_NEWCLASS, start, end, new CodeSemantics());
         super.visitNewClass(node, null);
@@ -490,11 +490,12 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     public Void visitVariable(VariableTree node, Void unused) {
         if (!node.getName().contentEquals(ANONYMOUS_VARIABLE_NAME)) {
             long start = positions.getStartPosition(ast, node);
-            long end = positions.getEndPosition(ast, node) - 1;
-            if (Objects.nonNull(node.getInitializer()) && !node.toString().contains(ENUM_MARKER)) {
+            long end = positions.getEndPosition(ast, node);
+            if (Objects.isNull(node.getInitializer())) {
                 // VARDEF token should end before the start of the assigned value.
-                // enum initializers are implicit - no need to subtract.
-                end -= node.getInitializer() == null ? 0 : node.getInitializer().toString().length();
+                end -= 1;
+            } else if (!node.toString().contains(ENUM_MARKER)) { // enum initializers are implicit - no need to subtract.
+                end -= node.getInitializer().toString().length();
             }
             String name = node.getName().toString();
             boolean inLocalScope = variableRegistry.inLocalScope();

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -1,6 +1,7 @@
 package de.jplag.java;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.Set;
 
 import de.jplag.Token;
@@ -57,6 +58,7 @@ import com.sun.source.util.TreeScanner;
 
 final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     private final static String ANONYMOUS_VARIABLE_NAME = "";
+    private static final String ENUM_MARKER = "/*enum*/";
 
     private final File file;
     private final Parser parser;
@@ -187,7 +189,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     private long extractStartPosition(ClassTree node) {
         boolean hasModifiers = !node.getModifiers().getFlags().isEmpty();
         long endPosition = positions.getEndPosition(ast, node.getModifiers());
-        if (hasModifiers && endPosition != -1) { // Java 25 compact source files have implicit (final) classes.
+        if (hasModifiers && endPosition > 0) { // Java 25 compact source files have implicit (final) classes.
             return endPosition + 1;
         }
         return positions.getStartPosition(ast, node);
@@ -404,10 +406,15 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
 
     @Override
     public Void visitNewClass(NewClassTree node, Void unused) {
+        // NEWCLASS token should span the class name, not the arguments.
         long start = positions.getStartPosition(ast, node);
         long end = positions.getEndPosition(ast, node.getIdentifier());
         if (!node.getTypeArguments().isEmpty()) {
             addToken(JavaTokenType.J_GENERIC, start, 3 + node.getIdentifier().toString().length(), new CodeSemantics());
+        }
+        if (start > end) {
+            // implicit constructor call for ENUMS - identifier is not present in code, so end needs to be fixed.
+            end = positions.getEndPosition(ast, node);
         }
         addToken(JavaTokenType.J_NEWCLASS, start, end, new CodeSemantics());
         super.visitNewClass(node, null);
@@ -484,7 +491,11 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         if (!node.getName().contentEquals(ANONYMOUS_VARIABLE_NAME)) {
             long start = positions.getStartPosition(ast, node);
             long end = positions.getEndPosition(ast, node) - 1;
-            end -= node.getInitializer() == null ? 0 : node.getInitializer().toString().length();
+            if (Objects.nonNull(node.getInitializer()) && !node.toString().contains(ENUM_MARKER)) {
+                // VARDEF token should end before the start of the assigned value.
+                // enum initializers are implicit - no need to subtract.
+                end -= node.getInitializer() == null ? 0 : node.getInitializer().toString().length();
+            }
             String name = node.getName().toString();
             boolean inLocalScope = variableRegistry.inLocalScope();
             // this presents a problem when classes are declared in local scopes, which can happen in ad-hoc implementations


### PR DESCRIPTION
 * parameters are parsed as length 0 by JavaC, then FixedSourcePositions previously turned it into length -1 
 * enum constants are parsed as the correct length, but the "initializer length" was subtracted from it (which is not present in the code). We use the (also artificially inserted) comment `/*enum*/` to detect this case. 
 - Similarly, for the implicit or explicit constructor calls for enum constants, no identifier is present in the code, so its length should not be subtracted.
 * For Java 25 compact classes, there was an off-by-one error in checking the start position.