### PR TITLE
Adds tests for invalid source files to the java module

### DIFF
--- a/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
@@ -291,7 +291,7 @@ public abstract class LanguageModuleTest {
     }
 
     private List<TestData> getExceptionTestFiles() {
-        return this.collector.getExceptionTestFile();
+        return ignoreEmptyTestType(this.collector.getExceptionTestFile());
     }
 
     /**

--- a/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/LanguageModuleTest.java
@@ -3,6 +3,7 @@ package de.jplag.testutils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -280,6 +281,17 @@ public abstract class LanguageModuleTest {
         List<Token> tokens = parseTokens(data);
 
         assertEquals(SharedTokenType.FILE_END, tokens.getLast().getType(), "Last token in " + data.describeTestSource() + " is not file end.");
+    }
+
+    @ParameterizedTest
+    @MethodSource("getExceptionTestFiles")
+    @DisplayName("Tests that the given test data leads to exceptions when parsing")
+    final void testExceptionFiles(TestData data) {
+        assertThrows(ParsingException.class, () -> parseTokens(data));
+    }
+
+    private List<TestData> getExceptionTestFiles() {
+        return this.collector.getExceptionTestFile();
     }
 
     /**

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TestDataCollector.java
@@ -25,6 +25,8 @@ public class TestDataCollector {
     private final List<TokenListTest> tokenSequenceTest;
     private final List<TokenPositionTestData> tokenPositionTestData;
 
+    private final List<TestData> exceptionTestFile;
+
     private final List<TestData> allTestData;
 
     private final File testFileLocation;
@@ -41,6 +43,8 @@ public class TestDataCollector {
         this.containedTokenData = new ArrayList<>();
         this.tokenSequenceTest = new ArrayList<>();
         this.tokenPositionTestData = new ArrayList<>();
+
+        this.exceptionTestFile = new ArrayList<>();
 
         this.allTestData = new ArrayList<>();
     }
@@ -104,6 +108,18 @@ public class TestDataCollector {
     }
 
     /**
+     * Adds tests for invalid source files. No other tests will be run on these files
+     * @param exceptionTestsDirectory The directory containing the test data
+     */
+    public void addExceptionTests(String exceptionTestsDirectory) {
+        File directory = new File(this.testFileLocation, exceptionTestsDirectory);
+        assumeTrue(directory.exists() && directory.isDirectory());
+        for (File file : directory.listFiles()) {
+            this.exceptionTestFile.add(new FileTestData(file));
+        }
+    }
+
+    /**
      * @return The test data that should be checked for source coverage
      */
     public List<TestData> getSourceCoverageData() {
@@ -143,6 +159,13 @@ public class TestDataCollector {
      */
     public List<TestData> getAllTestData() {
         return Collections.unmodifiableList(allTestData);
+    }
+
+    /**
+     * @return The test data for invalid source files
+     */
+    public List<TestData> getExceptionTestFile() {
+        return exceptionTestFile;
     }
 
     /**

--- a/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
+++ b/languages/java/src/test/java/de/jplag/java/JavaLanguageTest.java
@@ -91,6 +91,8 @@ public class JavaLanguageTest extends LanguageModuleTest {
                 J_APPLY, J_METHOD_END, J_METHOD_BEGIN, J_APPLY, J_METHOD_END, J_CLASS_END);
 
         collector.addTokenPositionTests("tokenPositions");
+
+        collector.addExceptionTests("exceptions");
     }
 
     @Override

--- a/languages/java/src/test/resources/de/jplag/java/exceptions/Invalid.java
+++ b/languages/java/src/test/resources/de/jplag/java/exceptions/Invalid.java
@@ -1,0 +1,1 @@
+asöldfjöasldkjf

--- a/languages/java/src/test/resources/de/jplag/java/exceptions/SyntaxError.java
+++ b/languages/java/src/test/resources/de/jplag/java/exceptions/SyntaxError.java
@@ -1,0 +1,3 @@
+class Test {
+    private String nonTerminatedLine
+}


### PR DESCRIPTION
Adds some simple tests, that make sure that invalid source files lead to a parsing exception instead of crashing