### PR TITLE
Adapted token position test format

### DIFF
--- a/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
+++ b/language-testutils/src/test/java/de/jplag/testutils/datacollector/TokenPositionTestData.java
@@ -78,7 +78,7 @@ public class TokenPositionTestData implements TestData {
 
         String typeName = tokenDescriptionParts[tokenDescriptionParts.length - 2];
         int length = Integer.parseInt(tokenDescriptionParts[tokenDescriptionParts.length - 1]);
-        this.expectedTokens.add(new TokenData(typeName, currentSourceLine, column, currentSourceLine, column + length));
+        this.expectedTokens.add(new TokenData(typeName, currentSourceLine, column, currentSourceLine, column + length - 1));
     }
 
     @Override

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/apply.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/apply.cpp
@@ -1,6 +1,6 @@
 > void main() {
 >     int x = calculateValue();
-$             | APPLY 13
+$             | APPLY 14
 > }
 >
 > int calculateValue() {

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/assign.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/assign.cpp
@@ -1,4 +1,4 @@
 > void main() {
 >     int x = 1;
-$         | ASSIGN 0
+$         | ASSIGN 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/braced_init.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/braced_init.cpp
@@ -1,5 +1,5 @@
 > void test() {
 >     Type variable = {1, 2, field=""};
-$                     | BRACED_INIT_BEGIN 0
-$                                    | BRACED_INIT_END 0
+$                     | BRACED_INIT_BEGIN 1
+$                                    | BRACED_INIT_END 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/break_loop.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/break_loop.cpp
@@ -1,6 +1,6 @@
 > void main() {
 >     while(true) {
 >         break;
-$         | BREAK 4
+$         | BREAK 5
 >     }
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/class.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/class.cpp
@@ -1,4 +1,4 @@
 > class Test {
-$ | CLASS_BEGIN 4
+$ | CLASS_BEGIN 5
 > };
-$ | CLASS_END 0
+$ | CLASS_END 1

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/class_inner.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/class_inner.cpp
@@ -1,6 +1,6 @@
 > struct Test {
 >     class InnerClass {
-$     | CLASS_BEGIN 4
+$     | CLASS_BEGIN 5
 >     };
-$     | CLASS_END 0
+$     | CLASS_END 1
 > };

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/continue_loop.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/continue_loop.cpp
@@ -1,6 +1,6 @@
 > void test() {
 >     while(true) {
 >         continue;
-$         | CONTINUE 7
+$         | CONTINUE 8
 >     }
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/do.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/do.cpp
@@ -1,6 +1,6 @@
 > void main() {
 >     do {
-$     | DO_BEGIN 1
+$     | DO_BEGIN 2
 >     } while(true)
-$                 | DO_END 0
+$                 | DO_END 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/enum.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/enum.cpp
@@ -1,4 +1,4 @@
 > enum TestEnum {
-$ | ENUM_BEGIN 3
+$ | ENUM_BEGIN 4
 > };
-$ | ENUM_END 0
+$ | ENUM_END 1

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/for.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/for.cpp
@@ -1,6 +1,6 @@
 > void main() {
 >     for(int i = 0; i < 10; i++) {
-$     | FOR_BEGIN 2
+$     | FOR_BEGIN 3
 >     }
-$     | FOR_END 0
+$     | FOR_END 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/function.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/function.cpp
@@ -1,5 +1,5 @@
 > int main() {
-$ | FUNCTION_BEGIN 2
+$ | FUNCTION_BEGIN 3
 >     return 1;
 > }
-$ | FUNCTION_END 0
+$ | FUNCTION_END 1

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/function_member.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/function_member.cpp
@@ -1,6 +1,6 @@
 > class Test {
 >     void memberFunction() {
-$     | FUNCTION_BEGIN 3
+$     | FUNCTION_BEGIN 4
 >     }
-$     | FUNCTION_END 0
+$     | FUNCTION_END 1
 > };

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/generic_class.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/generic_class.cpp
@@ -1,3 +1,3 @@
 > template <typename T> class Test {
-$ | GENERIC 7
+$ | GENERIC 8
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/generic_function.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/generic_function.cpp
@@ -1,4 +1,4 @@
 > template <typename T> T myMax(T x, T y){
-$ | GENERIC 7
+$ | GENERIC 8
 >     return (x > y) ? x : y;
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/goto.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/goto.cpp
@@ -1,5 +1,5 @@
 > void test() {
 > label:
 >     goto label;
-$     | GOTO 3
+$     | GOTO 4
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/if.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/if.cpp
@@ -1,6 +1,6 @@
 > void main() {
 >     if(true) {
-$     | IF_BEGIN 1
+$     | IF_BEGIN 2
 >     }
-$     | IF_END 0
+$     | IF_END 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/if_else.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/if_else.cpp
@@ -1,8 +1,8 @@
 > void main() {
 >     if (false) {
-$     | IF_BEGIN 1
+$     | IF_BEGIN 2
 >     } else {
-$       | ELSE 3
+$       | ELSE 4
 >     }
-$     | IF_END 0
+$     | IF_END 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/new.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/new.cpp
@@ -1,4 +1,4 @@
 > void test() {
 >     String test = new String();
-$                   | NEWCLASS 2
+$                   | NEWCLASS 3
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/new_array.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/new_array.cpp
@@ -1,4 +1,4 @@
 > void test() {
 >     int[] array = new int[10]
-$                   | NEWARRAY 2
+$                   | NEWARRAY 3
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/questionmark.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/questionmark.cpp
@@ -1,4 +1,4 @@
 > void main() {
 >     int x = false? 1: 2
-$             | QUESTIONMARK 4
+$             | QUESTIONMARK 5
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/return.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/return.cpp
@@ -1,4 +1,4 @@
 > int test() {
 >     return 1+1;
-$     | RETURN 5
+$     | RETURN 6
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/static_assert.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/static_assert.cpp
@@ -1,4 +1,4 @@
 > void main() {
 >     static_assert(size_of(*main) == 8, "Invalid Platform")
-$     | STATIC_ASSERT 12
+$     | STATIC_ASSERT 13
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/struct.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/struct.cpp
@@ -1,4 +1,4 @@
 > struct Test {
-$ | STRUCT_BEGIN 5
+$ | STRUCT_BEGIN 6
 > };
-$ | STRUCT_END 0
+$ | STRUCT_END 1

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/struct_inner.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/struct_inner.cpp
@@ -1,6 +1,6 @@
 > class Test {
 >     struct InnerStruct {
-$     | STRUCT_BEGIN 5
+$     | STRUCT_BEGIN 6
 >     };
-$     | STRUCT_END 0
+$     | STRUCT_END 1
 > };

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/switch.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/switch.cpp
@@ -1,16 +1,16 @@
 > void test(int param) {
 >     switch(param) {
-$     | SWITCH_BEGIN 5
+$     | SWITCH_BEGIN 6
 >         case 1:
-$         | CASE 3
+$         | CASE 4
 >             break;
-$             | BREAK 4
+$             | BREAK 5
 >         case 2:
-$         | CASE 3
+$         | CASE 4
 >             break;
 >         default:
-$         | DEFAULT 6
+$         | DEFAULT 7
 >             break;
 >     }
-$     | SWITCH_END 0
+$     | SWITCH_END 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/throw.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/throw.cpp
@@ -1,4 +1,4 @@
 > void test() {
 >     throw new Exception("Error");
-$     | THROW 4
+$     | THROW 5
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/try.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/try.cpp
@@ -1,9 +1,9 @@
 > void main() {
 >     try {
-$     | TRY_BEGIN 2
+$     | TRY_BEGIN 3
 >     } catch(Exception e) {
-$       | CATCH_BEGIN 4
+$       | CATCH_BEGIN 5
 >     }
-$     | CATCH_END 0
-$     | TRY_END 0
+$     | CATCH_END 1
+$     | TRY_END 1
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/union.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/union.cpp
@@ -1,4 +1,4 @@
 > union Test {
-$ | UNION_BEGIN 4
+$ | UNION_BEGIN 5
 > };
-$ | UNION_END 0
+$ | UNION_END 1

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/vardef.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/vardef.cpp
@@ -1,4 +1,4 @@
 > void main() {
 >     int x = 0;
-$     | VARDEF 2
+$     | VARDEF 3
 > }

--- a/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/while.cpp
+++ b/languages/cpp/src/test/resources/de/jplag/cpp/tokenPositions/while.cpp
@@ -1,6 +1,6 @@
 > void main() {
 >     while(true) {
-$     | WHILE_BEGIN 4
+$     | WHILE_BEGIN 5
 >     }
-$     | WHILE_END 0
+$     | WHILE_END 1
 > }

--- a/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
+++ b/languages/java/src/main/java/de/jplag/java/TokenGeneratingTreeScanner.java
@@ -98,7 +98,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
      * @param length is the length of the token.
      */
     private void addToken(JavaTokenType tokenType, long position, int length, CodeSemantics semantics) {
-        addToken(tokenType, position, position + length, semantics);
+        addToken(tokenType, position, position + length - 1, semantics);
     }
 
     /**
@@ -155,7 +155,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
             long nameLength = node.getSimpleName().length();
             // The start position for the is calculated that way, because the @ is the final element in the modifier list for
             // annotations
-            addToken(JavaTokenType.J_ANNO_T_BEGIN, start - 2, start - 2 + 11 + nameLength, semantics);
+            addToken(JavaTokenType.J_ANNO_T_BEGIN, start - 2, start - 2 + 11 + nameLength - 1, semantics);
         } else if (node.getKind() == Tree.Kind.CLASS) {
             addToken(JavaTokenType.J_CLASS_BEGIN, start, 5, semantics);
         }
@@ -408,7 +408,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     public Void visitNewClass(NewClassTree node, Void unused) {
         // NEWCLASS token should span the class name, not the arguments.
         long start = positions.getStartPosition(ast, node);
-        long end = positions.getEndPosition(ast, node.getIdentifier());
+        long end = positions.getEndPosition(ast, node.getIdentifier()) - 1;
         if (!node.getTypeArguments().isEmpty()) {
             addToken(JavaTokenType.J_GENERIC, start, 3 + node.getIdentifier().toString().length(), new CodeSemantics());
         }
@@ -432,7 +432,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     @Override
     public Void visitNewArray(NewArrayTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
-        long end = node.getType() == null ? start + 1 : positions.getEndPosition(ast, node.getType());
+        long end = node.getType() == null ? start + 1 : positions.getEndPosition(ast, node.getType()) - 1;
         addToken(JavaTokenType.J_NEWARRAY, start, end, new CodeSemantics());
         scan(node.getType(), null);
         scan(node.getDimensions(), null);
@@ -490,7 +490,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     public Void visitVariable(VariableTree node, Void unused) {
         if (!node.getName().contentEquals(ANONYMOUS_VARIABLE_NAME)) {
             long start = positions.getStartPosition(ast, node);
-            long end = positions.getEndPosition(ast, node);
+            long end = positions.getEndPosition(ast, node) - 1;
             if (Objects.isNull(node.getInitializer())) {
                 // VARDEF token should end before semicolon
                 end -= 1;
@@ -593,7 +593,7 @@ final class TokenGeneratingTreeScanner extends TreeScanner<Void, Void> {
     @Override
     public Void visitDefaultCaseLabel(DefaultCaseLabelTree node, Void unused) {
         long start = positions.getStartPosition(ast, node);
-        long end = positions.getEndPosition(ast, node);
+        long end = positions.getEndPosition(ast, node) - 1;
         addToken(JavaTokenType.J_DEFAULT, start, end, CodeSemantics.createControl());
         return super.visitDefaultCaseLabel(node, null);
     }


### PR DESCRIPTION
The token position tests now treat the start end the end of a token both as inclusive. This means that the length is calculated as (end - start + 1). To reflect this the java token end positions have been adapted and the tests for the cpp language module have been changed.

Since these changes only affect the token positions I don't think they should be considered breaking.

Fixes #2980