### PR TITLE
Allow opening other report when starting viewer with local file

### DIFF
--- a/report-viewer/report-viewer/src/stores/reportStore.ts
+++ b/report-viewer/report-viewer/src/stores/reportStore.ts
@@ -39,6 +39,8 @@ export const reportStore = defineStore('reportStore', () => {
   const anonymizedSet = ref(new Set<string>())
   const anonymizedNumber = ref(new Map<string, number>())
 
+  const hasLoadedLocalReportBefore = ref(false)
+
   function loadReport(
     _files: File[],
     _submissionFiles: SubmissionFile[],
@@ -301,7 +303,8 @@ export const reportStore = defineStore('reportStore', () => {
     allAreAnonymized,
     setAnonymous,
     getBaseCodeReport,
-    getSubmissionIds
+    getSubmissionIds,
+    hasLoadedLocalReportBefore
   }
 })
 

--- a/report-viewer/report-viewer/src/views/FileUploadView.vue
+++ b/report-viewer/report-viewer/src/views/FileUploadView.vue
@@ -35,6 +35,14 @@
           <div>Drag and Drop report file on this page</div>
           <div>Or click here to select a file</div>
         </div>
+        <!-- When we loaded a local report we can assume that a local report is present. If this is not the case we catch this with the localFileStatus -->
+        <ButtonComponent
+          v-if="reportStore().hasLoadedLocalReportBefore && localFileStatus !== 'notFound'"
+          class="mx-auto my-2 w-96"
+          @click="navigateToOverview()"
+        >
+          Open Local Report
+        </ButtonComponent>
         <div>(No files will be uploaded)</div>
         <a
           href="https://github.com/jplag/JPlag/wiki/1.-How-to-Use-JPlag"
@@ -63,13 +71,17 @@ import { canLoadFile } from '@/stores/fileLoading'
 import { uiStore } from '@/stores/uiStore'
 import { ReportFileHandler } from '@jplag/parser'
 import { LoadingCircle } from '@jplag/ui-components/base'
+import ButtonComponent from '@jplag/ui-components/base/ButtonComponent.vue'
 
 reportStore().reset()
+const localFileStatus = ref<'found' | 'notFound' | 'unknown'>('unknown')
 
 const exampleFiles = ref(import.meta.env.MODE == 'demo' || import.meta.env.MODE == 'dev-demo')
 
 canLoadFile().then((value) => {
-  if (value) {
+  localFileStatus.value = value ? 'found' : 'notFound'
+  if (value && !reportStore().hasLoadedLocalReportBefore) {
+    reportStore().hasLoadedLocalReportBefore = true
     navigateToOverview()
   }
 })


### PR DESCRIPTION
When starting the viewer with a local file or just directly having it started after the run, it becomes impossible to open another different report in the same viewer instance.
This is due to the viewer directly trying to open the local report.

This PR changes the viewers behavior, so that on the first opening of the LandingPage the report gets opened normally. When then returning to this page the LandingPage gets displayed, but with the a button offering to open the local report.

<img width="1181" height="687" alt="grafik" src="https://github.com/user-attachments/assets/cc15ec21-42af-470d-962b-89bdcd9a0ae1" />

One issue with that version is that when you open a seperate report and then open a comparison in a new tab, it either displays a misleading error or even opens a comparison if the submissions happen to both be present. Is this a case we want to handle?