### PR TITLE
Dont run sonarcloud report viewer for external

### DIFF
--- a/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
@@ -61,7 +61,7 @@ jobs:
           npm run test:unit
       
       - name: SonarCloud Scan
-        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.organization == 'jplag' }}
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.owner.login == 'jplag' }}
         uses: SonarSource/sonarqube-scan-action@v8.2.0
         with:
           projectBaseDir: report-viewer

--- a/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
@@ -61,7 +61,7 @@ jobs:
           npm run test:unit
       
       - name: SonarCloud Scan
-        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.base.repo.owner != 'jplag' }}
         uses: SonarSource/sonarqube-scan-action@v8.2.0
         with:
           projectBaseDir: report-viewer

--- a/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
@@ -61,7 +61,7 @@ jobs:
           npm run test:unit
       
       - name: SonarCloud Scan
-        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.owner == 'jplag' }}
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.owner.name == 'jplag' }}
         uses: SonarSource/sonarqube-scan-action@v8.2.0
         with:
           projectBaseDir: report-viewer

--- a/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
@@ -61,7 +61,7 @@ jobs:
           npm run test:unit
       
       - name: SonarCloud Scan
-        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.base.repo.owner != 'jplag' }}
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.owner == 'jplag' }}
         uses: SonarSource/sonarqube-scan-action@v8.2.0
         with:
           projectBaseDir: report-viewer

--- a/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
@@ -61,7 +61,7 @@ jobs:
           npm run test:unit
       
       - name: SonarCloud Scan
-        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.owner.name == 'jplag' }}
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.organization == 'jplag' }}
         uses: SonarSource/sonarqube-scan-action@v8.2.0
         with:
           projectBaseDir: report-viewer


### PR DESCRIPTION
Before starting the sonarcloud scan it asks whether the root repo for the pr is owned by jplag

AS seen [here](https://github.com/jplag/JPlag/actions/runs/29906287569/job/88878628419?pr=3061) It skips it correctly