### PR TITLE
Harden GitHub Actions: pin by commit SHA and declare workflow permissions

### DIFF
--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -26,7 +26,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -37,15 +37,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: 25
         distribution: 'temurin'
 
-    - uses: actions/setup-node@v7
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: "lts/*"
 
@@ -56,7 +56,7 @@ jobs:
       run: mvn -Pwith-report-viewer clean package assembly:single
 
     - name: Upload Assembly
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "JPlag Jar"
         path: "cli/target/jplag-*-jar-with-dependencies.jar"

--- a/.github/workflows/build-maven.yml
+++ b/.github/workflows/build-maven.yml
@@ -19,8 +19,16 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/check-sonarcloud-main-develop.yml
+++ b/.github/workflows/check-sonarcloud-main-develop.yml
@@ -21,23 +21,23 @@ jobs:
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: 25
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/check-sonarcloud-main-develop.yml
+++ b/.github/workflows/check-sonarcloud-main-develop.yml
@@ -14,6 +14,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sonar:
     name: SonarCloud Scan

--- a/.github/workflows/check-sonarcloud-pr.yml
+++ b/.github/workflows/check-sonarcloud-pr.yml
@@ -12,6 +12,12 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# This workflow checks out fork-controlled code under workflow_run,
+# so the token is restricted to reads.
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   get-info:
     name: "Get information about the source run"

--- a/.github/workflows/check-sonarcloud-pr.yml
+++ b/.github/workflows/check-sonarcloud-pr.yml
@@ -29,7 +29,7 @@ jobs:
       sourceEvent: ${{ steps.source-run-info.outputs.sourceEvent }}
     steps:
       - name: "Get information about the origin 'CI' run"
-        uses: potiuk/get-workflow-origin@v1_3
+        uses: potiuk/get-workflow-origin@588cc14f9f1cdf1b8be3db816855e96422204fec # v1_3
         id: source-run-info
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -42,25 +42,25 @@ jobs:
     needs: get-info
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: 25
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/check-spotless.yml
+++ b/.github/workflows/check-spotless.yml
@@ -18,8 +18,16 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/check-spotless.yml
+++ b/.github/workflows/check-spotless.yml
@@ -25,7 +25,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: 25
         distribution: 'temurin'

--- a/.github/workflows/close-issue-after-merge.yml
+++ b/.github/workflows/close-issue-after-merge.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   close_issues:
     if: github.event.pull_request.merged == true && github.base_ref == 'develop'

--- a/.github/workflows/close-issue-after-merge.yml
+++ b/.github/workflows/close-issue-after-merge.yml
@@ -12,7 +12,7 @@ jobs:
     
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
     - name: Run script
       working-directory: .github/workflows/scripts

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/deploy-docs.yml'
   workflow_dispatch:
 
+# The last step commits the regenerated docs back.
+permissions:
+  contents: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -14,10 +14,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.SDQ_DEV_DEPLOY_TOKEN }}
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki
@@ -31,6 +31,6 @@ jobs:
         run: cp -r ./docs/. ./wiki
 
       - name: Deploy 🚀
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           repository: wiki

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -7,17 +7,17 @@ jobs:
   publish-maven-central:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Set maven settings.xml
-        uses: whelk-io/maven-settings-xml-action@v22
+        uses: whelk-io/maven-settings-xml-action@9dc09b23833fa9aa7f27b63db287951856f3433d # v22
         with:
           servers: '[{ "id": "central", "username": "${{ secrets.CENTRAL_USER }}", "password": "${{ secrets.CENTRAL_TOKEN }}" }]'
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_KEY }}
       - name: Publish package
@@ -26,12 +26,12 @@ jobs:
   publish-release-artifact:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: '25'
           distribution: 'temurin'
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
@@ -52,7 +52,7 @@ jobs:
         run: mvn -Pwith-report-viewer -U -B clean package assembly:single
 
       - name: Attach CLI to Release on GitHub
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: cli/target/jplag-*-jar-with-dependencies.jar

--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   release:
     types: [created, published]
+permissions:
+  contents: read
+
 jobs:
   publish-maven-central:
     runs-on: ubuntu-latest
@@ -24,6 +27,9 @@ jobs:
         run: mvn -P deployment -U -B deploy
 
   publish-release-artifact:
+    # softprops/action-gh-release uploads the artifact to the release.
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/report-viewer-build.yml
+++ b/.github/workflows/report-viewer-build.yml
@@ -15,7 +15,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/report-viewer-build.yml
+++ b/.github/workflows/report-viewer-build.yml
@@ -8,8 +8,16 @@ on:
       - ".github/workflows/report-viewer-build.yml"
       - "report-viewer/**"
       
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/report-viewer-check-lint.yml
+++ b/.github/workflows/report-viewer-check-lint.yml
@@ -13,8 +13,16 @@ on:
       - ".github/workflows/report-viewer-lint.yml"
       - "report-viewer/**"
       
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/report-viewer-check-lint.yml
+++ b/.github/workflows/report-viewer-check-lint.yml
@@ -20,7 +20,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/report-viewer-check-prettier.yml
+++ b/.github/workflows/report-viewer-check-prettier.yml
@@ -13,8 +13,16 @@ on:
       - "report-viewer/**"
 
       
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/report-viewer-check-prettier.yml
+++ b/.github/workflows/report-viewer-check-prettier.yml
@@ -20,7 +20,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/report-viewer-deploy-demo.yml
+++ b/.github/workflows/report-viewer-deploy-demo.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 25
           distribution: 'temurin'
@@ -24,7 +24,7 @@ jobs:
         run: mvn clean package assembly:single
 
       - name: Upload Assembly
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "JPlag"
           path: "cli/target/jplag-*-jar-with-dependencies.jar"
@@ -36,16 +36,16 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Get JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: JPlag
 
@@ -59,7 +59,7 @@ jobs:
         run: java -jar jplag.jar ACCEPTED -bc base -r example
 
       - name: Upload Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "Result"
           path: "example.jplag"
@@ -70,11 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
@@ -92,7 +92,7 @@ jobs:
           cat report-viewer/report-viewer/src/version/version.json
 
       - name: Download Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Result
           path: report-viewer/report-viewer/public
@@ -104,7 +104,7 @@ jobs:
           npm run build-demo
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: report-viewer/report-viewer/dist

--- a/.github/workflows/report-viewer-deploy-demo.yml
+++ b/.github/workflows/report-viewer-deploy-demo.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-jar:
     runs-on: ubuntu-latest
@@ -66,6 +69,9 @@ jobs:
 
 
   build-and-deploy:
+    # The pages deploy pushes to a branch.
+    permissions:
+      contents: write
     needs: run-example
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/report-viewer-deploy-dev-demo.yml
+++ b/.github/workflows/report-viewer-deploy-dev-demo.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - develop
       
+permissions:
+  contents: read
+
 jobs:
   build-jar:
     runs-on: ubuntu-latest
@@ -66,6 +69,9 @@ jobs:
             
 
   build-and-deploy:
+    # The pages deploy pushes to a branch.
+    permissions:
+      contents: write
     needs: run-example
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/report-viewer-deploy-dev-demo.yml
+++ b/.github/workflows/report-viewer-deploy-dev-demo.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 25
           distribution: 'temurin'
@@ -24,7 +24,7 @@ jobs:
         run: mvn clean package assembly:single
         
       - name: Upload Assembly
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "JPlag"
           path: "cli/target/jplag-*-jar-with-dependencies.jar"
@@ -36,16 +36,16 @@ jobs:
 
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 25
           distribution: 'temurin'
       
       - name: Get JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: JPlag
       
@@ -59,7 +59,7 @@ jobs:
         run: java -jar jplag.jar ACCEPTED -bc base -r example
       
       - name: Upload Result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "Result"
           path: "example.jplag"
@@ -70,16 +70,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
               
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
       
       - name: Download Results
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Result
           path: report-viewer/report-viewer/public
@@ -91,7 +91,7 @@ jobs:
           npm run build-dev-demo
         
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: report-viewer/report-viewer/dist

--- a/.github/workflows/report-viewer-deploy-develop.yml
+++ b/.github/workflows/report-viewer-deploy-develop.yml
@@ -9,6 +9,10 @@ on:
       - ".github/workflows/report-viewer-deploy-develop.yml"
       - "report-viewer/**"
       
+# The pages deploy pushes to a branch.
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/report-viewer-deploy-develop.yml
+++ b/.github/workflows/report-viewer-deploy-develop.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
@@ -29,7 +29,7 @@ jobs:
           npm run build-dev
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: report-viewer/report-viewer/dist

--- a/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
@@ -15,8 +15,16 @@ on:
       - "report-viewer/**"
       - ".github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml"
 
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
+++ b/.github/workflows/report-viewer-test-unit-and-check-sonarcloud.yml
@@ -22,7 +22,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -33,9 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
@@ -62,7 +62,7 @@ jobs:
       
       - name: SonarCloud Scan
         if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.owner.login == 'jplag' }}
-        uses: SonarSource/sonarqube-scan-action@v8.2.1
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
           projectBaseDir: report-viewer
         env:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -12,8 +12,16 @@ on:
       - "**.java"
       - "**.g4"
 
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -19,7 +19,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -30,15 +30,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 25
           distribution: 'temurin'
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
@@ -49,7 +49,7 @@ jobs:
         run: mv cli/target/jplag-*-jar-with-dependencies.jar cli/target/jplag.jar
 
       - name: Upload Assembly
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "JPlag"
           path: "cli/target/jplag.jar"
@@ -84,16 +84,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Get JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: JPlag
 
@@ -112,7 +112,7 @@ jobs:
           java -jar jplag.jar ${{ matrix.dataset.folder }} -r ${{ matrix.dataset.name }}-report ${{ matrix.dataset.cliArgs }}
 
       - name: Upload result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "${{ matrix.dataset.name }}-${{ matrix.os }}"
           path: "${{ matrix.dataset.name }}-report.jplag"
@@ -128,9 +128,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
 
@@ -145,7 +145,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Download JPlag Reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: "*-${{ matrix.os }}"
           path: "report-viewer/report-viewer/tests/e2e/assets"
@@ -157,7 +157,7 @@ jobs:
           npm run test:e2e
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: "test-results-${{ matrix.os }}"

--- a/.github/workflows/verify-coverage-report.yml
+++ b/.github/workflows/verify-coverage-report.yml
@@ -14,6 +14,9 @@ on:
       - "./scripts/checkCoverage.py"
       - "**/pom.xml"
 
+permissions:
+  contents: read
+
 jobs:
   check_coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-coverage-report.yml
+++ b/.github/workflows/verify-coverage-report.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
     - name: Run script
       working-directory: .github/workflows/scripts

--- a/.github/workflows/verify-help-text.yml
+++ b/.github/workflows/verify-help-text.yml
@@ -16,8 +16,16 @@ on:
       - "**.md"
       - "**.java"
 
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}

--- a/.github/workflows/verify-help-text.yml
+++ b/.github/workflows/verify-help-text.yml
@@ -23,7 +23,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -35,10 +35,10 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: 25
         distribution: 'temurin'

--- a/.github/workflows/verify-report-schema.yml
+++ b/.github/workflows/verify-report-schema.yml
@@ -17,7 +17,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
+        uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
         with:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
@@ -29,7 +29,7 @@ jobs:
     
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       
     - name: Run script
       working-directory: .github/workflows/scripts

--- a/.github/workflows/verify-report-schema.yml
+++ b/.github/workflows/verify-report-schema.yml
@@ -10,8 +10,16 @@ on:
       - "report-viewer/**"
       - "**.java"
 
+permissions:
+  contents: read
+
 jobs:
   pre_job:
+    # skip-duplicate-actions documents actions:write + contents:read
+    # as its minimum.
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}


### PR DESCRIPTION
Hi, drive-by CI hardening in two commits, one logical change each. Targeting develop per your PR guidelines since this is not a patch release change.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v5` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. The exposed spots here are `publish-on-release.yml` (Maven Central deploy with your GPG signing key and Sonatype credentials) and the pages deploy workflows. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). Dependabot keeps opening its bump PRs exactly as before, it understands sha pins with a version comment.

Two of the pinned actions have archived upstream repos (`potiuk/get-workflow-origin`, `whelk-io/maven-settings-xml-action`), so no security fixes are coming for them. Pinning contains the risk for now, replacing them at some point would be better still, that call is yours.

**Commit 2 adds `permissions:` blocks to the workflows that had none** (35 jobs). Without one, the GITHUB_TOKEN inherits the repository default scope. Each scope was derived from what the workflow actually does with the token, not guessed:

- The nine check/test workflows using skip-duplicate-actions get `contents: read`, with `actions: write` on the pre_job only, which is the minimum that action documents.
- The pages deploys and deploy-docs get `contents: write` on the job that pushes.
- `publish-on-release.yml`: `contents: write` only on the release-artifact job, the Maven Central job deploys through Sonatype and GPG secrets and keeps read.
- `close-issue-after-merge.yml` gets `issues: write`.
- `check-sonarcloud-pr.yml` checks out fork PR code under workflow_run; its token is now restricted to reads, which also limits what that code could do with it.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v5`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

All shas were resolved from the upstream repos and cross checked against their release tags. No workflow logic changes.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on develop. I will also open a PR which adds it to CI so none of this quietly drifts back, that one is a bonus, this PR stands on its own.