### PR TITLE
Configure Sonar to ignore test coverage of imported ANTLR Java files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
         <sonar.organization>jplag</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.coverage.exclusions>**/grammar/*.java</sonar.coverage.exclusions>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <maven.compiler.source>25</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
         <sonar.organization>jplag</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.coverage.exclusions>**/grammar/*.java</sonar.coverage.exclusions>
+        <sonar.coverage.exclusions>**/grammar/**/*.java</sonar.coverage.exclusions>
         <!--suppress UnresolvedMavenProperty -->
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/coverage-report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <maven.compiler.source>25</maven.compiler.source>


### PR DESCRIPTION
Sonar keeps failing on PRs that include changes affecting language modules because of low test coverage for ANTLR files imported from the ANTLR/grammar-v4 project. This PR configures Sonar to ignore the test coverage on these files.