### PR TITLE
Parse File Lists instead of Sets to persist file order in Submissions

### DIFF
--- a/core/src/main/java/de/jplag/Submission.java
+++ b/core/src/main/java/de/jplag/Submission.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,7 +41,7 @@ public class Submission implements Comparable<Submission> {
     private final String name; // identifier for the submission (a directory or file name).
     private final File submissionRootFile; // Root of the submission, a director or file (including the subdir if used).
     private final boolean isNew; // old submissions are only checked against new ones.
-    private final Collection<File> files;
+    private final List<File> files;
     private final Language language;
 
     private SubmissionState state; // whether an error occurred during parsing or not
@@ -60,7 +59,7 @@ public class Submission implements Comparable<Submission> {
      * @param files are the files of the submissions, if the root is a single file it should just contain one file.
      * @param language is the language of the submission.
      */
-    public Submission(String name, File submissionRootFile, boolean isNew, Collection<File> files, Language language) {
+    public Submission(String name, File submissionRootFile, boolean isNew, List<File> files, Language language) {
         this.name = name;
         this.submissionRootFile = submissionRootFile;
         this.isNew = isNew;
@@ -102,9 +101,9 @@ public class Submission implements Comparable<Submission> {
 
     /**
      * Provided all source code files.
-     * @return a collection of files this submission consists of.
+     * @return a list of files this submission consists of.
      */
-    public Collection<File> getFiles() {
+    public List<File> getFiles() {
         return files;
     }
 
@@ -198,7 +197,7 @@ public class Submission implements Comparable<Submission> {
      * @param tokenList is the list of these tokens.
      */
     public void setTokenList(List<Token> tokenList) {
-        this.tokenList = Collections.unmodifiableList(new ArrayList<>(tokenList));
+        this.tokenList = List.copyOf(tokenList);
     }
 
     /**
@@ -254,7 +253,7 @@ public class Submission implements Comparable<Submission> {
         }
 
         try {
-            tokenList = language.parse(new HashSet<>(files), normalize);
+            tokenList = language.parse(files, normalize);
         } catch (CriticalParsingException e) {
             throw new LanguageException(e.getMessage(), e.getCause());
         } catch (ParsingException e) {
@@ -312,7 +311,7 @@ public class Submission implements Comparable<Submission> {
 
     private List<Integer> getOrder(List<Token> tokenList) {
         List<Integer> order = new ArrayList<>(tokenList.size());  // a little too big
-        int currentLineNumber = tokenList.get(0).getStartLine();
+        int currentLineNumber = tokenList.getFirst().getStartLine();
         order.add(currentLineNumber);
         for (Token token : tokenList) {
             if (token.getStartLine() != currentLineNumber) {

--- a/core/src/main/java/de/jplag/SubmissionSetBuilder.java
+++ b/core/src/main/java/de/jplag/SubmissionSetBuilder.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -269,7 +268,7 @@ public class SubmissionSetBuilder {
      * @param file - File to start the scan from.
      * @return a list of nested files.
      */
-    private Collection<File> parseFilesRecursively(File file) {
+    private List<File> parseFilesRecursively(File file) {
         if (isFileExcluded(file)) {
             return Collections.emptyList();
         }
@@ -284,7 +283,7 @@ public class SubmissionSetBuilder {
             return Collections.emptyList();
         }
 
-        Collection<File> files = new ArrayList<>();
+        List<File> files = new ArrayList<>();
 
         for (String fileName : nestedFileNames) {
             files.addAll(parseFilesRecursively(new File(file, fileName)));

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
@@ -3,7 +3,6 @@ package de.jplag.antlr;
 import java.io.File;
 import java.io.Reader;
 import java.util.List;
-import java.util.Set;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
@@ -48,7 +47,7 @@ public abstract class AbstractAntlrParserAdapter<T extends Parser> {
      * @return The extracted tokens
      * @throws ParsingException If anything goes wrong
      */
-    public List<Token> parse(Set<File> files) throws ParsingException {
+    public List<Token> parse(List<File> files) throws ParsingException {
         TokenCollector collector = new TokenCollector(extractsSemantics);
         for (File file : files) {
             parseFile(file, collector);

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractAntlrParserAdapter.java
@@ -42,7 +42,7 @@ public abstract class AbstractAntlrParserAdapter<T extends Parser> {
     }
 
     /**
-     * Parsers the set of files.
+     * Parses the list of files.
      * @param files The files
      * @return The extracted tokens
      * @throws ParsingException If anything goes wrong

--- a/language-antlr-utils/src/test/java/de/jplag/antlr/LanguageTest.java
+++ b/language-antlr-utils/src/test/java/de/jplag/antlr/LanguageTest.java
@@ -1,6 +1,6 @@
 package de.jplag.antlr;
 
-import java.util.Set;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -16,6 +16,6 @@ class LanguageTest {
     @Test
     void testLanguageWithStaticParser() throws ParsingException {
         TestLanguage lang = new TestLanguage();
-        Assertions.assertEquals(0, lang.parse(Set.of(), false).size());
+        Assertions.assertEquals(0, lang.parse(List.of(), false).size());
     }
 }

--- a/language-antlr-utils/src/test/java/de/jplag/antlr/testLanguage/TestLanguage.java
+++ b/language-antlr-utils/src/test/java/de/jplag/antlr/testLanguage/TestLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.antlr.testLanguage;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -34,7 +33,7 @@ public class TestLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new TestParserAdapter().parse(files);
     }
 }

--- a/language-api/src/main/java/de/jplag/Language.java
+++ b/language-api/src/main/java/de/jplag/Language.java
@@ -45,7 +45,7 @@ public interface Language {
     int minimumTokenMatch();
 
     /**
-     * Parses a set of files. Override this method if you require normalization within the language module.
+     * Parses a list of files. Override this method if you require normalization within the language module.
      * @param files are the files to parse.
      * @param normalize True, if the tokens should be normalized
      * @return the list of parsed JPlag tokens.

--- a/language-api/src/main/java/de/jplag/Language.java
+++ b/language-api/src/main/java/de/jplag/Language.java
@@ -3,7 +3,6 @@ package de.jplag;
 import java.io.File;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import de.jplag.commentextraction.CommentExtractorSettings;
 import de.jplag.options.LanguageOptions;
@@ -46,25 +45,13 @@ public interface Language {
     int minimumTokenMatch();
 
     /**
-     * Parses a set of files. Override this method if you do not require normalization.
-     * @param files are the files to parse.
-     * @return the list of parsed JPlag tokens.
-     * @throws ParsingException if an error during parsing the files occurred.
-     * @deprecated Replaced by {@link #parse(Set, boolean)}
-     */
-    @Deprecated(forRemoval = true)
-    default List<Token> parse(Set<File> files) throws ParsingException {
-        return parse(files, false);
-    }
-
-    /**
      * Parses a set of files. Override this method if you require normalization within the language module.
      * @param files are the files to parse.
      * @param normalize True, if the tokens should be normalized
      * @return the list of parsed JPlag tokens.
      * @throws ParsingException if an error during parsing the files occurred.
      */
-    List<Token> parse(Set<File> files, boolean normalize) throws ParsingException;
+    List<Token> parse(List<File> files, boolean normalize) throws ParsingException;
 
     /**
      * @return Indicates whether the tokens returned by parse have semantic information added to them, i.e., whether the

--- a/language-api/src/main/java/de/jplag/util/FileUtils.java
+++ b/language-api/src/main/java/de/jplag/util/FileUtils.java
@@ -13,7 +13,6 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -129,13 +128,13 @@ public final class FileUtils {
     }
 
     /**
-     * Detects the most probable charset over the whole set of files.
+     * Detects the most probable charset over the whole list of files.
      * @param files The files to check
      * @param isSubmissionFile If true and a charset is set for submissions, that charset will be used always
      * @return The most probable charset
      * @throws ParsingException if reading the source files leads to an error.
      */
-    public static Charset detectCharsetFromMultiple(Collection<File> files, boolean isSubmissionFile) throws ParsingException {
+    public static Charset detectCharsetFromMultiple(List<File> files, boolean isSubmissionFile) throws ParsingException {
         if (isSubmissionFile && userSpecifiedCharset != null) {
             return userSpecifiedCharset;
         } else {
@@ -144,12 +143,12 @@ public final class FileUtils {
     }
 
     /**
-     * Detects the most probable charset over the whole set of files.
+     * Detects the most probable charset over the whole list of files.
      * @param files The files to check
      * @return The most probable charset
      * @throws ParsingException if reading the source files leads to an error.
      */
-    public static Charset detectCharsetFromMultiple(Collection<File> files) throws ParsingException {
+    public static Charset detectCharsetFromMultiple(List<File> files) throws ParsingException {
         Map<String, List<Integer>> charsetValues = new HashMap<>();
 
         List<CharsetMatch[]> matchData = new ArrayList<>();

--- a/language-api/src/test/java/de/jplag/util/FileUtilTest.java
+++ b/language-api/src/test/java/de/jplag/util/FileUtilTest.java
@@ -5,7 +5,8 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Set;
+import java.util.List;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ class FileUtilTest {
 
     @Test
     void testDetectFromFileSet() throws ParsingException {
-        Set<File> files = Set.of(TEST_FILE_SET_LOCATION.toFile().listFiles());
+        List<File> files = List.of(Objects.requireNonNull(TEST_FILE_SET_LOCATION.toFile().listFiles()));
         Charset encoding = FileUtils.detectCharsetFromMultiple(files);
         Assertions.assertEquals(StandardCharsets.ISO_8859_1, encoding);
     }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/FileTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/FileTestData.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -23,7 +22,7 @@ class FileTestData implements TestData {
 
     @Override
     public List<Token> parseTokens(Language language) throws ParsingException {
-        return language.parse(Set.of(file), false);
+        return language.parse(List.of(file), false);
     }
 
     @Override

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/InlineTestData.java
@@ -2,7 +2,6 @@ package de.jplag.testutils.datacollector;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import de.jplag.Language;
@@ -25,7 +24,7 @@ class InlineTestData implements TestData {
     public List<Token> parseTokens(Language language) throws ParsingException, IOException {
         File file = File.createTempFile("testSource", language.fileExtensions().getFirst());
         FileUtils.write(file, this.testData);
-        List<Token> tokens = language.parse(Collections.singleton(file), false);
+        List<Token> tokens = language.parse(List.of(file), false);
         TemporaryFileHolder.addTemporaryFile(file);
         return tokens;
     }

--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import de.jplag.Language;
@@ -85,7 +84,7 @@ public class TokenPositionTestData implements TestData {
     public List<Token> parseTokens(Language language) throws ParsingException, IOException {
         File file = File.createTempFile("testSource", language.fileExtensions().getFirst());
         FileUtils.write(file, String.join(System.lineSeparator(), sourceLines));
-        List<Token> tokens = language.parse(Collections.singleton(file), false);
+        List<Token> tokens = language.parse(List.of(file), false);
         TemporaryFileHolder.addTemporaryFile(file);
         return tokens;
     }

--- a/languages/c/src/main/java/de/jplag/c/CLanguage.java
+++ b/languages/c/src/main/java/de/jplag/c/CLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.c;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class CLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new Scanner().scan(files);
     }
 }

--- a/languages/c/src/main/java/de/jplag/c/Scanner.java
+++ b/languages/c/src/main/java/de/jplag/c/Scanner.java
@@ -3,7 +3,6 @@ package de.jplag.c;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,7 +26,7 @@ public class Scanner {
      * @return the token sequence.
      * @throws ParsingException if parsing fails.
      */
-    public List<Token> scan(Set<File> files) throws ParsingException {
+    public List<Token> scan(List<File> files) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
             this.currentFile = file;

--- a/languages/c/src/main/java/de/jplag/c/Scanner.java
+++ b/languages/c/src/main/java/de/jplag/c/Scanner.java
@@ -22,7 +22,7 @@ public class Scanner {
 
     /**
      * Scans a set of C files.
-     * @param files is the set of files.
+     * @param files is the list of files.
      * @return the token sequence.
      * @throws ParsingException if parsing fails.
      */

--- a/languages/cpp/src/main/java/de/jplag/cpp/CPPLanguage.java
+++ b/languages/cpp/src/main/java/de/jplag/cpp/CPPLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.cpp;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -47,7 +46,7 @@ public class CPPLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new CPPParserAdapter().parse(files);
     }
 

--- a/languages/csharp/src/main/java/de/jplag/csharp/CSharpLanguage.java
+++ b/languages/csharp/src/main/java/de/jplag/csharp/CSharpLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.csharp;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class CSharpLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new CSharpParserAdapter().parse(files);
     }
 }

--- a/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/DynamicEmfLanguage.java
+++ b/languages/emf-metamodel-dynamic/src/main/java/de/jplag/emf/dynamic/DynamicEmfLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.emf.dynamic;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.ParsingException;
 import de.jplag.Token;
@@ -29,7 +28,7 @@ public class DynamicEmfLanguage extends EmfLanguage { // currently not included 
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         throw new UnsupportedOperationException("Language module is deprecated and no longer supported!");
     }
 }

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/EmfLanguage.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/EmfLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.emf;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import org.eclipse.emf.ecore.EcorePackage;
 
@@ -54,7 +53,7 @@ public class EmfLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new EcoreParser().parse(files, normalize);
     }
 

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
@@ -2,10 +2,8 @@ package de.jplag.emf.parser;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 
@@ -31,13 +29,13 @@ public class EcoreParser {
     protected AbstractMetamodelVisitor visitor;
 
     /**
-     * Parses all tokens from a set of files.
-     * @param files is the set of files.
+     * Parses all tokens from a list of files.
+     * @param files is the list of files.
      * @param normalize specifies if the containment tree normalization should be executed or not.
      * @return the list of parsed tokens.
      * @throws ParsingException if parsing fails.
      */
-    public List<Token> parse(@MonotonicNonNull Collection<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
             parseModelFile(file, normalize);

--- a/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
+++ b/languages/emf-metamodel/src/main/java/de/jplag/emf/parser/EcoreParser.java
@@ -2,9 +2,10 @@ package de.jplag.emf.parser;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 
@@ -36,7 +37,7 @@ public class EcoreParser {
      * @return the list of parsed tokens.
      * @throws ParsingException if parsing fails.
      */
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(@MonotonicNonNull Collection<File> files, boolean normalize) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
             parseModelFile(file, normalize);

--- a/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
+++ b/languages/emf-metamodel/src/test/java/de/jplag/emf/MinimalMetamodelTest.java
@@ -27,7 +27,7 @@ class MinimalMetamodelTest extends AbstractEmfTest {
     @DisplayName("Test tokens generated from example metamodels")
     void testBookstoreMetamodels() throws ParsingException {
         List<File> testFiles = Arrays.stream(TEST_SUBJECTS).map(path -> new File(BASE_PATH.toFile(), path)).toList();
-        List<Token> result = language.parse(new HashSet<>(testFiles), true);
+        List<Token> result = language.parse(testFiles, true);
 
         logger.debug(TokenPrinterUtils.printTokensByFile(result, file -> new File(file.getAbsolutePath() + EmfLanguage.VIEW_FILE_EXTENSION)));
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();

--- a/languages/emf-model/src/main/java/de/jplag/emf/model/EmfModelLanguage.java
+++ b/languages/emf-model/src/main/java/de/jplag/emf/model/EmfModelLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.emf.model;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -65,7 +64,7 @@ public class EmfModelLanguage extends EmfLanguage {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         if (!options.getMetamodelPathOption().hasValue()) {
             throw new ParsingException(files.iterator().next(), NO_METAMODEL_ERROR);
         }

--- a/languages/emf-model/src/test/java/de/jplag/emf/model/MinimalModelInstanceTest.java
+++ b/languages/emf-model/src/test/java/de/jplag/emf/model/MinimalModelInstanceTest.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
@@ -49,7 +48,7 @@ class MinimalModelInstanceTest {
         List<File> baseFiles = new ArrayList<>(Arrays.asList(baseFile.listFiles()));
         options.getMetamodelPathOption().setValue(METAMODEL_PATH.toString());
         try {
-            List<Token> tokens = language.parse(new HashSet<>(baseFiles), true);
+            List<Token> tokens = language.parse(baseFiles, true);
             assertNotEquals(0, tokens.size());
             logger.debug(
                     TokenPrinterUtils.printTokensByFile(tokens, file -> new File(file.getAbsolutePath() + EmfModelLanguage.VIEW_FILE_EXTENSION)));

--- a/languages/golang/src/main/java/de/jplag/golang/GoLanguage.java
+++ b/languages/golang/src/main/java/de/jplag/golang/GoLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.golang;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class GoLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new GoParserAdapter().parse(files);
     }
 }

--- a/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
+++ b/languages/java/src/main/java/de/jplag/java/JavaLanguage.java
@@ -3,7 +3,6 @@ package de.jplag.java;
 import java.io.File;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -40,7 +39,7 @@ public class JavaLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new Parser().parse(files);
     }
 

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import javax.tools.DiagnosticCollector;
 import javax.tools.JavaCompiler;
@@ -49,7 +49,7 @@ public class JavacAdapter {
      * @param parser is the parser to receive the tokens.
      * @throws ParsingException if an error occurs during parsing.
      */
-    public void parseFiles(Set<File> files, final Parser parser) throws ParsingException {
+    public void parseFiles(Collection<File> files, final Parser parser) throws ParsingException {
         var listener = new DiagnosticCollector<>();
 
         List<ParsingException> parsingExceptions = new ArrayList<>();

--- a/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
+++ b/languages/java/src/main/java/de/jplag/java/JavacAdapter.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -49,7 +48,7 @@ public class JavacAdapter {
      * @param parser is the parser to receive the tokens.
      * @throws ParsingException if an error occurs during parsing.
      */
-    public void parseFiles(Collection<File> files, final Parser parser) throws ParsingException {
+    public void parseFiles(List<File> files, final Parser parser) throws ParsingException {
         var listener = new DiagnosticCollector<>();
 
         List<ParsingException> parsingExceptions = new ArrayList<>();

--- a/languages/java/src/main/java/de/jplag/java/Parser.java
+++ b/languages/java/src/main/java/de/jplag/java/Parser.java
@@ -3,7 +3,6 @@ package de.jplag.java;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import javax.tools.ToolProvider;
 
@@ -28,7 +27,7 @@ public class Parser {
      * @return the tokens sequence for the files.
      * @throws ParsingException if parsing fails.
      */
-    public List<Token> parse(Set<File> files) throws ParsingException {
+    public List<Token> parse(List<File> files) throws ParsingException {
         ensureJavacIsAvailable();
         tokens = new ArrayList<>();
         new JavacAdapter().parseFiles(files, this);

--- a/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinLanguage.java
+++ b/languages/kotlin/src/main/java/de/jplag/kotlin/KotlinLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.kotlin;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class KotlinLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new KotlinParserAdapter().parse(files);
     }
 }

--- a/languages/llvmir/src/main/java/de/jplag/llvmir/LLVMIRLanguage.java
+++ b/languages/llvmir/src/main/java/de/jplag/llvmir/LLVMIRLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.llvmir;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class LLVMIRLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new LLVMIRParserAdapter().parse(files);
 
     }

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguage.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.multilang;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +55,7 @@ public class MultiLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         this.printWarning();
         MultiLanguageParser parser = new MultiLanguageParser(this.options);
         return parser.parseFiles(files, normalize);

--- a/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageParser.java
+++ b/languages/multi-language/src/main/java/de/jplag/multilang/MultiLanguageParser.java
@@ -2,12 +2,14 @@ package de.jplag.multilang;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -40,12 +42,12 @@ public class MultiLanguageParser {
      * @return a list of parsed tokens
      * @throws ParsingException if parsing fails
      */
-    public List<Token> parseFiles(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parseFiles(@MonotonicNonNull Collection<File> files, boolean normalize) throws ParsingException {
         List<Token> results = new ArrayList<>();
         for (File file : files) {
             Optional<Language> language = findLanguageForFile(file);
             if (language.isPresent()) {
-                results.addAll(language.get().parse(Set.of(file), normalize));
+                results.addAll(language.get().parse(List.of(file), normalize));
             }
         }
         return results;

--- a/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
+++ b/languages/multi-language/src/test/java/de/java/multilang/MultilangTest.java
@@ -7,8 +7,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -28,8 +26,8 @@ class MultilangTest {
     private static File javaCode;
     private static File cppCode;
 
-    private static final List<TokenType> expectedTokens = List.of(CPPTokenType.FUNCTION_BEGIN, CPPTokenType.RETURN, CPPTokenType.FUNCTION_END,
-            FILE_END, JavaTokenType.J_CLASS_BEGIN, JavaTokenType.J_CLASS_END, FILE_END);
+    private static final List<TokenType> expectedTokens = List.of(JavaTokenType.J_CLASS_BEGIN, JavaTokenType.J_CLASS_END, FILE_END,
+            CPPTokenType.FUNCTION_BEGIN, CPPTokenType.RETURN, CPPTokenType.FUNCTION_END, FILE_END);
 
     @BeforeAll
     static void setUp() throws IOException {
@@ -47,7 +45,7 @@ class MultilangTest {
 
         ((MultiLanguageOptions) languageModule.getOptions()).getLanguageNames().setValue("java,cpp");
 
-        Set<File> sources = new TreeSet<>(List.of(javaCode, cppCode)); // Using TreeSet to ensure order of entries
+        List<File> sources = List.of(javaCode, cppCode); // Using TreeSet to ensure order of entries
         List<Token> tokens = languageModule.parse(sources, false);
 
         Assertions.assertEquals(expectedTokens, tokens.stream().map(Token::getType).toList());
@@ -59,7 +57,7 @@ class MultilangTest {
         ((MultiLanguageOptions) languageModule.getOptions()).getLanguageNames().setValue("thisIsNotALanguage");
 
         Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> {
-            languageModule.parse(Set.of(javaCode, cppCode), false);
+            languageModule.parse(List.of(javaCode, cppCode), false);
         });
     }
 

--- a/languages/python-3/src/main/java/de/jplag/python3/PythonLanguage.java
+++ b/languages/python-3/src/main/java/de/jplag/python3/PythonLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.python3;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class PythonLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new PythonParserAdapter().parse(files);
     }
 }

--- a/languages/rlang/src/main/java/de/jplag/rlang/RLanguage.java
+++ b/languages/rlang/src/main/java/de/jplag/rlang/RLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.rlang;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class RLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new RParserAdapter().parse(files);
     }
 }

--- a/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
+++ b/languages/rlang/src/test/java/de/jplag/rlang/RLanguageTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -49,7 +48,7 @@ class RLanguageTest {
     @Test
     void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
+            List<Token> tokens = language.parse(List.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinterUtils.printTokensByFile(tokens);
             logger.info(output);
 

--- a/languages/rust/src/main/java/de/jplag/rust/RustLanguage.java
+++ b/languages/rust/src/main/java/de/jplag/rust/RustLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.rust;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class RustLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new RustParserAdapter().parse(files);
     }
 }

--- a/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
+++ b/languages/rust/src/test/java/de/jplag/rust/RustLanguageTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -57,7 +56,7 @@ class RustLanguageTest {
     @Test
     void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
+            List<Token> tokens = language.parse(List.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinterUtils.printTokensByFile(tokens);
             logger.info(output);
 

--- a/languages/scala/src/main/java/de/jplag/scala/ScalaLanguage.java
+++ b/languages/scala/src/main/java/de/jplag/scala/ScalaLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.scala;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -36,7 +35,7 @@ public class ScalaLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new ScalaParser().parse(files);
     }
 }

--- a/languages/scala/src/main/java/de/jplag/scala/ScalaParser.java
+++ b/languages/scala/src/main/java/de/jplag/scala/ScalaParser.java
@@ -69,8 +69,11 @@ import static de.jplag.scala.ScalaTokenType.YIELD;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import de.jplag.ParsingException;
 import de.jplag.Token;
@@ -406,7 +409,7 @@ public class ScalaParser {
      * @return The list of tokens
      * @throws ParsingException If the parsing fails
      */
-    public List<Token> parse(Set<File> files) throws ParsingException {
+    public List<Token> parse(@MonotonicNonNull Collection<File> files) throws ParsingException {
         this.tokens = new ArrayList<>();
         for (File file : files) {
             parseFile(file);

--- a/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
@@ -23,7 +23,7 @@ public class Parser {
 
     /**
      * Parses a set of scheme files.
-     * @param files is the set of files.
+     * @param files is the list of files.
      * @return the token sequence.
      * @throws ParsingException if parsing fails.
      */

--- a/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/Parser.java
@@ -3,7 +3,6 @@ package de.jplag.scheme;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +27,7 @@ public class Parser {
      * @return the token sequence.
      * @throws ParsingException if parsing fails.
      */
-    public List<Token> parse(Set<File> files) throws ParsingException {
+    public List<Token> parse(List<File> files) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
             currentFile = file;

--- a/languages/scheme/src/main/java/de/jplag/scheme/SchemeLanguage.java
+++ b/languages/scheme/src/main/java/de/jplag/scheme/SchemeLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.scheme;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class SchemeLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new Parser().parse(files);
     }
 }

--- a/languages/scxml/src/main/java/de/jplag/scxml/ScxmlLanguage.java
+++ b/languages/scxml/src/main/java/de/jplag/scxml/ScxmlLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.scxml;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -41,7 +40,7 @@ public class ScxmlLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new ScxmlParserAdapter().parse(files);
     }
 

--- a/languages/scxml/src/main/java/de/jplag/scxml/parser/ScxmlParserAdapter.java
+++ b/languages/scxml/src/main/java/de/jplag/scxml/parser/ScxmlParserAdapter.java
@@ -47,8 +47,8 @@ public class ScxmlParserAdapter {
     }
 
     /**
-     * Extracts all tokens from a set of files.
-     * @param files the set of files
+     * Extracts all tokens from a list of files.
+     * @param files the list of files
      * @return the list of parsed tokens
      * @throws ParsingException if the statechart could not be parsed
      */

--- a/languages/scxml/src/main/java/de/jplag/scxml/parser/ScxmlParserAdapter.java
+++ b/languages/scxml/src/main/java/de/jplag/scxml/parser/ScxmlParserAdapter.java
@@ -3,7 +3,6 @@ package de.jplag.scxml.parser;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -53,7 +52,7 @@ public class ScxmlParserAdapter {
      * @return the list of parsed tokens
      * @throws ParsingException if the statechart could not be parsed
      */
-    public List<Token> parse(Set<File> files) throws ParsingException {
+    public List<Token> parse(List<File> files) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
             parseStatechartFile(file);

--- a/languages/scxml/src/test/java/de/jplag/scxml/ScxmlTokenGeneratorTest.java
+++ b/languages/scxml/src/test/java/de/jplag/scxml/ScxmlTokenGeneratorTest.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -63,7 +62,7 @@ class ScxmlTokenGeneratorTest {
     private final File baseDirectory = BASE_PATH.toFile();
 
     private List<TokenType> getTokenTypes(ScxmlParserAdapter adapter, File testFile) throws ParsingException {
-        return adapter.parse(Set.of(testFile)).stream().map(Token::getType).toList();
+        return adapter.parse(List.of(testFile)).stream().map(Token::getType).toList();
     }
 
     @Test
@@ -101,7 +100,7 @@ class ScxmlTokenGeneratorTest {
     void testViewFile() throws ParsingException, IOException {
         File testFile = new File(baseDirectory, TestSubjects.COMPLEX.fileName);
         ScxmlParserAdapter adapter = new ScxmlParserAdapter();
-        adapter.parse(Set.of(testFile));
+        adapter.parse(List.of(testFile));
 
         File viewFile = new File(testFile.getPath() + ScxmlLanguage.VIEW_FILE_EXTENSION);
         File expectedViewFile = new File(baseDirectory, TestSubjects.COMPLEX_VIEW_FILE.fileName);

--- a/languages/swift/src/main/java/de/jplag/swift/SwiftLanguage.java
+++ b/languages/swift/src/main/java/de/jplag/swift/SwiftLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.swift;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -37,7 +36,7 @@ public class SwiftLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new SwiftParserAdapter().parse(files);
     }
 }

--- a/languages/swift/src/test/java/de/jplag/swift/SwiftFrontendTest.java
+++ b/languages/swift/src/test/java/de/jplag/swift/SwiftFrontendTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -64,7 +63,7 @@ class SwiftFrontendTest {
     @Test
     void parseTestFiles() throws ParsingException {
         for (String fileName : testFiles) {
-            List<Token> tokens = language.parse(Set.of(new File(testFileLocation, fileName)), false);
+            List<Token> tokens = language.parse(List.of(new File(testFileLocation, fileName)), false);
             String output = TokenPrinterUtils.printTokensByFile(tokens);
             logger.info(output);
 

--- a/languages/text/src/main/java/de/jplag/text/NaturalLanguage.java
+++ b/languages/text/src/main/java/de/jplag/text/NaturalLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.text;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -39,7 +38,7 @@ public class NaturalLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new ParserAdapter().parse(files);
     }
 

--- a/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
+++ b/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
@@ -47,7 +47,7 @@ public class ParserAdapter {
     }
 
     /**
-     * Parses a set of files.
+     * Parses a list of files.
      * @param files are the files to parse.
      * @return the token sequence.
      * @throws ParsingException is parsing fails.

--- a/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
+++ b/languages/text/src/main/java/de/jplag/text/ParserAdapter.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +52,7 @@ public class ParserAdapter {
      * @return the token sequence.
      * @throws ParsingException is parsing fails.
      */
-    public List<Token> parse(Set<File> files) throws ParsingException {
+    public List<Token> parse(List<File> files) throws ParsingException {
         tokens = new ArrayList<>();
         for (File file : files) {
             logger.trace("Parsing file {}", file);

--- a/languages/text/src/test/java/jplag/text/NaturalLanguageTest.java
+++ b/languages/text/src/test/java/jplag/text/NaturalLanguageTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +42,7 @@ class NaturalLanguageTest {
     @Test
     void testParsingJavaDoc() throws ParsingException {
         // Parse test input
-        List<Token> result = language.parse(Set.of(new File(BASE_PATH.toFile(), TEST_SUBJECT)), false);
+        List<Token> result = language.parse(List.of(new File(BASE_PATH.toFile(), TEST_SUBJECT)), false);
         logger.info(TokenPrinterUtils.printTokensByFile(result));
 
         List<TokenType> tokenTypes = result.stream().map(Token::getType).toList();
@@ -56,7 +55,7 @@ class NaturalLanguageTest {
     void testLineBreakInputs(String input) throws IOException, ParsingException {
         File testFile = File.createTempFile("input", "txt");
         Files.writeString(testFile.toPath(), input);
-        List<Token> result = language.parse(Set.of(testFile), false);
+        List<Token> result = language.parse(List.of(testFile), false);
         assertEquals(1, result.size());
     }
 
@@ -65,8 +64,8 @@ class NaturalLanguageTest {
     void testTokenAfterLineBreak(String input) throws IOException, ParsingException {
         File testFile = File.createTempFile("input", "txt");
         Files.writeString(testFile.toPath(), input);
-        List<Token> result = language.parse(Set.of(testFile), false);
-        assertEquals(2, result.get(0).getStartLine());
+        List<Token> result = language.parse(List.of(testFile), false);
+        assertEquals(2, result.getFirst().getStartLine());
     }
 
 }

--- a/languages/typescript/src/main/java/de/jplag/typescript/TypeScriptLanguage.java
+++ b/languages/typescript/src/main/java/de/jplag/typescript/TypeScriptLanguage.java
@@ -2,7 +2,6 @@ package de.jplag.typescript;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import de.jplag.Language;
 import de.jplag.ParsingException;
@@ -44,7 +43,7 @@ public class TypeScriptLanguage implements Language {
     }
 
     @Override
-    public List<Token> parse(Set<File> files, boolean normalize) throws ParsingException {
+    public List<Token> parse(List<File> files, boolean normalize) throws ParsingException {
         return new TypeScriptParserAdapter(options.useStrictDefault()).parse(files);
     }
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "devDependencies": {
         "bibtex": "^0.9.0",
-        "vitepress": "^1.6.3"
+        "vitepress": "^1.6.4"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -147,6 +147,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.27.0.tgz",
       "integrity": "sha512-EJJ7WmvmUXZdchueKFCK8UZFyLqy4Hz64snNp0cTc7c0MKaSeDGYEDxVsIJKp15r7ORaoGxSyS4y6BGZMXYuCg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.27.0",
         "@algolia/requester-browser-xhr": "5.27.0",
@@ -1377,6 +1378,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.27.0.tgz",
       "integrity": "sha512-2PvAgvxxJzA3+dB+ERfS2JPdvUsxNf89Cc2GF5iCcFupTULOwmbfinvqrC4Qj9nHJJDNf494NqEN/1f9177ZTQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.27.0",
         "@algolia/client-analytics": "5.27.0",
@@ -1561,6 +1563,7 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
       "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -2132,6 +2135,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2187,10 +2191,11 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.3.tgz",
-      "integrity": "sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@docsearch/css": "3.8.2",
         "@docsearch/js": "3.8.2",
@@ -2232,6 +2237,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.16.tgz",
       "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.16",
         "@vue/compiler-sfc": "3.5.16",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-3.0",
       "devDependencies": {
         "bibtex": "^0.9.0",
-        "vitepress": "^1.6.4"
+        "vitepress": "^1.6.3"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -147,7 +147,6 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.27.0.tgz",
       "integrity": "sha512-EJJ7WmvmUXZdchueKFCK8UZFyLqy4Hz64snNp0cTc7c0MKaSeDGYEDxVsIJKp15r7ORaoGxSyS4y6BGZMXYuCg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.27.0",
         "@algolia/requester-browser-xhr": "5.27.0",
@@ -1378,7 +1377,6 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.27.0.tgz",
       "integrity": "sha512-2PvAgvxxJzA3+dB+ERfS2JPdvUsxNf89Cc2GF5iCcFupTULOwmbfinvqrC4Qj9nHJJDNf494NqEN/1f9177ZTQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.27.0",
         "@algolia/client-analytics": "5.27.0",
@@ -1563,7 +1561,6 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.5.tgz",
       "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -2135,7 +2132,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -2191,11 +2187,10 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
-      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.3.tgz",
+      "integrity": "sha512-fCkfdOk8yRZT8GD9BFqusW3+GggWYZ/rYncOfmgcDtP3ualNHCAg+Robxp2/6xfH1WwPHtGpPwv7mbA3qomtBw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@docsearch/css": "3.8.2",
         "@docsearch/js": "3.8.2",
@@ -2237,7 +2232,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.16.tgz",
       "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.16",
         "@vue/compiler-sfc": "3.5.16",

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,6 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "bibtex": "^0.9.0",
-    "vitepress": "^1.6.3"
+    "vitepress": "^1.6.4"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,6 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "bibtex": "^0.9.0",
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.3"
   }
 }


### PR DESCRIPTION
This PR changes the `Language` API to parse `List`s of `File`s instead of `Set`s. This fixes the current behavior where a submission's token sequence changes depending on the submission set; this, in turn, led to inconsistent behavior while matching submissions.

Closes #3001.