### PR TITLE
Fix resource leak and unused file reader 

### DIFF
--- a/language-api/src/main/java/de/jplag/util/FileUtils.java
+++ b/language-api/src/main/java/de/jplag/util/FileUtils.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -49,8 +50,15 @@ public final class FileUtils {
      * @throws IOException If the file does not exist for is not readable
      */
     public static BufferedReader openFileReader(File file, boolean isSubmissionFile) throws IOException {
-        InputStream stream = new BufferedInputStream(new FileInputStream(file));
-        Charset charset = isSubmissionFile && userSpecifiedCharset != null ? userSpecifiedCharset : detectCharset(stream);
+        Charset charset;
+        if (isSubmissionFile && Objects.nonNull(userSpecifiedCharset)) {
+            charset = userSpecifiedCharset;
+        } else {
+            try (InputStream stream = new BufferedInputStream(new FileInputStream(file))) {
+                charset = detectCharset(stream);
+            }
+        }
+
         BufferedReader reader = new BufferedReader(new FileReader(file, charset));
         removeBom(reader, charset);
         return reader;


### PR DESCRIPTION
The `FileUtils::openFileReader` method uses a separate reader to identify the charset; however, that reader is never closed. 
As a result, tests that create and then read files (such as those in the EMF Metamodel language module) were unable to delete them after the test, as the still-open reader was blocking deletion. Only in the _next_ run of the same test could the temporary files be deleted, but the test failed after finding unexpected files.
This behavior caused the test to alternate between failing and succeeding. On GitHub's machines, obviously, this never occurs, as no test is run more than once on the same file system state.

Now, the reader is properly closed (we can also go for `reader.close()` instead of the try-with-resources if anyone has strong preferences). Also, if the user-defined charset is used, the reader will no longer be created. 