### PR TITLE
Improve match merging memory allocation and performance

### DIFF
--- a/core/src/main/java/de/jplag/merging/MatchMerging.java
+++ b/core/src/main/java/de/jplag/merging/MatchMerging.java
@@ -2,7 +2,9 @@ package de.jplag.merging;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 
 import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
@@ -20,9 +22,12 @@ import de.jplag.options.JPlagOptions;
  * Based on configurable parameters MinimumNeighborLength and MaximumGapSize, it alters prior results from pairwise
  * submission comparisons and merges all neighboring matches that fit the specified thresholds. Submissions are referred
  * to as left and right and neighboring matches as upper and lower. When neighboring matches get merged they become one
- * and the tokens separating them get removed from the submission clone. MinimumNeighborLength describes how short a
- * match can be and MaximumGapSize describes how many tokens can be between two neighboring matches. Both are set in
- * {@link JPlagOptions} as {@link MergingOptions} and default to (2,6).
+ * and the tokens separating them (the gap) are subsumed into the length of the merged match rather than being removed
+ * from any token sequence. MinimumNeighborLength describes how short a match can be and MaximumGapSize describes how
+ * many tokens can be between two neighboring matches. Both are set in {@link JPlagOptions} as {@link MergingOptions}
+ * and default to (2,6). Note that MinimumNeighborLength is not enforced here: it is applied upstream in
+ * {@code GreedyStringTiling}, which lowers its minimum match length accordingly when merging is enabled, so that
+ * shorter matches are available as merge candidates.
  */
 public class MatchMerging {
     private final JPlagOptions options;
@@ -54,8 +59,9 @@ public class MatchMerging {
     }
 
     private JPlagComparison mergeMatchesOf(JPlagComparison comparison, ProgressBar progressBar) {
-        Submission leftSubmission = comparison.firstSubmission().copy();
-        Submission rightSubmission = comparison.secondSubmission().copy();
+        // Submissions are never mutated during merging; reuse originals instead of copying.
+        Submission leftSubmission = comparison.firstSubmission();
+        Submission rightSubmission = comparison.secondSubmission();
         List<Match> globalMatches = new ArrayList<>(comparison.matches());
         globalMatches.addAll(comparison.ignoredMatches());
 
@@ -85,9 +91,14 @@ public class MatchMerging {
         sortedByLeft.sort(Comparator.comparingInt(Match::startOfFirst));
         sortedByRight.sort(Comparator.comparingInt(Match::startOfSecond));
 
-        for (int i = 0; i < sortedByLeft.size() - 1; i++) {
+        // Position of each match in the right-order, by object identity, to avoid a quadratic indexOf scan below.
+        Map<Match, Integer> rightPosition = new IdentityHashMap<>();
+        for (int i = 0; i < sortedByRight.size(); i++) {
+            rightPosition.put(sortedByRight.get(i), i);
+        }
 
-            if (sortedByRight.indexOf(sortedByLeft.get(i)) == sortedByRight.indexOf(sortedByLeft.get(i + 1)) - 1) {
+        for (int i = 0; i < sortedByLeft.size() - 1; i++) {
+            if (rightPosition.get(sortedByLeft.get(i)).intValue() == rightPosition.get(sortedByLeft.get(i + 1)).intValue() - 1) {
                 neighbors.add(new Neighbor(sortedByLeft.get(i), sortedByLeft.get(i + 1)));
             }
         }
@@ -171,11 +182,10 @@ public class MatchMerging {
             return false;
         }
 
-        List<Token> tokenLeft = new ArrayList<>(leftSubmission.getTokenList());
-        List<Token> tokenRight = new ArrayList<>(rightSubmission.getTokenList());
-
-        tokenLeft = tokenLeft.subList(upperMatch.endOfFirst() + 1, upperMatch.endOfFirst() + tokensBetweenLeft + 1);
-        tokenRight = tokenRight.subList(upperMatch.endOfSecond() + 1, upperMatch.endOfSecond() + tokensBetweenRight + 1);
+        // subList returns a view, so no copy of the (potentially large) token lists is made per merge attempt.
+        List<Token> tokenLeft = leftSubmission.getTokenList().subList(upperMatch.endOfFirst() + 1, upperMatch.endOfFirst() + tokensBetweenLeft + 1);
+        List<Token> tokenRight = rightSubmission.getTokenList().subList(upperMatch.endOfSecond() + 1,
+                upperMatch.endOfSecond() + tokensBetweenRight + 1);
 
         return containsFileEndToken(tokenLeft) || containsFileEndToken(tokenRight);
     }

--- a/core/src/test/java/de/jplag/merging/MatchMergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MatchMergingTest.java
@@ -56,7 +56,8 @@ class MatchMergingTest extends TestBase {
 
         comparisonStrategy = new LongestCommonSubsequenceSearch(options);
 
-        // Largest two single-file submissions provide token lists big enough for hand-built match indices; token content is never inspected.
+        // Largest two single-file submissions provide token lists big enough for hand-built match indices; token content is
+        // never inspected.
         List<Submission> singleFileSubmissions = submissionSet.getSubmissions().stream().filter(submission -> submission.getFiles().size() == 1)
                 .sorted(Comparator.comparingInt(Submission::getNumberOfTokens).reversed().thenComparing(Submission::getName)).toList();
         leftSubmission = singleFileSubmissions.get(0);

--- a/core/src/test/java/de/jplag/merging/MatchMergingTest.java
+++ b/core/src/test/java/de/jplag/merging/MatchMergingTest.java
@@ -2,6 +2,7 @@ package de.jplag.merging;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -13,6 +14,8 @@ import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import de.jplag.JPlagComparison;
 import de.jplag.JPlagResult;
@@ -38,6 +41,8 @@ class MatchMergingTest extends TestBase {
     private List<JPlagComparison> comparisonsAfter;
     private final LongestCommonSubsequenceSearch comparisonStrategy;
     private final SubmissionSet submissionSet;
+    private final Submission leftSubmission;
+    private final Submission rightSubmission;
     private static final int MINIMUM_NEIGHBOR_LENGTH = 1;
     private static final int MAXIMUM_GAP_SIZE = 10;
     private static final int MINIMUM_REQUIRED_MERGES = 0;
@@ -50,6 +55,12 @@ class MatchMergingTest extends TestBase {
         submissionSet = builder.buildSubmissionSet();
 
         comparisonStrategy = new LongestCommonSubsequenceSearch(options);
+
+        // Largest two single-file submissions provide token lists big enough for hand-built match indices; token content is never inspected.
+        List<Submission> singleFileSubmissions = submissionSet.getSubmissions().stream().filter(submission -> submission.getFiles().size() == 1)
+                .sorted(Comparator.comparingInt(Submission::getNumberOfTokens).reversed().thenComparing(Submission::getName)).toList();
+        leftSubmission = singleFileSubmissions.get(0);
+        rightSubmission = singleFileSubmissions.get(1);
     }
 
     @BeforeEach
@@ -233,6 +244,61 @@ class MatchMergingTest extends TestBase {
         for (File file : files) {
             assertEquals(files.getFirst(), file, "Two different files in token sequence: " + files.getFirst().getName() + " and " + file.getName());
         }
+    }
+
+    @DisplayName("Neighbors merge iff the average gap does not exceed the maximum gap size.")
+    @ParameterizedTest(name = "gap of 5, maximumGapSize={0} -> {1} match(es)")
+    @CsvSource({"4, 2", "5, 1", "6, 1"})
+    void testGapSizeBoundary(int maximumGapSize, int expectedMatchCount) {
+        // Two length-3 matches separated by a symmetric gap of 5 tokens.
+        List<Match> handBuiltMatches = List.of(new Match(0, 0, 3, 3), new Match(8, 8, 3, 3));
+        List<Match> merged = mergeHandBuilt(new MergingOptions(true, 1, maximumGapSize, 0), handBuiltMatches);
+        assertEquals(expectedMatchCount, merged.size());
+    }
+
+    @Test
+    @DisplayName("Matches whose order differs between the two submissions are not neighbors and are not merged.")
+    void testReorderedMatchesAreNotMerged() {
+        // Matches in opposite order: A then B on the left, B then A on the right.
+        Match matchA = new Match(0, 8, 3, 3);
+        Match matchB = new Match(4, 0, 3, 3);
+        List<Match> merged = mergeHandBuilt(new MergingOptions(true, 1, 10, 0), List.of(matchA, matchB));
+
+        List<Match> sortedResult = merged.stream().sorted(Comparator.comparingInt(Match::startOfFirst)).toList();
+        assertIterableEquals(List.of(matchA, matchB), sortedResult, "Reordered matches must remain unmerged");
+    }
+
+    @DisplayName("A comparison is only rewritten when the number of merges reaches minimumRequiredMerges.")
+    @ParameterizedTest(name = "{0} contiguous matches, minimumRequiredMerges=3 -> {1} match(es)")
+    @CsvSource({"4, 1", "3, 3"})
+    void testMinimumRequiredMergesBoundary(int chainLength, int expectedMatchCount) {
+        // A chain of N contiguous length-2 matches produces N-1 merges. Threshold=3: needs chain of 4 to rewrite.
+        List<Match> handBuiltMatches = new ArrayList<>();
+        for (int i = 0; i < chainLength; i++) {
+            handBuiltMatches.add(new Match(2 * i, 2 * i, 2, 2));
+        }
+        List<Match> merged = mergeHandBuilt(new MergingOptions(true, 1, 6, 3), handBuiltMatches);
+        assertEquals(expectedMatchCount, merged.size());
+    }
+
+    @Test
+    @DisplayName("An insertion on one side produces an asymmetric merged match that subsumes the gap per side.")
+    void testAsymmetricGapMerge() {
+        // No gap on the left, four inserted tokens on the right: average gap 2, so the matches merge.
+        List<Match> handBuiltMatches = List.of(new Match(0, 0, 3, 3), new Match(3, 7, 3, 3));
+        List<Match> merged = mergeHandBuilt(new MergingOptions(true, 1, 6, 0), handBuiltMatches);
+
+        assertEquals(1, merged.size());
+        Match mergedMatch = merged.getFirst();
+        assertEquals(new Match(0, 0, 6, 10), mergedMatch);
+        assertNotEquals(mergedMatch.lengthOfFirst(), mergedMatch.lengthOfSecond(), "The merged match must keep asymmetric side lengths");
+    }
+
+    private List<Match> mergeHandBuilt(MergingOptions mergingOptions, List<Match> handBuiltMatches) {
+        JPlagOptions unitOptions = options.withMinimumTokenMatch(1).withMergingOptions(mergingOptions);
+        JPlagComparison comparison = new JPlagComparison(leftSubmission, rightSubmission, new ArrayList<>(handBuiltMatches), new ArrayList<>());
+        JPlagResult result = new JPlagResult(List.of(comparison), submissionSet, 0L, unitOptions);
+        return new MatchMerging(unitOptions).mergeMatchesOf(result).getAllComparisons().getFirst().matches();
     }
 
     private static JPlagComparison findComparison(List<JPlagComparison> comparisons, String firstName, String secondName) {


### PR DESCRIPTION
For larger datasets (especially many large programs), subsequence match merging (SMM) consumes a lot of memory due to the copying of lists. In a JVM with less memory allocated, this also greatly increases the runtime. This PR improves the SMM performance by eliminating unnecessary submission copies, replacing the O(n²) index lookup with a constant-time IdentityHashMap, and using subList views instead of copying token lists. However, runtime is still affected when SMM is enabled due to the greedy string tiling overhead.

Contributes towards #1430 (and thus also #1569).

**Example Measurements:**

- (macOS, M4 Pro Chip, JDK 26, -Xmx16g)
- 367 programs with ~1500 LOC each
- Allocation measured via `ThreadMXBean.getTotalThreadAllocatedBytes()`

| **Match Merging Algorithm** | **Runtime Mean** | **Alloc/iter** |
|---|---:|---:|
| Current | 2.72s | 22.1 GB |
| New Version | 1.13s | 2.7 GB |

| **GST overhead** | **Runtime Mean** |
|---|---:|
| Merging disabled | 5.7s |
| Merging enabled | 2.8 min |