### PR TITLE
Java token position tests - Continue to Loop end

### DIFF
--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -424,7 +424,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     @Override
     public Void visitTypeParameter(TypeParameterTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
-        // This is odd, but also done like this in Javagg 1.7
+        // This is odd, but also done like this in Java 1.7
         addToken(JavaTokenType.J_GENERIC, start, node.getName().length(), new CodeSemantics());
         return super.visitTypeParameter(node, null);
     }

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -330,9 +330,9 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
         scan(node.getCatches(), null);
         if (node.getFinallyBlock() != null) {
             start = positions.getStartPosition(ast, node.getFinallyBlock());
-            addToken(JavaTokenType.J_FINALLY_BEGIN, start, 3, CodeSemantics.createControl());
+            addToken(JavaTokenType.J_FINALLY_BEGIN, start, 1, CodeSemantics.createControl());
             scan(node.getFinallyBlock(), null);
-            end = positions.getEndPosition(ast, node.getFinallyBlock());
+            end = positions.getEndPosition(ast, node.getFinallyBlock()) - 1;
             addToken(JavaTokenType.J_FINALLY_END, end, 1, CodeSemantics.createControl());
         }
         addToken(JavaTokenType.J_TRY_END, end - 1, 1, CodeSemantics.createControl());
@@ -424,8 +424,8 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     @Override
     public Void visitTypeParameter(TypeParameterTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
-        // This is odd, but also done like this in Java 1.7
-        addToken(JavaTokenType.J_GENERIC, start, 1, new CodeSemantics());
+        // This is odd, but also done like this in Javagg 1.7
+        addToken(JavaTokenType.J_GENERIC, start, node.getName().length(), new CodeSemantics());
         return super.visitTypeParameter(node, null);
     }
 

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Continue_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Continue_1.java
@@ -1,0 +1,8 @@
+> class Continue {
+>     public static void main() {
+>         while (true) {
+>             continue;
+$             | J_CONTINUE 8
+>         }
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Default_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Default_1.java
@@ -1,0 +1,11 @@
+> class Default {
+>     public static void main(String[] args) {
+>         switch (args[0]) {
+>             case "":
+>                 break;
+>             default:
+$             | J_DEFAULT 7
+>                 break;
+>         }
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Default_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Default_2.java
@@ -1,0 +1,9 @@
+> class Default {
+>     public static void main(String[] args) {
+>         int result = switch (args[0]) {
+>             case "" -> 1;
+>             default -> 0;
+$             | J_DEFAULT 7
+>         };
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/EnumDeclaration_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/EnumDeclaration_1.java
@@ -1,0 +1,4 @@
+> enum Enum {
+$ | J_ENUM_BEGIN 4
+> }
+$ | J_ENUM_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/EnumDeclaration_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/EnumDeclaration_2.java
@@ -1,0 +1,5 @@
+> public enum Enum {
+$        | J_ENUM_BEGIN 4
+>     INTERNAL, EXTERNAL;
+> }
+$ | J_ENUM_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Export.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Export.java
@@ -1,0 +1,6 @@
+> module mymodule {
+>     exports com.w3schools.package1;
+$     | J_EXPORTS 7
+>     exports com.w3Schools.package2 to module1, module2;
+$     | J_EXPORTS 7
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Finally_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Finally_1.java
@@ -1,0 +1,13 @@
+> class Finally {
+>     public void test() {
+>         try {
+>             throw new RuntimeException();
+>         } catch (Exception e) {
+>             return;
+>         } finally {
+$                   | J_FINALLY_BEGIN 1
+>             System.out.println("Cleanup");
+>         }
+$         | J_FINALLY_END 1
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Finally_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Finally_2.java
@@ -1,0 +1,11 @@
+> class Finally {
+>     public void test() {
+>         try(InputStream inputStream = new FileInputStream("/some/file.txt")) {
+>             throw new RuntimeException();
+>         } finally {
+$                   | J_FINALLY_BEGIN 1
+>             System.out.println("Cleanup");
+>         }
+$         | J_FINALLY_END 1
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Generic_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Generic_1.java
@@ -1,0 +1,3 @@
+> class Generic<T> {
+$               | J_GENERIC 1
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Generic_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Generic_2.java
@@ -1,0 +1,4 @@
+> class Generic<T, V> {
+$               | J_GENERIC 1
+$                  | J_GENERIC 1
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Generic_3.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Generic_3.java
@@ -1,0 +1,5 @@
+> class Generic {
+>     public <Type> void test(Type param) {
+$             | J_GENERIC 4
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/If_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/If_1.java
@@ -1,0 +1,8 @@
+> class If {
+>     public void test() {
+>         if (true) {
+$         | J_IF_BEGIN 2
+>         }
+$         | J_IF_END 1
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/If_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/If_2.java
@@ -1,0 +1,9 @@
+> class If {
+>     public void test() {
+>         if (true) {
+$         | J_IF_BEGIN 2
+>         } else {
+$         | J_IF_END 1
+>         }
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Import_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Import_1.java
@@ -1,0 +1,8 @@
+> import java.util.Set;
+$ | J_IMPORT 6
+> import static de.jplag.rust.RustTokenType.CLOSURE_BODY_END;
+$ | J_IMPORT 6
+>
+> class Imports {
+>
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Interface_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Interface_1.java
@@ -1,0 +1,4 @@
+> interface Language {
+$ | J_INTERFACE_BEGIN 9
+> }
+$ | J_INTERFACE_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Interface_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Interface_2.java
@@ -1,0 +1,4 @@
+> public interface Language {
+$        | J_INTERFACE_BEGIN 9
+> }
+$ | J_INTERFACE_END 1

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_1.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_1.java
@@ -1,0 +1,8 @@
+> class Loop {
+>     public void test() {
+>         while (true) {
+$         | J_LOOP_BEGIN 5
+>         }
+$         | J_LOOP_END 1
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_2.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_2.java
@@ -1,0 +1,8 @@
+> class Loop {
+>     public void test() {
+>         for (int i = 0; i < 10; i++) {
+$         | J_LOOP_BEGIN 3
+>         }
+$         | J_LOOP_END 1
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_3.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_3.java
@@ -1,0 +1,8 @@
+> class Loop {
+>     public void test() {
+>         do {
+$         | J_LOOP_BEGIN 2
+>         } while (true);
+$         | J_LOOP_END 1
+>     }
+> }

--- a/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_4.java
+++ b/languages/java/src/test/resources/de/jplag/java/tokenPositions/Loop_4.java
@@ -1,0 +1,8 @@
+> class Loop {
+>     public void test(int[] values) {
+>         for (int x: values) {
+$         | J_LOOP_BEGIN 3
+>         }
+$         | J_LOOP_END 1
+>     }
+> }


### PR DESCRIPTION
Contains tests for token positions for the java token types continue to loop_end.

This PR also adjusts some token lengths. Since it does not change the token list, I think it's fine to do this without a separate PR