### PR TITLE
Implemented a simple test-tool for antlr langauge modules

### DIFF
--- a/cli/src/test/java/de/jplag/cli/antlrtesttool/AntlrLanguageDebugger.java
+++ b/cli/src/test/java/de/jplag/cli/antlrtesttool/AntlrLanguageDebugger.java
@@ -1,0 +1,22 @@
+package de.jplag.cli.antlrtesttool;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * Launches the AntlrLanguage used to manually debug antlr language modules.
+ */
+public class AntlrLanguageDebugger {
+    /**
+     * Launches the tester
+     * @throws IOException -
+     */
+    @Test
+    @Disabled
+    void test() throws IOException {
+        System.setProperty("awt.useSystemAAFontSettings","on");
+        new MainMenu();
+    }
+}

--- a/cli/src/test/java/de/jplag/cli/antlrtesttool/AntlrLanguageTester.java
+++ b/cli/src/test/java/de/jplag/cli/antlrtesttool/AntlrLanguageTester.java
@@ -1,0 +1,108 @@
+package de.jplag.cli.antlrtesttool;
+
+import de.jplag.antlr.AbstractAntlrParserAdapter;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTree;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultHighlighter;
+import javax.swing.text.Highlighter;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeSelectionModel;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * A graphical test tool for antlr languages
+ */
+public class AntlrLanguageTester extends JPanel {
+    private TestRunner runner;
+    private JTree output;
+    private Highlighter highlighter;
+
+    /**
+     * New instance
+     * @param adapter The adapter to test
+     * @throws RuntimeException -
+     */
+    public AntlrLanguageTester(AbstractAntlrParserAdapter<?> adapter) {
+        try {
+            this.runner = new TestRunner(adapter);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+
+        setLayout(new GridLayout(1, 2));
+
+        add(buildTestInput());
+        add(buildOutputPanel());
+    }
+
+    private JPanel buildTestInput() {
+        JPanel inputPanel = new JPanel();
+        inputPanel.setLayout(new BorderLayout());
+
+        JTextArea textInput = new JTextArea();
+        textInput.setTabSize(3);
+        inputPanel.add(textInput, BorderLayout.CENTER);
+
+        highlighter = new DefaultHighlighter();
+        textInput.setHighlighter(highlighter);
+
+        JPanel buttonsPanel = new JPanel();
+        buttonsPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
+        inputPanel.add(buttonsPanel, BorderLayout.NORTH);
+
+        JButton runButton = new JButton("Run");
+        runButton.addActionListener((event) -> {
+            runTest(textInput.getText());
+        });
+        buttonsPanel.add(runButton);
+
+        return inputPanel;
+    }
+
+    private JPanel buildOutputPanel() {
+        JPanel outputPanel = new JPanel();
+        outputPanel.setLayout(new BorderLayout());
+
+        output = new JTree();
+        output.setModel(new DefaultTreeModel(new DefaultMutableTreeNode("Nothing here yet")));
+        output.getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
+
+        output.addTreeSelectionListener((event) -> {
+            DefaultMutableTreeNode node = (DefaultMutableTreeNode) output.getLastSelectedPathComponent();
+            highlighter.removeAllHighlights();
+            if(node != null) {
+                TreeEntry data = (TreeEntry) node.getUserObject();
+                if (data.start() != -1 && data.end() != -1) {
+                    try {
+                        highlighter.addHighlight(data.start(), data.end(), new DefaultHighlighter.DefaultHighlightPainter(Color.CYAN));
+                    } catch (BadLocationException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        });
+
+        outputPanel.add(new JScrollPane(output), BorderLayout.CENTER);
+
+        return outputPanel;
+    }
+
+    private void runTest(String inputData) {
+        try {
+            output.setModel(new DefaultTreeModel(runner.runTest(inputData)));
+            output.revalidate();
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/cli/src/test/java/de/jplag/cli/antlrtesttool/MainMenu.java
+++ b/cli/src/test/java/de/jplag/cli/antlrtesttool/MainMenu.java
@@ -1,0 +1,75 @@
+package de.jplag.cli.antlrtesttool;
+
+import com.google.common.reflect.ClassPath;
+import de.jplag.antlr.AbstractAntlrParserAdapter;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * The main menu for the language tester
+ */
+public class MainMenu {
+    /**
+     * New instance. Automatically runs the tool and waits for the window to exit
+     * @throws IOException -
+     * @throws RuntimeException -
+     */
+    public MainMenu() throws IOException {
+        JFrame frame = new JFrame();
+
+        JPanel panel = new JPanel();
+        panel.setLayout(new GridLayout(100, 1));
+
+        panel.add(new JLabel("Choose your adapter"));
+        panel.add(new JLabel("  "));
+
+        ClassPath path = ClassPath.from(AntlrLanguageTester.class.getClassLoader());
+        path.getTopLevelClasses().stream().filter(it -> {
+            try {
+                return it.getName().startsWith("de.jplag") && AbstractAntlrParserAdapter.class.isAssignableFrom(it.load());
+            } catch (Throwable e) {
+                return false;
+            }
+        }).forEach(it -> {
+                    JButton button = new JButton(it.getSimpleName());
+                    button.addActionListener((event) -> {
+                        try {
+                            AbstractAntlrParserAdapter<?> instance = (AbstractAntlrParserAdapter<?>) it.load().getConstructor().newInstance();
+                            frame.setContentPane(new AntlrLanguageTester(instance));
+                            frame.revalidate();
+                        } catch (NoSuchMethodException | InstantiationException |
+                                 IllegalAccessException | InvocationTargetException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    panel.add(button);
+                }
+        );
+
+        JPanel wrapper = new JPanel();
+        wrapper.setLayout(new FlowLayout(FlowLayout.CENTER));
+
+        wrapper.add(panel);
+
+        frame.setContentPane(wrapper);
+
+        frame.pack();
+        frame.setVisible(true);
+        synchronized (frame) {
+            while (frame.isShowing()) {
+                try {
+                    frame.wait(1000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/cli/src/test/java/de/jplag/cli/antlrtesttool/TestRunner.java
+++ b/cli/src/test/java/de/jplag/cli/antlrtesttool/TestRunner.java
@@ -1,0 +1,171 @@
+package de.jplag.cli.antlrtesttool;
+
+import de.jplag.antlr.AbstractAntlrListener;
+import de.jplag.antlr.AbstractAntlrParserAdapter;
+import de.jplag.antlr.ContextVisitor;
+import de.jplag.antlr.HandlerData;
+import de.jplag.antlr.TerminalVisitor;
+import de.jplag.antlr.TokenCollector;
+import de.jplag.semantics.VariableRegistry;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.MutableTreeNode;
+import javax.swing.tree.TreeNode;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Runs the antlr grammar and identifies generated tokens
+ */
+public class TestRunner {
+    private Method createLexer;
+    private Method createParser;
+    private Method getContext;
+
+    private AbstractAntlrParserAdapter<?> adapter;
+    private AbstractAntlrListener listener;
+
+    private List<ContextVisitor<ParserRuleContext>> contextVisitors;
+    private List<TerminalVisitor> terminalVisitors;
+
+    /**
+     * New instance
+     * @param adapter The adapter to test
+     * @throws NoSuchMethodException -
+     * @throws InvocationTargetException -
+     * @throws IllegalAccessException -
+     * @throws NoSuchFieldException -
+     */
+    public TestRunner(AbstractAntlrParserAdapter<?> adapter) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, NoSuchFieldException {
+        createLexer = adapter.getClass().getDeclaredMethod("createLexer", CharStream.class);
+        createParser = adapter.getClass().getDeclaredMethod("createParser", CommonTokenStream.class);
+        getContext = adapter.getClass().getDeclaredMethod("getEntryContext", Parser.class);
+        Method getListener = adapter.getClass().getDeclaredMethod("getListener");
+
+
+        createLexer.setAccessible(true);
+        createParser.setAccessible(true);
+        getContext.setAccessible(true);
+        getListener.setAccessible(true);
+
+        this.adapter = adapter;
+        listener = (AbstractAntlrListener) getListener.invoke(adapter);
+
+        Field contextVisitorsField = AbstractAntlrListener.class.getDeclaredField("contextVisitors");
+        Field terminalVisitorsFiled = AbstractAntlrListener.class.getDeclaredField("terminalVisitors");
+
+        contextVisitorsField.setAccessible(true);
+        terminalVisitorsFiled.setAccessible(true);
+
+        contextVisitors = (List<ContextVisitor<ParserRuleContext>>) contextVisitorsField.get(listener);
+        terminalVisitors = (List<TerminalVisitor>) terminalVisitorsFiled.get(listener);
+    }
+
+    /**
+     * Runs the test on the given input
+     * @param input The source to parse
+     * @return The tree node to display
+     * @throws InvocationTargetException -
+     * @throws IllegalAccessException -
+     */
+    public TreeNode runTest(String input) throws InvocationTargetException, IllegalAccessException {
+        Lexer lexer = (Lexer) createLexer.invoke(adapter, CharStreams.fromString(input));
+        Parser parser = (Parser) createParser.invoke(adapter, new CommonTokenStream(lexer));
+        ParserRuleContext context = (ParserRuleContext) getContext.invoke(adapter, parser);
+
+        return buildForContext(context);
+    }
+
+    private MutableTreeNode buildForContext(ParserRuleContext context) {
+        TreeEntry entry;
+        String text = context.getClass().getSimpleName() + " " + getTokenGenerationInformation(context);
+        if(context.getStop() == null || context.getStop().getStartIndex() < context.getStart().getStartIndex()) {
+            entry = new TreeEntry(-1, -1, text);
+        } else {
+            entry = new TreeEntry(context.getStart().getStartIndex(), context.getStop().getStopIndex() + 1, text);
+        }
+
+        DefaultMutableTreeNode mutableTreeNode = new DefaultMutableTreeNode(entry);
+
+        for (int i = 0; i < context.getChildCount(); i++) {
+            ParseTree child = context.getChild(i);
+            if(child instanceof ParserRuleContext childContext) {
+                mutableTreeNode.add(buildForContext(childContext));
+            }
+
+            if(child instanceof TerminalNode terminal) {
+                String childText = terminal.getSymbol().getText() + " " + getTokenGenerationInformation(terminal);
+                DefaultMutableTreeNode childNode = new DefaultMutableTreeNode(new TreeEntry(terminal.getSymbol().getStartIndex(), terminal.getSymbol().getStopIndex() + 1, childText));
+                mutableTreeNode.add(childNode);
+            }
+        }
+        return mutableTreeNode;
+    }
+
+    private String getTokenGenerationInformation(ParserRuleContext context) {
+        AtomicInteger entryCount = new AtomicInteger();
+        AtomicInteger exitCount = new AtomicInteger();
+
+        String entry = contextVisitors.stream().filter(it -> it.matches(context)).flatMap(it -> {
+            TokenCollector collector = new TokenCollector(false);
+            HandlerData<ParserRuleContext> data = new HandlerData<>(context, new VariableRegistry(), collector);
+            it.enter(data);
+            entryCount.addAndGet(collector.getTokens().size());
+            return collector.getTokens().stream();
+        }).map(it -> "\"" + it.getType().getDescription() + "\"").collect(Collectors.joining(", ", "entry -> [", "]"));
+
+        String exit = contextVisitors.stream().filter(it -> it.matches(context)).flatMap(it -> {
+            TokenCollector collector = new TokenCollector(false);
+            HandlerData<ParserRuleContext> data = new HandlerData<>(context, new VariableRegistry(), collector);
+            it.exit(data);
+            exitCount.addAndGet(collector.getTokens().size());
+            return collector.getTokens().stream();
+        }).map(it -> "\"" + it.getType().getDescription() + "\"").collect(Collectors.joining(", ", "exit -> [", "]"));
+
+        if(entryCount.get() + exitCount.get() > 0) {
+            String result = "{";
+            if(entryCount.get() > 0) {
+                result += entry;
+            }
+            if(entryCount.get() > 0 && exitCount.get() > 0) {
+                result += "; ";
+            }
+            if(exitCount.get() > 0) {
+                result += exit;
+            }
+            return result + "}";
+        } else {
+            return "";
+        }
+    }
+
+    private String getTokenGenerationInformation(TerminalNode terminalNode) {
+        AtomicInteger count = new AtomicInteger();
+
+        String text = terminalVisitors.stream().filter(it -> it.matches(terminalNode)).flatMap(it -> {
+            TokenCollector collector = new TokenCollector(false);
+            HandlerData<TerminalNode> data = new HandlerData<>(terminalNode, new VariableRegistry(), collector);
+            it.enter(data);
+            count.addAndGet(collector.getTokens().size());
+            return collector.getTokens().stream();
+        }).map(it -> "\"" + it.getType().getDescription() + "\"").collect(Collectors.joining(", ", "visit -> [", "]"));
+
+        if(count.get() > 0) {
+            return text;
+        } else {
+            return "";
+        }
+    }
+}

--- a/cli/src/test/java/de/jplag/cli/antlrtesttool/TreeEntry.java
+++ b/cli/src/test/java/de/jplag/cli/antlrtesttool/TreeEntry.java
@@ -1,0 +1,14 @@
+package de.jplag.cli.antlrtesttool;
+
+/**
+ * Data for the output tree.
+ * @param start The start of the highlight matching this node
+ * @param end The end of the highlight matching this node
+ * @param text The text to display
+ */
+public record TreeEntry(int start, int end, String text) {
+    @Override
+    public String toString() {
+        return text;
+    }
+}

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractVisitor.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/AbstractVisitor.java
@@ -110,7 +110,7 @@ public abstract class AbstractVisitor<T> {
      * @param entity The entity to check.
      * @return Whether to visit the entity.
      */
-    boolean matches(T entity) {
+    public boolean matches(T entity) {
         return this.condition.test(entity);
     }
 
@@ -118,7 +118,7 @@ public abstract class AbstractVisitor<T> {
      * Enter a given entity, injecting the needed dependencies.
      * @param data is the data passed to the visitors.
      */
-    void enter(HandlerData<T> data) {
+    public void enter(HandlerData<T> data) {
         handleEnter(data, this::extractEnterToken, this::extractEnterToken);
     }
 

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/ContextVisitor.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/ContextVisitor.java
@@ -189,7 +189,7 @@ public class ContextVisitor<T extends ParserRuleContext> extends AbstractVisitor
      * Exit a given entity, injecting the needed dependencies.
      * @param data is the data of the original visitor
      */
-    void exit(HandlerData<T> data) {
+    public void exit(HandlerData<T> data) {
         if (this.delegate != null) {
             this.delegate.delegateExit(data);
             return;
@@ -200,7 +200,7 @@ public class ContextVisitor<T extends ParserRuleContext> extends AbstractVisitor
     }
 
     @Override
-    void enter(HandlerData<T> data) {
+    public void enter(HandlerData<T> data) {
         if (this.delegate != null) {
             this.delegate.delegateEnter(data);
             return;
@@ -219,7 +219,7 @@ public class ContextVisitor<T extends ParserRuleContext> extends AbstractVisitor
     }
 
     @Override
-    boolean matches(T entity) {
+    public boolean matches(T entity) {
         if (this.delegate != null && !this.delegate.isPresent(entity)) {
             return false;
         }

--- a/language-antlr-utils/src/main/java/de/jplag/antlr/TokenCollector.java
+++ b/language-antlr-utils/src/main/java/de/jplag/antlr/TokenCollector.java
@@ -28,7 +28,7 @@ public class TokenCollector {
     /**
      * @param extractsSemantics If semantics are extracted
      */
-    TokenCollector(boolean extractsSemantics) {
+    public TokenCollector(boolean extractsSemantics) {
         this.collected = new ArrayList<>();
         this.extractsSemantics = extractsSemantics;
     }
@@ -36,7 +36,7 @@ public class TokenCollector {
     /**
      * @return All collected tokens
      */
-    List<Token> getTokens() {
+    public List<Token> getTokens() {
         return Collections.unmodifiableList(this.collected);
     }
 

--- a/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
+++ b/languages/kotlin/src/test/java/de/jplag/kotlin/KotlinLanguageTest.java
@@ -33,4 +33,7 @@ public class KotlinLanguageTest extends LanguageModuleTest {
     protected void configureIgnoredLines(TestSourceIgnoredLinesCollector collector) {
         collector.ignoreMultipleLines("/*", "*/");
     }
+
+    void test() {
+    }
 }


### PR DESCRIPTION
Contains a simple tool to debug antlr language modules. It is implemented as a unit test, so it can be launched straight from the ide. Opens a simple window to let you chose the language module you want and accepts some source code. It displays the antlr parse tree (with highlighting in the source code) and shows what nodes would have lead to tokens being created.

Unlike regular IDE plugins that let you debug a grammar, this also executed the Java-code associated with the grammars, which is necessary for some grammars to behave as intended.

The source code is mostly ad-hoc code and there is basically no error handling. It also uses a lot of reflections and even class-path scanning. While I don't consider this good practice for regular JPlag code, I think for this purpose it's fine, as this is mostly a tool intended to help debug the antlr grammars.

@jplag/maintainer If you think I should improve the code-style or you would prefer not having this included in the repository, that's fine. But I think this might be a useful tool to have around.

This is how the tool looks:

<img width="303" height="431" alt="20260827_00h10m49s_grim" src="https://github.com/user-attachments/assets/c8efde21-9353-490e-8d38-3b27e0be0ae8" />
<img width="1918" height="1078" alt="20260827_00h11m55s_grim" src="https://github.com/user-attachments/assets/f9e5dd7b-e38d-47ea-9004-0d185b382fe7" />
