### PR TITLE
Add --host flag for configurable report viewer bind address

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Advanced
       --encoding=<submissionCharsetOverride>
                         Specifies the charset of the submissions. This disables
                           the automatic charset detection
+      -H, --host=<host>     The bind address for the internal report viewer
+                          (default: 127.0.0.1).
       --log-level=<{ERROR, WARN, INFO, DEBUG, TRACE}>
                         Set the log level for the cli.
       -m, --similarity-threshold=<similarityThreshold>

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -3,8 +3,6 @@ package de.jplag.cli;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -67,8 +65,6 @@ public final class CLI {
             // help text has been printed, do nothing else
             return;
         }
-
-        validateHostOption();
 
         CollectedLogger.setLogLevel(this.inputHandler.getCliOptions().advanced.logLevel);
         ProgressBarLogger.setProgressBarProvider(new CliProgressBarProvider());
@@ -143,17 +139,7 @@ public final class CLI {
      */
     public void runViewer(File resultFile) throws IOException {
         finalizeLogger(); // Prints the errors. The later finalizeLogger will print any errors logged after this point.
-        InetAddress bindAddress = InetAddress.getByName(this.inputHandler.getCliOptions().advanced.host);
-        JPlagRunner.runInternalServer(resultFile, this.inputHandler.getCliOptions().advanced.port, bindAddress);
-    }
-
-    private void validateHostOption() throws CliException {
-        String host = this.inputHandler.getCliOptions().advanced.host;
-        try {
-            InetAddress.getByName(host);
-        } catch (UnknownHostException e) {
-            throw new CliException("Invalid bind address: " + host);
-        }
+        JPlagRunner.runInternalServer(resultFile, this.inputHandler.getCliOptions().advanced.port, this.inputHandler.getCliOptions().advanced.host);
     }
 
     private void selectModeAutomatically() throws IOException, ExitException {

--- a/cli/src/main/java/de/jplag/cli/CLI.java
+++ b/cli/src/main/java/de/jplag/cli/CLI.java
@@ -3,6 +3,8 @@ package de.jplag.cli;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,6 +67,8 @@ public final class CLI {
             // help text has been printed, do nothing else
             return;
         }
+
+        validateHostOption();
 
         CollectedLogger.setLogLevel(this.inputHandler.getCliOptions().advanced.logLevel);
         ProgressBarLogger.setProgressBarProvider(new CliProgressBarProvider());
@@ -139,7 +143,17 @@ public final class CLI {
      */
     public void runViewer(File resultFile) throws IOException {
         finalizeLogger(); // Prints the errors. The later finalizeLogger will print any errors logged after this point.
-        JPlagRunner.runInternalServer(resultFile, this.inputHandler.getCliOptions().advanced.port);
+        InetAddress bindAddress = InetAddress.getByName(this.inputHandler.getCliOptions().advanced.host);
+        JPlagRunner.runInternalServer(resultFile, this.inputHandler.getCliOptions().advanced.port, bindAddress);
+    }
+
+    private void validateHostOption() throws CliException {
+        String host = this.inputHandler.getCliOptions().advanced.host;
+        try {
+            InetAddress.getByName(host);
+        } catch (UnknownHostException e) {
+            throw new CliException("Invalid bind address: " + host);
+        }
     }
 
     private void selectModeAutomatically() throws IOException, ExitException {

--- a/cli/src/main/java/de/jplag/cli/JPlagRunner.java
+++ b/cli/src/main/java/de/jplag/cli/JPlagRunner.java
@@ -39,18 +39,6 @@ public final class JPlagRunner {
      * Runs the internal server. Blocks until the server has stopped.
      * @param resultFile is the result file to pass to the server. May be null.
      * @param port is the port to open the server on.
-     * @throws IOException if the internal server throws an exception
-     * @deprecated Use {@link #runInternalServer(File, int, InetAddress)} instead
-     */
-    @Deprecated(since = "7.0.0", forRemoval = true)
-    public static void runInternalServer(File resultFile, int port) throws IOException {
-        runInternalServer(resultFile, port, InetAddress.getLoopbackAddress());
-    }
-
-    /**
-     * Runs the internal server. Blocks until the server has stopped.
-     * @param resultFile is the result file to pass to the server. May be null.
-     * @param port is the port to open the server on.
      * @param bindAddress is the address to bind the server to.
      * @throws IOException if the internal server throws an exception
      */
@@ -60,9 +48,8 @@ public final class JPlagRunner {
             return;
         }
 
-        if (bindAddress.isAnyLocalAddress()) {
-            logger.warn("Binding to all interfaces ({}). The report viewer will be accessible from any network interface.",
-                    bindAddress.getHostAddress());
+        if (!bindAddress.isLoopbackAddress()) {
+            logger.warn("Binding to non-loopback address ({}). The report viewer may be accessible from any network.", bindAddress.getHostAddress());
         }
 
         ReportViewer reportViewer = new ReportViewer(resultFile, port, bindAddress);

--- a/cli/src/main/java/de/jplag/cli/JPlagRunner.java
+++ b/cli/src/main/java/de/jplag/cli/JPlagRunner.java
@@ -3,6 +3,8 @@ package de.jplag.cli;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URI;
 
 import org.slf4j.Logger;
@@ -38,23 +40,61 @@ public final class JPlagRunner {
      * @param resultFile is the result file to pass to the server. May be null.
      * @param port is the port to open the server on.
      * @throws IOException if the internal server throws an exception
+     * @deprecated Use {@link #runInternalServer(File, int, InetAddress)} instead
      */
+    @Deprecated
     public static void runInternalServer(File resultFile, int port) throws IOException {
+        runInternalServer(resultFile, port, InetAddress.getLoopbackAddress());
+    }
+
+    /**
+     * Runs the internal server. Blocks until the server has stopped.
+     * @param resultFile is the result file to pass to the server. May be null.
+     * @param port is the port to open the server on.
+     * @param bindAddress is the address to bind the server to.
+     * @throws IOException if the internal server throws an exception
+     */
+    public static void runInternalServer(File resultFile, int port, InetAddress bindAddress) throws IOException {
         if (!ReportViewer.hasCompiledViewer()) {
             logger.warn("The report viewer is not available. Check whether you compiled JPlag with the report viewer.");
             return;
         }
-        ReportViewer reportViewer = new ReportViewer(resultFile, port);
+
+        if (bindAddress.isAnyLocalAddress()) {
+            logger.warn("Binding to all interfaces ({}). The report viewer will be accessible from any network interface.",
+                    bindAddress.getHostAddress());
+        }
+
+        ReportViewer reportViewer = new ReportViewer(resultFile, port, bindAddress);
         int actualPort = reportViewer.start();
-        logger.info("ReportViewer started on port http://localhost:{}", actualPort);
+
+        String displayHost = getDisplayHost(bindAddress);
+        String urlHost = getUrlHost(bindAddress);
+
+        logger.info("ReportViewer started on http://{}:{}", displayHost, actualPort);
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-            Desktop.getDesktop().browse(URI.create("http://localhost:" + actualPort + "/"));
+            Desktop.getDesktop().browse(URI.create("http://" + urlHost + ":" + actualPort + "/"));
         } else {
-            logger.info("Could not open browser. You can open the Report Viewer here: http://localhost:{}/", actualPort);
+            logger.info("Could not open browser. You can open the Report Viewer here: http://{}:{}/", displayHost, actualPort);
         }
 
         System.out.println("Press Enter key to exit...");
         System.in.read();
         reportViewer.stop();
+    }
+
+    private static String getDisplayHost(InetAddress bindAddress) {
+        if (bindAddress.isAnyLocalAddress()) {
+            return "localhost";
+        }
+        return bindAddress.getHostAddress();
+    }
+
+    private static String getUrlHost(InetAddress bindAddress) {
+        String hostAddress = bindAddress.getHostAddress();
+        if (bindAddress instanceof Inet6Address) {
+            return "[" + hostAddress + "]";
+        }
+        return hostAddress;
     }
 }

--- a/cli/src/main/java/de/jplag/cli/JPlagRunner.java
+++ b/cli/src/main/java/de/jplag/cli/JPlagRunner.java
@@ -42,7 +42,7 @@ public final class JPlagRunner {
      * @throws IOException if the internal server throws an exception
      * @deprecated Use {@link #runInternalServer(File, int, InetAddress)} instead
      */
-    @Deprecated
+    @Deprecated(since = "7.0.0", forRemoval = true)
     public static void runInternalServer(File resultFile, int port) throws IOException {
         runInternalServer(resultFile, port, InetAddress.getLoopbackAddress());
     }

--- a/cli/src/main/java/de/jplag/cli/options/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/options/CliOptions.java
@@ -1,6 +1,7 @@
 package de.jplag.cli.options;
 
 import java.io.File;
+import java.net.InetAddress;
 import java.nio.charset.Charset;
 
 import org.slf4j.event.Level;
@@ -132,8 +133,9 @@ public class CliOptions implements Runnable {
         public int port = 1996;
 
         /** Bind address for internal report viewer. */
-        @Option(names = {"-H", "--host"}, description = "The bind address for the internal report viewer (default: ${DEFAULT-VALUE}).")
-        public String host = "127.0.0.1";
+        @Option(names = {"-H",
+                "--host"}, description = "The bind address for the internal report viewer (default: 127.0.0.1).", converter = InetAddressConverter.class)
+        public InetAddress host = InetAddress.getLoopbackAddress();
 
         /** Export similarity as CSV. */
         @Option(names = "--csv-export", description = "Export pairwise similarity values as a CSV file.")

--- a/cli/src/main/java/de/jplag/cli/options/CliOptions.java
+++ b/cli/src/main/java/de/jplag/cli/options/CliOptions.java
@@ -131,6 +131,10 @@ public class CliOptions implements Runnable {
         @Option(names = {"-P", "--port"}, description = "The port used for the internal report viewer (default: ${DEFAULT-VALUE}).")
         public int port = 1996;
 
+        /** Bind address for internal report viewer. */
+        @Option(names = {"-H", "--host"}, description = "The bind address for the internal report viewer (default: ${DEFAULT-VALUE}).")
+        public String host = "127.0.0.1";
+
         /** Export similarity as CSV. */
         @Option(names = "--csv-export", description = "Export pairwise similarity values as a CSV file.")
         public boolean csvExport = false;

--- a/cli/src/main/java/de/jplag/cli/options/InetAddressConverter.java
+++ b/cli/src/main/java/de/jplag/cli/options/InetAddressConverter.java
@@ -1,0 +1,22 @@
+package de.jplag.cli.options;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import de.jplag.cli.CliException;
+
+import picocli.CommandLine;
+
+/**
+ * Converts a CLI string argument to an {@link InetAddress}.
+ */
+public class InetAddressConverter implements CommandLine.ITypeConverter<InetAddress> {
+    @Override
+    public InetAddress convert(String value) throws Exception {
+        try {
+            return InetAddress.getByName(value);
+        } catch (UnknownHostException e) {
+            throw new CliException("Invalid bind address: " + value, e);
+        }
+    }
+}

--- a/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
+++ b/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
@@ -44,7 +44,7 @@ public class ReportViewer implements HttpHandler {
      * @throws IOException If the result file cannot be read
      * @deprecated Use {@link #ReportViewer(File, int, InetAddress)} instead
      */
-    @Deprecated
+    @Deprecated(since = "7.0.0", forRemoval = true)
     public ReportViewer(File resultFile, int port) throws IOException {
         this(resultFile, port, InetAddress.getLoopbackAddress());
     }

--- a/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
+++ b/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Objects;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -32,6 +33,7 @@ public class ReportViewer implements HttpHandler {
 
     private final RoutingTree routingTree;
     private final int port;
+    private final InetAddress bindAddress;
 
     private HttpServer server;
 
@@ -40,8 +42,23 @@ public class ReportViewer implements HttpHandler {
      * @param resultFile The result file to use for the report viewer
      * @param port The port to use for the server. You can use 0 to use any free port.
      * @throws IOException If the result file cannot be read
+     * @deprecated Use {@link #ReportViewer(File, int, InetAddress)} instead
      */
+    @Deprecated
     public ReportViewer(File resultFile, int port) throws IOException {
+        this(resultFile, port, InetAddress.getLoopbackAddress());
+    }
+
+    /**
+     * Launches a locally hosted report viewer.
+     * @param resultFile The result file to use for the report viewer
+     * @param port The port to use for the server. You can use 0 to use any free port.
+     * @param bindAddress The address to bind the server to
+     * @throws IOException If the result file cannot be read
+     */
+    public ReportViewer(File resultFile, int port, InetAddress bindAddress) throws IOException {
+        Objects.requireNonNull(bindAddress, "bindAddress must not be null");
+
         this.routingTree = new RoutingTree();
 
         this.routingTree.insertRouting("", new RoutingResources(REPORT_VIEWER_RESOURCE_PREFIX).or(new RoutingAlias(INDEX_PATH)));
@@ -51,6 +68,7 @@ public class ReportViewer implements HttpHandler {
         }
 
         this.port = port;
+        this.bindAddress = bindAddress;
     }
 
     /**
@@ -70,7 +88,7 @@ public class ReportViewer implements HttpHandler {
         BindException lastException = new BindException("Could not create server. Probably due to no free port found.");
         while (server == null && remainingLookups-- > 0) {
             try {
-                server = HttpServer.create(new InetSocketAddress(InetAddress.getByAddress(new byte[] {127, 0, 0, 1}), currentPort), 0);
+                server = HttpServer.create(new InetSocketAddress(bindAddress, currentPort), 0);
             } catch (BindException e) {
                 logger.info("Port {} is not available. Trying to find a different one.", currentPort);
                 lastException = e;

--- a/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
+++ b/cli/src/main/java/de/jplag/cli/server/ReportViewer.java
@@ -41,18 +41,6 @@ public class ReportViewer implements HttpHandler {
      * Launches a locally hosted report viewer.
      * @param resultFile The result file to use for the report viewer
      * @param port The port to use for the server. You can use 0 to use any free port.
-     * @throws IOException If the result file cannot be read
-     * @deprecated Use {@link #ReportViewer(File, int, InetAddress)} instead
-     */
-    @Deprecated(since = "7.0.0", forRemoval = true)
-    public ReportViewer(File resultFile, int port) throws IOException {
-        this(resultFile, port, InetAddress.getLoopbackAddress());
-    }
-
-    /**
-     * Launches a locally hosted report viewer.
-     * @param resultFile The result file to use for the report viewer
-     * @param port The port to use for the server. You can use 0 to use any free port.
      * @param bindAddress The address to bind the server to
      * @throws IOException If the result file cannot be read
      */

--- a/cli/src/test/java/de/jplag/cli/HostOptionTest.java
+++ b/cli/src/test/java/de/jplag/cli/HostOptionTest.java
@@ -15,7 +15,6 @@ import de.jplag.cli.test.CliTest;
 import de.jplag.exceptions.ExitException;
 
 class HostOptionTest extends CliTest {
-    private static final String DEFAULT_HOST = "127.0.0.1";
     private static final String ANY_HOST = "0.0.0.0";
     private static final String LOCALHOST = "localhost";
     private static final String IPV6_LOOPBACK = "::1";

--- a/cli/src/test/java/de/jplag/cli/HostOptionTest.java
+++ b/cli/src/test/java/de/jplag/cli/HostOptionTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,43 +15,50 @@ import de.jplag.cli.test.CliTest;
 import de.jplag.exceptions.ExitException;
 
 class HostOptionTest extends CliTest {
+    private static final String DEFAULT_HOST = "127.0.0.1";
+    private static final String ANY_HOST = "0.0.0.0";
+    private static final String LOCALHOST = "localhost";
+    private static final String IPV6_LOOPBACK = "::1";
+    private static final String INVALID_HOST = "invalid.host";
+    private static final String INVALID_HOST_WITH_DOMAIN = "invalid.host.address.that.does.not.exist";
+
     @Test
     void testDefaultHost() throws IOException, ExitException {
         CliInputHandler inputHandler = this.runCli().inputHandler();
-        assertEquals("127.0.0.1", inputHandler.getCliOptions().advanced.host);
+        assertEquals(InetAddress.getLoopbackAddress(), inputHandler.getCliOptions().advanced.host);
     }
 
     @Test
     void testCustomHost() throws IOException, ExitException {
-        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, "0.0.0.0")).inputHandler();
-        assertEquals("0.0.0.0", inputHandler.getCliOptions().advanced.host);
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, ANY_HOST)).inputHandler();
+        assertEquals(InetAddress.getByName(ANY_HOST), inputHandler.getCliOptions().advanced.host);
     }
 
     @Test
     void testLocalhostHostname() throws IOException, ExitException {
-        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, "localhost")).inputHandler();
-        assertEquals("localhost", inputHandler.getCliOptions().advanced.host);
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, LOCALHOST)).inputHandler();
+        assertEquals(InetAddress.getByName(LOCALHOST), inputHandler.getCliOptions().advanced.host);
     }
 
     @Test
     void testIPv6Loopback() throws IOException, ExitException {
-        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, "::1")).inputHandler();
-        assertEquals("::1", inputHandler.getCliOptions().advanced.host);
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, IPV6_LOOPBACK)).inputHandler();
+        assertEquals(InetAddress.getByName(IPV6_LOOPBACK), inputHandler.getCliOptions().advanced.host);
     }
 
     @Test
     void testInvalidHost() {
         assertThrowsExactly(CliException.class, () -> {
-            this.runCli(args -> args.with(CliArgument.HOST, "invalid.host.address.that.does.not.exist"));
+            this.runCli(args -> args.with(CliArgument.HOST, INVALID_HOST_WITH_DOMAIN));
         });
     }
 
     @Test
     void testInvalidHostMessage() {
         CliException exception = assertThrowsExactly(CliException.class, () -> {
-            this.runCli(args -> args.with(CliArgument.HOST, "invalid.host"));
+            this.runCli(args -> args.with(CliArgument.HOST, INVALID_HOST));
         });
-        assertTrue(exception.getMessage().contains("Invalid bind address: invalid.host"));
+        assertTrue(exception.getCause().getCause().getMessage().contains("Invalid bind address: " + INVALID_HOST));
     }
 
     @Override

--- a/cli/src/test/java/de/jplag/cli/HostOptionTest.java
+++ b/cli/src/test/java/de/jplag/cli/HostOptionTest.java
@@ -1,0 +1,60 @@
+package de.jplag.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import de.jplag.cli.picocli.CliInputHandler;
+import de.jplag.cli.test.CliArgument;
+import de.jplag.cli.test.CliTest;
+import de.jplag.exceptions.ExitException;
+
+class HostOptionTest extends CliTest {
+    @Test
+    void testDefaultHost() throws IOException, ExitException {
+        CliInputHandler inputHandler = this.runCli().inputHandler();
+        assertEquals("127.0.0.1", inputHandler.getCliOptions().advanced.host);
+    }
+
+    @Test
+    void testCustomHost() throws IOException, ExitException {
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, "0.0.0.0")).inputHandler();
+        assertEquals("0.0.0.0", inputHandler.getCliOptions().advanced.host);
+    }
+
+    @Test
+    void testLocalhostHostname() throws IOException, ExitException {
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, "localhost")).inputHandler();
+        assertEquals("localhost", inputHandler.getCliOptions().advanced.host);
+    }
+
+    @Test
+    void testIPv6Loopback() throws IOException, ExitException {
+        CliInputHandler inputHandler = this.runCli(args -> args.with(CliArgument.HOST, "::1")).inputHandler();
+        assertEquals("::1", inputHandler.getCliOptions().advanced.host);
+    }
+
+    @Test
+    void testInvalidHost() {
+        assertThrowsExactly(CliException.class, () -> {
+            this.runCli(args -> args.with(CliArgument.HOST, "invalid.host.address.that.does.not.exist"));
+        });
+    }
+
+    @Test
+    void testInvalidHostMessage() {
+        CliException exception = assertThrowsExactly(CliException.class, () -> {
+            this.runCli(args -> args.with(CliArgument.HOST, "invalid.host"));
+        });
+        assertTrue(exception.getMessage().contains("Invalid bind address: invalid.host"));
+    }
+
+    @Override
+    public void addDefaultParameters() {
+        // prevents the submission directory from being added to the parameters automatically
+    }
+}

--- a/cli/src/test/java/de/jplag/cli/test/CliArgument.java
+++ b/cli/src/test/java/de/jplag/cli/test/CliArgument.java
@@ -80,4 +80,7 @@ public record CliArgument<T>(String name, boolean isPositional) {
     /** Required number of merges. */
     public static CliArgument<Integer> REQUIRED_MERGES = new CliArgument<>("required-merges", false);
 
+    /** Bind address for report viewer. */
+    public static CliArgument<String> HOST = new CliArgument<>("host", false);
+
 }

--- a/docs/1.-How-to-Use-JPlag.md
+++ b/docs/1.-How-to-Use-JPlag.md
@@ -62,6 +62,8 @@ Advanced
       --encoding=<submissionCharsetOverride>
                         Specifies the charset of the submissions. This disables
                           the automatic charset detection
+      -H, --host=<host>     The bind address for the internal report viewer
+                          (default: 127.0.0.1).
       --log-level=<{ERROR, WARN, INFO, DEBUG, TRACE}>
                         Set the log level for the cli.
       -m, --similarity-threshold=<similarityThreshold>

--- a/docs/1.-How-to-Use-JPlag.md
+++ b/docs/1.-How-to-Use-JPlag.md
@@ -189,6 +189,22 @@ This can be prevented by passing `--mode run` (`java -jar jplag.jar --mode run <
 
 Additional information can be found [here](7.-Report-Viewer.md)
 
+### Report Viewer Network Binding
+
+By default, the report viewer binds to `127.0.0.1` (loopback only), making it accessible only from the local machine. This is the most secure option for local usage.
+
+To make the report viewer accessible from other machines or containers (e.g., for Docker port forwarding or remote access), use the `--host` option:
+
+```bash
+# Bind to all network interfaces
+java -jar jplag.jar --host 0.0.0.0 <submission directory>
+
+# Bind to a specific network interface
+java -jar jplag.jar --host 192.168.1.100 <submission directory>
+```
+
+**Security Note:** The report viewer has no authentication mechanism and is intended for local use. When binding to `0.0.0.0` or another non-loopback address, ensure it is only exposed to trusted networks. In containerized or shared environments, consider using firewall rules or network policies to restrict access.
+
 ## Basic Concepts
 
 This section explains some fundamental concepts about JPlag that make it easier to understand and use.


### PR DESCRIPTION
Adds --host/-H CLI option to configure the Report Viewer server bind address. The server was previously hardcoded to 127.0.0.1, making it inaccessible via Docker port forwarding or remote network access.

### Changes:
- CliOptions.java: Added --host option (default: 127.0.0.1)
- ReportViewer.java: Added InetAddress bindAddress parameter, Objects.requireNonNull check, deprecated old constructor
- JPlagRunner.java: Added InetAddress parameter with deprecated overload, IPv6 URL formatting, 0.0.0.0 warning, localhost display for wildcard addresses
- CLI.java: Added fail-fast validateHostOption() in executeCli()
- HostOptionTest.java: 6 new tests (default, custom, localhost, IPv6, invalid, error message)
- CliArgument.java: Added HOST test constant
- README.md, docs/1.-How-to-Use-JPlag.md: Updated CLI help text

### Closes issue #3000