### PR TITLE
Fix overflow at top of comparison table

### DIFF
--- a/report-viewer/ui-components/widget/comparisonTable/ComparisonTableFilter.vue
+++ b/report-viewer/ui-components/widget/comparisonTable/ComparisonTableFilter.vue
@@ -5,8 +5,12 @@
       <h2 class="col-start-1 row-start-1">{{ header }}</h2>
 
       <!-- On wide screens: SearchBar and Button on same row. On slim: seperate rows -->
-      <div class="flex grow flex-col gap-x-2 gap-y-2 md:flex-row">
-        <ToolTipComponent direction="left" class="w-full max-w-full grow" :show-info-symbol="false">
+      <div class="flex grow flex-col gap-x-2 gap-y-2 md:flex-row md:flex-wrap">
+        <ToolTipComponent
+          direction="left"
+          class="w-full max-w-full flex-[1_1_0]"
+          :show-info-symbol="false"
+        >
           <template #default>
             <SearchBarComponent
               v-model="searchString"

--- a/report-viewer/ui-components/widget/comparisonTable/ComparisonTableFilter.vue
+++ b/report-viewer/ui-components/widget/comparisonTable/ComparisonTableFilter.vue
@@ -1,43 +1,47 @@
 <template>
-  <div
-    class="grid grid-cols-1 grid-rows-4 space-y-2 gap-x-2 md:grid-cols-[auto_1fr_auto] md:grid-rows-[auto_auto]"
-  >
-    <h2 class="col-start-1 row-start-1">{{ header }}</h2>
-    <ToolTipComponent
-      direction="left"
-      class="row-starsdt-2 col-start-1 w-full max-w-full md:col-start-2 md:row-start-1"
-      :show-info-symbol="false"
-    >
-      <template #default>
-        <SearchBarComponent
-          v-model="searchString"
-          class="w-full"
-          placeholder="Filter/Unhide Comparisons"
-        />
-      </template>
-      <template #tooltip>
-        <p class="text-sm whitespace-pre">
-          Type in the name of a submission to only show comparisons that contain this submission.
-        </p>
-        <p class="text-sm whitespace-pre">Fully written out names get unhidden.</p>
-        <p class="text-sm whitespace-pre">
-          You can also filter by index by entering a number or typing <i>index:number</i>
-        </p>
-        <p class="text-sm whitespace-pre">
-          You can filter for specific similarity thresholds via &lt;/&gt;/&lt;=/&gt;= followed by
-          the percentage. <br />
-          You can filter for a specific metric by prefacing the percentage with the short metric
-          name (e.g. <i>avg:>80</i>)
-        </p>
-      </template>
-    </ToolTipComponent>
+  <div class="flex flex-col gap-y-2">
+    <!-- Try placing Heading, SearchBar and Button on same row. If not possible line break(wrap) after heading  -->
+    <div class="flex flex-wrap gap-x-2 gap-y-2">
+      <h2 class="col-start-1 row-start-1">{{ header }}</h2>
 
-    <ButtonComponent
-      class="col-start-1 row-start-3 w-30 min-w-fit whitespace-nowrap md:col-start-3 md:row-start-1"
-      @click="emit('changeAnonymousForAll')"
-    >
-      {{ allAreAnonymized ? 'Show All' : 'Anonymize All' }}
-    </ButtonComponent>
+      <!-- On wide screens: SearchBar and Button on same row. On slim: seperate rows -->
+      <div class="flex grow flex-col gap-x-2 gap-y-2 md:flex-row">
+        <ToolTipComponent direction="left" class="w-full max-w-full grow" :show-info-symbol="false">
+          <template #default>
+            <SearchBarComponent
+              v-model="searchString"
+              class="w-full"
+              placeholder="Filter/Unhide Comparisons"
+            />
+          </template>
+          <template #tooltip>
+            <p class="text-sm whitespace-pre">
+              Type in the name of a submission to only show comparisons that contain this
+              submission.
+            </p>
+            <p class="text-sm whitespace-pre">Fully written out names get unhidden.</p>
+            <p class="text-sm whitespace-pre">
+              You can also filter by index by entering a number or typing <i>index:number</i>
+            </p>
+            <p class="text-sm whitespace-pre">
+              You can filter for specific similarity thresholds via &lt;/&gt;/&lt;=/&gt;= followed
+              by the percentage. <br />
+              You can filter for a specific metric by prefacing the percentage with the short metric
+              name (e.g. <i>avg:>80</i>)
+            </p>
+          </template>
+        </ToolTipComponent>
+
+        <ButtonComponent
+          class="col-start-1 row-start-3 w-30 min-w-fit whitespace-nowrap md:col-start-3 md:row-start-1"
+          @click="emit('changeAnonymousForAll')"
+        >
+          {{ allAreAnonymized ? 'Show All' : 'Anonymize All' }}
+        </ButtonComponent>
+      </div>
+    </div>
+
+    <!-- Always in a row below the rest -->
     <MetricSelector
       class="col-start-1 row-start-4 md:col-span-3 md:col-start-1 md:row-start-2"
       title="Secondary Metric:"

--- a/report-viewer/ui-components/widget/optionsSelectors/OptionsSelectorComponent.vue
+++ b/report-viewer/ui-components/widget/optionsSelectors/OptionsSelectorComponent.vue
@@ -2,41 +2,43 @@
   Component for selecting one of multiple options.
 -->
 <template>
-  <div
-    class="flex h-fit flex-row flex-wrap items-center gap-y-1 text-center text-xs md:flex-nowrap"
-  >
-    <div v-if="title != ''" class="mr-3 text-base">
+  <div class="flex h-fit flex-col flex-wrap items-start gap-y-1 text-center text-xs md:flex-row">
+    <div v-if="title != ''" class="mr-3 text-base whitespace-nowrap">
       {{ title }}
     </div>
-    <div v-for="[index, label] in labels.entries()" :key="index">
-      <ToolTipComponent
-        v-if="(label as ToolTipLabel).displayValue !== undefined"
-        :direction="tooltipDirection"
-        :tool-tip-container-will-be-centered="true"
-        :show-info-symbol="false"
-      >
-        <template #default>
-          <OptionComponent
-            :selected="index == getSelected()"
-            :has-tool-tip="true"
-            @click="select(index)"
-          >
-            <span class="flex items-center gap-x-1 align-middle">
-              <slot :name="(label as ToolTipLabel).displayValue.replace(' ', '-').toLowerCase()" />
-              <span>{{ (label as ToolTipLabel).displayValue }}</span>
-            </span>
-          </OptionComponent>
-        </template>
+    <div class="flex flex-[1_1_0] flex-row flex-wrap items-center gap-y-1 text-center">
+      <div v-for="[index, label] in labels.entries()" :key="index">
+        <ToolTipComponent
+          v-if="(label as ToolTipLabel).displayValue !== undefined"
+          :direction="tooltipDirection"
+          :tool-tip-container-will-be-centered="true"
+          :show-info-symbol="false"
+        >
+          <template #default>
+            <OptionComponent
+              :selected="index == getSelected()"
+              :has-tool-tip="true"
+              @click="select(index)"
+            >
+              <span class="flex items-center gap-x-1 align-middle">
+                <slot
+                  :name="(label as ToolTipLabel).displayValue.replace(' ', '-').toLowerCase()"
+                />
+                <span>{{ (label as ToolTipLabel).displayValue }}</span>
+              </span>
+            </OptionComponent>
+          </template>
 
-        <template #tooltip>
-          <p class="text-sm whitespace-pre-wrap" :style="tooltipStyle">
-            {{ (label as ToolTipLabel).tooltip }}
-          </p>
-        </template>
-      </ToolTipComponent>
-      <OptionComponent v-else :selected="index == getSelected()" @click="select(index)">{{
-        label
-      }}</OptionComponent>
+          <template #tooltip>
+            <p class="text-sm whitespace-pre-wrap" :style="tooltipStyle">
+              {{ (label as ToolTipLabel).tooltip }}
+            </p>
+          </template>
+        </ToolTipComponent>
+        <OptionComponent v-else :selected="index == getSelected()" @click="select(index)">{{
+          label
+        }}</OptionComponent>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Elements at the top of the comparison table could easily overflow, especially when zoomed in.

This fixes that, by defining more concrete wrapping behaviors