### PR TITLE
Show failed names in groups in info tab

### DIFF
--- a/report-viewer/report-viewer/src/views/InformationView.vue
+++ b/report-viewer/report-viewer/src/views/InformationView.vue
@@ -126,13 +126,13 @@
         <TextInformation label="Missing Comparisons" class="pb-1">{{
           missingComparisons
         }}</TextInformation>
-        <TextInformation label="Failed Submissions" class="pb-1">{{
-          runInformation.failedSubmissions.length > 0
-            ? runInformation.failedSubmissions
-                .map((s) => `${s.submissionId} (${stringifySubmissionState(s.submissionState)})`)
-                .join(', ')
-            : 'None'
-        }}</TextInformation>
+        <TextInformation label="Failed Submissions" class="pb-1">
+          <FailedSubmissionsDisplay
+            v-if="runInformation.failedSubmissions.length > 0"
+            :submissions="runInformation.failedSubmissions"
+          />
+          <span v-else>None</span>
+        </TextInformation>
       </ScrollableComponent>
     </ContainerComponent>
   </div>
@@ -140,8 +140,7 @@
 
 <script setup lang="ts">
 import { ContainerComponent, TextInformation, ScrollableComponent } from '@jplag/ui-components/base'
-import { MetricTypes } from '@jplag/ui-components/widget'
-import { SubmissionState } from '@jplag/model'
+import { FailedSubmissionsDisplay, MetricTypes } from '@jplag/ui-components/widget'
 import { reportStore } from '@/stores/reportStore'
 import { computed, onErrorCaptured } from 'vue'
 import { redirectOnError } from '@/router'
@@ -152,10 +151,6 @@ const options = computed(() => reportStore().getCliOptions())
 const missingComparisons = computed(
   () => runInformation.value.totalComparisons - reportStore().includedComparisonCount()
 )
-
-function stringifySubmissionState(reason: SubmissionState) {
-  return reason.toString().replace(/_/g, ' ').toLowerCase()
-}
 
 onErrorCaptured((error) => {
   redirectOnError(error, 'Error displaying information:\n', 'OverviewView', 'Back to overview')

--- a/report-viewer/ui-components/base/TextInformation.vue
+++ b/report-viewer/ui-components/base/TextInformation.vue
@@ -6,7 +6,7 @@
     <ToolTipComponent :direction="tooltipSide">
       <template #default>
         <div class="flex items-start gap-x-1">
-          <span>{{ label }}:</span>
+          <span class="whitespace-nowrap">{{ label }}:</span>
           <i><slot name="default"></slot></i>
         </div>
       </template>

--- a/report-viewer/ui-components/widget/failedSubmissions/FailedSubmissionCategory.vue
+++ b/report-viewer/ui-components/widget/failedSubmissions/FailedSubmissionCategory.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <div class="cursor-pointer select-none" @click="expanded = !expanded">
+      <FontAwesomeIcon :icon="expanded ? faCaretDown : faCaretRight" />{{ title }} ({{
+        submissionIds.length
+      }})
+    </div>
+    <div v-if="expanded" class="pl-5">
+      <div v-for="id in sortedSubmissionIds" :key="id">
+        {{ id }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { SubmissionState } from '@jplag/model'
+import { computed, PropType, ref } from 'vue'
+
+const props = defineProps({
+  category: {
+    type: String as PropType<SubmissionState>,
+    required: true
+  },
+  submissionIds: {
+    type: Array as PropType<string[]>,
+    required: true
+  }
+})
+
+const expanded = ref(false)
+
+const sortedSubmissionIds = computed(() => {
+  return [...props.submissionIds].sort()
+})
+
+const title = computed(() => {
+  const parts = props.category.split('_')
+  return parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase()).join(' ')
+})
+</script>

--- a/report-viewer/ui-components/widget/failedSubmissions/FailedSubmissionsDisplay.vue
+++ b/report-viewer/ui-components/widget/failedSubmissions/FailedSubmissionsDisplay.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <div v-for="category in categories" :key="category">
+      <FailedSubmissionCategory :category="category" :submission-ids="categorized[category]" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { FailedSubmission, SubmissionState } from '@jplag/model'
+import { computed } from 'vue'
+import FailedSubmissionCategory from './FailedSubmissionCategory.vue'
+
+const props = defineProps({
+  submissions: {
+    type: Array<FailedSubmission>,
+    required: true
+  }
+})
+
+const categorized = computed(() => {
+  const categories: Record<SubmissionState, string[]> = {
+    [SubmissionState.CANNOT_PARSE]: [],
+    [SubmissionState.NOTHING_TO_PARSE]: [],
+    [SubmissionState.TOO_SMALL]: [],
+    [SubmissionState.UNPARSED]: [],
+    [SubmissionState.VALID]: []
+  }
+  for (const submission of props.submissions) {
+    const state = submission.submissionState
+    if (!categories[state]) {
+      categories[state] = []
+    }
+    categories[state].push(submission.submissionId)
+  }
+  return categories
+})
+
+const categories = computed(() =>
+  [
+    SubmissionState.CANNOT_PARSE,
+    SubmissionState.NOTHING_TO_PARSE,
+    SubmissionState.TOO_SMALL,
+    SubmissionState.UNPARSED
+  ].filter((category) => categorized.value[category].length > 0)
+)
+</script>

--- a/report-viewer/ui-components/widget/index.ts
+++ b/report-viewer/ui-components/widget/index.ts
@@ -10,6 +10,7 @@ import OptionComponent from './optionsSelectors/OptionComponent.vue'
 import OptionsSelectorComponent from './optionsSelectors/OptionsSelectorComponent.vue'
 import MetricIcon from './MetricIcon.vue'
 import NameElement from './NameElement.vue'
+import FailedSubmissionsDisplay from './failedSubmissions/FailedSubmissionsDisplay.vue'
 
 export * from './distributionVisualization/DistributionChartConfig'
 export * from './fileDisplaying/FileSortingOptions'
@@ -27,5 +28,6 @@ export {
   OptionComponent,
   OptionsSelectorComponent,
   MetricIcon,
-  NameElement
+  NameElement,
+  FailedSubmissionsDisplay
 }


### PR DESCRIPTION
Closes #2790 

I omitted showing anonymized names in the due to (1) them not being of any use to the user and (2) the user having to explicitly expand the section to see the names, thus hiding them by default

<img width="345" height="104" alt="grafik" src="https://github.com/user-attachments/assets/1bff9265-9d52-40d3-acb4-7caed6df770c" />
<img width="343" height="122" alt="grafik" src="https://github.com/user-attachments/assets/0566d8c3-9ab7-44fb-a389-3ecd291354a1" />
<img width="349" height="140" alt="grafik" src="https://github.com/user-attachments/assets/6c87c35b-2121-49ac-aaa3-ccd2317d1326" />
<img width="333" height="84" alt="grafik" src="https://github.com/user-attachments/assets/2ed89541-ff42-4987-a032-d714b8ade725" />


<details>
<summary>Entire Info Screen</summary>

<img width="1904" height="908" alt="grafik" src="https://github.com/user-attachments/assets/a708ba80-7584-4b03-9eb5-0f688319d0e3" />

</details>