### PR TITLE
Fix scrolling to match on sorted files

### DIFF
--- a/report-viewer/ui-components/widget/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/ui-components/widget/fileDisplaying/FilesContainer.vue
@@ -216,9 +216,8 @@ function scrollTo(file: string, line: number) {
  * Collapses all the code panels.
  */
 function collapseAll() {
-  const keys = Object.keys(codePanels.value)
-  for (const key of keys) {
-    codePanels.value[key].collapse()
+  for (const codePanel of Object.values(codePanels.value)) {
+    codePanel.collapse()
   }
 }
 
@@ -226,16 +225,14 @@ function collapseAll() {
  * Expands all the code panels.
  */
 function expandAll() {
-  const keys = Object.keys(codePanels.value)
-  for (const key of keys) {
-    codePanels.value[key].expand()
+  for (const codePanel of Object.values(codePanels.value)) {
+    codePanel.expand()
   }
 }
 
 const allCollapsed = computed(() => {
-  const keys = Object.keys(codePanels.value)
-  for (const key of keys) {
-    if (!codePanels.value[key].isCollapsed()) {
+  for (const codePanel of Object.values(codePanels.value)) {
+    if (!codePanel.isCollapsed()) {
       return false
     }
   }

--- a/report-viewer/ui-components/widget/fileDisplaying/FilesContainer.vue
+++ b/report-viewer/ui-components/widget/fileDisplaying/FilesContainer.vue
@@ -31,7 +31,11 @@
         <CodePanel
           v-for="file in sortedFiles"
           :key="file.fileName"
-          ref="codePanels"
+          :ref="
+            (el) => {
+              codePanels[file.fileName] = el as CodePanelType
+            }
+          "
           :file="file"
           :matches="matchesPerFile[file.fileName]"
           :highlight-language="highlightLanguage"
@@ -178,8 +182,9 @@ function emitFileMoving() {
   emit('filesMoved')
 }
 
-const codePanels: Ref<(typeof CodePanel)[]> = ref([])
-const scrollContainer: Ref<typeof ScrollableComponent | null> = ref(null)
+type CodePanelType = InstanceType<typeof CodePanel>
+const codePanels: Ref<Record<string, CodePanelType>> = ref({})
+const scrollContainer: Ref<InstanceType<typeof ScrollableComponent> | null> = ref(null)
 
 const tokenCount = computed(() => {
   return props.files.reduce((acc, file) => (file.tokenCount ?? 0) + acc - 1, 0)
@@ -191,15 +196,15 @@ const tokenCount = computed(() => {
  * @param line Line to scroll to.
  */
 function scrollTo(file: string, line: number) {
-  const fileIndex = sortedFiles.value.findIndex((f) => f.fileName === file)
-  if (fileIndex !== -1) {
-    codePanels.value[fileIndex].expand()
+  const codePanel = codePanels.value[file]
+  if (codePanel !== undefined) {
+    codePanel.expand()
     nextTick(() => {
       if (!scrollContainer.value) {
         return
       }
-      const childToScrollTo = codePanels.value[fileIndex].getLineRect(line) as DOMRect
-      const scrollBox = scrollContainer.value.getRoot() as HTMLElement
+      const childToScrollTo = codePanel.getLineRect(line)
+      const scrollBox = scrollContainer.value.getRoot()
       scrollBox.scrollTo({
         top: childToScrollTo.top + scrollBox.scrollTop - (scrollBox.clientHeight * 2) / 3
       })
@@ -211,18 +216,30 @@ function scrollTo(file: string, line: number) {
  * Collapses all the code panels.
  */
 function collapseAll() {
-  codePanels.value.forEach((panel) => panel.collapse())
+  const keys = Object.keys(codePanels.value)
+  for (const key of keys) {
+    codePanels.value[key].collapse()
+  }
 }
 
 /**
  * Expands all the code panels.
  */
 function expandAll() {
-  codePanels.value.forEach((panel) => panel.expand())
+  const keys = Object.keys(codePanels.value)
+  for (const key of keys) {
+    codePanels.value[key].expand()
+  }
 }
 
 const allCollapsed = computed(() => {
-  return codePanels.value.every((panel) => panel.isCollapsed())
+  const keys = Object.keys(codePanels.value)
+  for (const key of keys) {
+    if (!codePanels.value[key].isCollapsed()) {
+      return false
+    }
+  }
+  return true
 })
 
 defineExpose({


### PR DESCRIPTION
When changing the file sorting to something other than `Alphabetical`, clicking on a match or the bubble in the match list, this would scroll to a different position than intended or could even cause an error.

## Why the error occurred
We stored both the files and the UI elements displaying them in a list. When changing the sorting we sort the list of files, but not the list of UI Elements.
When we click an element we now search the files for the goal file and take its index. We then proceeded to scroll to the file at the found index. Due to not resorting the UI Element list, we would most likely select a different file and scroll to that.
It even throws an error, if we try to scroll to a line the file does not have (e.g. The intended line is 10. The file we now scroll to only has 5 lines. Then we get an error).

## Fix
Instead of storing the UI Elements in a list, we now store them in a map based on the file name and just look them up based on that

Fixes #2918 