### PR TITLE
Add Plumber to watch workflow security

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,34 @@
+name: Plumber
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: getplumber/plumber@7ad9d267ee5a00163cec9e5c749a088d5f565167 # v0.4.26
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,38 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: "2.0"
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the actions this repo
+      # already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - fkirc/skip-duplicate-actions
+        - JamesIves/github-pages-deploy-action
+        - stefanzweifel/git-auto-commit-action
+        - softprops/action-gh-release
+        - crazy-max/ghaction-import-gpg
+        - whelk-io/maven-settings-xml-action
+        - potiuk/get-workflow-origin
+
+    # Off in CI: reading branch protection settings needs an admin-read
+    # token, the default GITHUB_TOKEN cannot see them.
+    branchMustBeProtected:
+      enabled: false
+
+    # Off for now: get-workflow-origin and maven-settings-xml-action are
+    # archived upstream. They are pinned to commits in the meantime;
+    # enable this once they are replaced.
+    actionsMustNotBeArchived:
+      enabled: false
+
+    # Off for now: check-sonarcloud-pr analyzes fork PRs under
+    # workflow_run by design so Sonar can see the code. Its token is
+    # restricted to reads; moving that analysis to a safer pattern is a
+    # bigger change than this PR.
+    workflowMustNotUseDangerousTriggers:
+      enabled: false

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/y/jplag/JPlag)](https://github.com/jplag/JPlag/pulse)
 [![SonarCloud Coverage](https://sonarcloud.io/api/project_badges/measure?project=jplag_JPlag&metric=coverage)](https://sonarcloud.io/component_measures?metric=Coverage&view=list&id=jplag_JPlag)
 [![Java Version](https://img.shields.io/badge/java-SE%2025-yellowgreen)](#download-and-installation)
+[![Plumber Score](https://score.getplumber.io/github.com/jplag/JPlag.svg)](https://score.getplumber.io/github.com/jplag/JPlag)
 
 
 JPlag finds pairwise similarities among a set of multiple programs. It can reliably detect software plagiarism and collusion in software development, even when obfuscated. All similarities are calculated locally; no source code or plagiarism results are ever uploaded online. JPlag supports a large number of languages.


### PR DESCRIPTION
Companion to https://github.com/jplag/JPlag/pull/3084, merge that one first: the check added here flags the unpinned actions and the missing permissions blocks until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to develop and main and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, an archived dependency, a known CVE, that kind of thing.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the security tab as SARIF next to your Sonar results (skipped on PRs from forks, the report stays as an artifact there). It runs on the CLI's built-in defaults, no config file to review: the four controls this repo cannot satisfy yet are skipped through the action's `skip-controls` input, each with a comment in the workflow saying why (branch protection needs an admin token to read, the two archived actions are pinned until you replace them, the sources allowlist is worth configuring once config overrides ship, and check-sonarcloud-pr analyzes fork PRs under workflow_run by design with a read-only token since https://github.com/jplag/JPlag/pull/3084).
- `README.md`: one line, the score badge at the end of your badge row.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of the default branch. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, the hardening PR is the one that matters and it stands on its own.
